### PR TITLE
Promisify racer

### DIFF
--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "@startupjs/react-sharedb": "^0.22.0-alpha.0",
-    "bluebird": "^3.5.0",
     "racer": "0.9.9",
     "rich-text": "^4.0.0",
     "sharedb": "^1.0.0"

--- a/packages/init/src/util/common.js
+++ b/packages/init/src/util/common.js
@@ -1,8 +1,6 @@
 import richText from 'rich-text'
 import Racer from 'racer'
 import RacerRemoteDoc from 'racer/lib/Model/RemoteDoc'
-import Query from 'racer/lib/Model/Query'
-import { promisifyAll } from 'bluebird'
 import batch from './batch'
 import ormPlugin from '@startupjs/orm'
 
@@ -16,10 +14,6 @@ export default (ShareDB, { orm } = {}) => {
     if (this.shareDoc.type === richText.type) return
     return oldRemoteDocOnOp.apply(this, arguments)
   }
-
-  // Promisify the default model methods like subscribe, fetch, set, push, etc.
-  promisifyAll(Racer.Model.prototype)
-  promisifyAll(Query.prototype)
 
   // Add batching method
   Racer.Model.prototype.batch = batch

--- a/packages/orm/README.md
+++ b/packages/orm/README.md
@@ -22,11 +22,6 @@ Each ORM Entity must be inherited from `Model.ChildModel`.
 ```js
 
 import { Model } from 'racer'
-import { promisifyAll } from 'bluebird'
-
-// Promisify the default model methods like subscribe, fetch, set, push, etc.
-promisifyAll(Model.prototype)
-
 
 class PlayerModel extends Model.ChildModel {
   alert (message) {
@@ -38,15 +33,15 @@ class PlayerModel extends Model.ChildModel {
 class GamesModel extends Model.ChildModel {
   async addNew (userId = 'system', params = {}) {
     let gameId = this.id()
-    await this.addAsync('games', {      
+    await this.addAsync('games', {
       name: 'Dummy Game',
       ...params,
-      id: gameId,      
+      id: gameId,
       userId,
       playerIds: [],
-      createdAt: Date.now()      
+      createdAt: Date.now()
     })
-    return gameId    
+    return gameId
   }
 }
 
@@ -63,9 +58,9 @@ class GameModel extends Model.ChildModel {
   async addPlayer (userId, params = {}) {
     if (!userId) throw new Error('userId required')
     var playerId = this.id()
-    await this.root.addAsync('players', {      
+    await this.root.addAsync('players', {
       ...params,
-      id: playerId,      
+      id: playerId,
       userId,
       createdAt: Date.now()
     })
@@ -101,10 +96,10 @@ based on the document's data. Factory let you do that.
 Example:
 
 ```js
