### PR TITLE
[routes-middleware] Polyfill global react-native-web styles

### DIFF
--- a/packages/routes-middleware/lib/defaultClientLayout.js
+++ b/packages/routes-middleware/lib/defaultClientLayout.js
@@ -1,13 +1,14 @@
 const fs = require('fs')
 const path = require('path')
 const defaultStyles = fs.readFileSync(path.join(__dirname, 'defaultStyles.css'), 'utf8')
+const rnwPolyfill = fs.readFileSync(path.join(__dirname, 'reactNativeWeb.css'), 'utf8')
 
-module.exports = ({ head, styles, env, modelBundle, jsBundle }) => `
+module.exports = ({ head, styles, env, modelBundle, jsBundle, mode }) => `
 <html>
   <head>
     <meta name='viewport' content='width=device-width, initial-scale=1.0' />
     ${head || ''}
-    <style>${defaultStyles}</style>
+    <style>${defaultStyles}${mode === 'react-native' ? rnwPolyfill : ''}</style>
     ${styles || ''}
     <script>window.env = ${JSON.stringify(env)}</script>
   </head>

--- a/packages/routes-middleware/lib/index.js
+++ b/packages/routes-middleware/lib/index.js
@@ -4,6 +4,10 @@ const defaultClientLayout = require('./defaultClientLayout')
 const resourceManager = require('./resourceManager')
 const { matchRoutes } = require('react-router-config')
 const DEFAULT_APP_NAME = 'main'
+// `react-native` mode makes all root DOM elements fullscreen
+// with flex-direction column and removes scroll (ScrollView has to be used).
+// If you don't want this -- specify { mode: 'web' } in options.
+const DEFAULT_MODE = 'react-native'
 
 // Client Apps routes
 module.exports = function (appRoutes, options = {}) {
@@ -58,7 +62,8 @@ module.exports = function (appRoutes, options = {}) {
           head: getHead(appName, req),
           modelBundle: bundle,
           jsBundle: resourceManager.getResourcePath('bundle', appName, options),
-          env: model.get('_session.env') || {}
+          env: model.get('_session.env') || {},
+          mode: options.mode || DEFAULT_MODE
         })
         res.status(200).send(html)
       })

--- a/packages/routes-middleware/lib/reactNativeWeb.css
+++ b/packages/routes-middleware/lib/reactNativeWeb.css
@@ -1,0 +1,16 @@
+/* Polyfill root dom elements to work nicely with react-native-web */
+
+/* These styles make the body full-height */
+html, body {
+  height: 100%;
+}
+/* These styles disable body scrolling if you are using <ScrollView> */
+body {
+  overflow: hidden;
+}
+/* These styles make the root element full-height */
+#app {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}


### PR DESCRIPTION
Add `mode` option which can be:
- `react-native` (default)
- `web`

`react-native` mode makes all root DOM elements fullscreen with flex-direction column and removes scroll (`ScrollView` has to be used in react-native).

When you want a pure web project, specify `{ mode: 'web' }` in `startupjsServer` options.