-class BasePlayerModel extends Model.ChildModel {  
+class BasePlayerModel extends Model.ChildModel {
   getColor () {
     throw new Error('Player color is unknown')
-  }     
+  }
 }
 
 class AlliedPlayerModel extends BasePlayerModel {
@@ -120,7 +115,7 @@ class RivalPlayerModel extends BasePlayerModel {
 }
 
 function PlayerFactory ($player, $parent) {
-  // $player here is going to be just a pure scoped model  
+  // $player here is going to be just a pure scoped model
   let playerTeamId = $player.get('teamId')
   let $root = $player.root
   let myTeamId = $root.get('_session.myTeamId')

--- a/packages/orm/lib/promisifyRacer.js
+++ b/packages/orm/lib/promisifyRacer.js
@@ -1,0 +1,119 @@
+const Model = require('racer').Model
+const Query = require('racer/lib/Model/Query')
+
+// Methods to fix to properly handle (value, ..., cb) pair
+const FIX_VALUE_CB = {
+  // mutators
+  set: { minArgs: 2 },
+  setNull: { minArgs: 2 },
+  setEach: { minArgs: 2 },
+  push: { minArgs: 2 },
+  unshift: { minArgs: 2 },
+  insert: { minArgs: 3 },
+  remove: { minArgs: 2, onlyValidate: true },
+  move: { minArgs: 3, onlyValidate: true },
+  stringInsert: { minArgs: 3, onlyValidate: true },
+  stringRemove: { minArgs: 3, onlyValidate: true },
+  subtypeSubmit: { minArgs: 3, onlyValidate: true },
+  // setDiffs
+  setDiff: { minArgs: 2 },
+  setDiffDeep: { minArgs: 2 },
+  setArrayDiff: { minArgs: 2 },
+  setArrayDiffDeep: { minArgs: 2 }
+}
+const MUTATORS = [
+  // ref: https://github.com/derbyjs/racer/blob/master/lib/Model/mutators.js
+  'set',
+  'setNull',
+  'setEach',
+  'create',
+  'createNull',
+  'add',
+  'del',
+  'increment',
+  'push',
+  'unshift',
+  'insert',
+  'pop',
+  'shift',
+  'remove',
+  'move',
+  'stringInsert',
+  'stringRemove',
+  'subtypeSubmit',
+  // ref: https://github.com/derbyjs/racer/blob/master/lib/Model/setDiff.js
+  'setDiff',
+  'setDiffDeep',
+  'setArrayDiff',
+  'setArrayDiffDeep'
+]
+const SUBSCRIPTIONS = [
+  'subscribe',
+  'fetch'
+]
+const ASYNC_METHODS = MUTATORS.concat(SUBSCRIPTIONS)
+
+module.exports = function () {
+  for (const method in FIX_VALUE_CB) {
+    const { minArgs, onlyValidate } = FIX_VALUE_CB[method]
+    Model.prototype[method] = fixValueCbApi(
+      Model.prototype[method], method, minArgs, onlyValidate
+    )
+  }
+
+  for (const method of ASYNC_METHODS) {
+    Model.prototype[method] = optionalPromisify(Model.prototype[method])
+    Model.prototype[method + 'Async'] = deprecationWarning(
+      Model.prototype[method], method
+    )
+  }
+
+  for (const method of SUBSCRIPTIONS) {
+    Query.prototype[method] = optionalPromisify(Query.prototype[method])
+    Query.prototype[method + 'Async'] = deprecationWarning(
+      Query.prototype[method], method
+    )
+  }
+}
+
+function optionalPromisify (originalFn) {
+  return function optionalPromisifier (...args) {
+    if (args[args.length - 1] === 'function') {
+      return originalFn.apply(this, args)
+    } else {
+      return new Promise((resolve, reject) => {
+        // Append the callback
+        args.push(function promisifyCallback (err, value) {
+          if (err) return reject(err)
+          return resolve(value)
+        })
+        originalFn.apply(this, args)
+      })
+    }
+  }
+}
+
+function fixValueCbApi (originalFn, methodName, minArgs, onlyValidate) {
+  return function (...args) {
+    // perform op on current path when (value, [...], function) is passed
+    if (typeof arguments[arguments.length - 1] === 'function') {
+      if (arguments.length < minArgs) {
+        throw new Error('Not enough arguments for ' + methodName)
+      } else if (!onlyValidate && arguments.length === minArgs) {
+        args.unshift('')
+      }
+    }
+    return originalFn.apply(this, args)
+  }
+}
+
+function deprecationWarning (originalFn, methodName) {
+  return function () {
+    console.warn(
+      'model.' + methodName + 'Async() is DEPRECATED and going to be ' +
+      'REMOVED soon!\n Please use ' + methodName + '(), ' +
+      'it supports promises now and you can \'await\' it directly.'
+    )
+    return originalFn.apply(this, arguments)
+  }
+}


### PR DESCRIPTION
## Features

- Promisify modifiers all `Model` modifiers, like `set`, `setEach`, `push`, etc.
- Promisify `subscribe`/`fetch` of `Model` and `Query`

Now we can use everything as described in the racer docs but with `async/await`:

```jsx
observer(function User ({ userId }) {
  const [user, $user] = useDoc('users', userId)
  if (!user) throw $user.create()
  
  async function updateUserAge (age) {
    await $user.setDiff('age', age)
    await $user.adjustAgePolicies(age)
    alert('Your age and age policies update.')
    if (age < 18) {
	  alert('Content unsafe for children is blocked')
    }
  }

  // render user and an input to update his/her age
})
```

## DEPRECATIONS

- Deprecate `*Async()` methods on `Model` and `Query`. Regular methods should be used instead.