### PR TITLE
feat: add support for `::part()` css selector and `part` jsx attribute; add scoped styles similar to `styled-components` api

### DIFF
--- a/packages/babel-plugin-rn-stylename-inline/.gitignore
+++ b/packages/babel-plugin-rn-stylename-inline/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+yarn-error.log
+.coverage
+.idea
+package-lock.json

--- a/packages/babel-plugin-rn-stylename-inline/README.md
+++ b/packages/babel-plugin-rn-stylename-inline/README.md
@@ -1,0 +1,93 @@
+# @startupjs/babel-plugin-rn-stylename-inline
+
+Adds support for in-JS template strings `css\`\`` and `styl\`\``
+for CSS styles for react-native.
+
+Must be used together with `@startupjs/babel-plugin-rn-stylename` library.
+
+## Options
+
+`platform` -- what platform the compilation is on. For example, `web` or `ios` or `android`.
+
+## Example
+
+### Global file usage
+
+```jsx
+import React from 'react'
+import { View } from 'react-native'
+
+export default function Card () {
+  return <View styleName='card active'><Line /></View>
+}
+
+function Line () {
+  return <View styleName='line' />
+}
+
+css`
+  .card {
+    padding: 8px 16px;
+  }
+  .line {
+    margin-top: 16px;
+    border-radius: 8px;
+  }
+  .active {
+    background-color: red;
+  }
+`
+```
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+```jsx
+TBD
+```
+
+### Local component usage
+
+```jsx
+import React from 'react'
+import { View } from 'react-native'
+
+export default function Card () {
+  return <View styleName='root active'><Line /></View>
+
+  // .root will be scoped only to this specific component
+  css`
+    .root {
+      padding: 8px 16px;
+    }
+  `
+}
+
+function Line () {
+  return <View styleName='root' />
+
+  // .root will be scoped only to this specific component
+  css`
+    .root {
+      margin-top: 16px;
+      border-radius: 8px;
+    }
+  `
+}
+
+// you can use global- and local- scoped styles together
+css`
+  .active {
+    background-color: red;
+  }
+`
+```
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+```jsx
+TBD
+```
+
+## Licence
+
+MIT

--- a/packages/babel-plugin-rn-stylename-inline/__tests__/__snapshots__/index.spec.js.snap
+++ b/packages/babel-plugin-rn-stylename-inline/__tests__/__snapshots__/index.spec.js.snap
@@ -1,0 +1,397 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`@startupjs/babel-plugin-rn-stylename-inline Aliasing css and styl: Aliasing css and styl 1`] = `
+
+import React from 'react'
+import { css as myCss, styl as myStyl, observer } from 'startupjs'
+
+export default observer(function Card () {
+  myStyl\`
+    .card
+      color blue
+  \`
+  return <View styleName='card' />
+})
+
+myCss\`
+  .card {
+    color: red;
+    background-color: green;
+  }
+\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import React from 'react'
+import { observer } from 'startupjs'
+const __CSS_GLOBAL__ = {
+  card: {
+    color: 'red',
+    backgroundColor: 'green'
+  }
+}
+const _localCssInstance = {
+  card: {
+    color: '#00f'
+  }
+}
+export default observer(function Card() {
+  const __CSS_LOCAL__ = _localCssInstance
+  return <View styleName="card" />
+})
+
+
+`;
+
+exports[`@startupjs/babel-plugin-rn-stylename-inline Global and local css and styl. Several components: Global and local css and styl. Several components 1`] = `
+
+import React from 'react'
+import { css, styl } from 'startupjs'
+import { View } from 'react-native'
+
+export default function Card () {
+  return <View styleName='root active'><Line /></View>
+
+  styl\`
+    .root
+      padding 8px 16px
+  \`
+}
+
+function Line () {
+  return <View styleName='root' />
+
+  css\`
+    .root {
+      margin-top: 16px;
+      border-radius: 8px;
+    }
+  \`
+}
+
+styl\`
+  .active
+    background-color red
+\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import React from 'react'
+import { View } from 'react-native'
+const __CSS_GLOBAL__ = {
+  active: {
+    backgroundColor: '#f00'
+  }
+}
+const _localCssInstance2 = {
+  root: {
+    marginTop: 16,
+    borderRadius: 8
+  }
+}
+const _localCssInstance = {
+  root: {
+    paddingTop: 8,
+    paddingRight: 16,
+    paddingBottom: 8,
+    paddingLeft: 16
+  }
+}
+export default function Card() {
+  const __CSS_LOCAL__ = _localCssInstance
+  return (
+    <View styleName="root active">
+      <Line />
+    </View>
+  )
+}
+
+function Line() {
+  const __CSS_LOCAL__ = _localCssInstance2
+  return <View styleName="root" />
+}
+
+
+`;
+
+exports[`@startupjs/babel-plugin-rn-stylename-inline Global and local css. Several components: Global and local css. Several components 1`] = `
+
+import React from 'react'
+import { css } from 'startupjs'
+import { View } from 'react-native'
+
+export default function Card () {
+  return <View styleName='root active'><Line /></View>
+
+  css\`
+    .root {
+      padding: 8px 16px;
+    }
+  \`
+}
+
+function Line () {
+  return <View styleName='root' />
+
+  css\`
+    .root {
+      margin-top: 16px;
+      border-radius: 8px;
+    }
+  \`
+}
+
+css\`
+  .active {
+    background-color: red;
+  }
+\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import React from 'react'
+import { View } from 'react-native'
+const __CSS_GLOBAL__ = {
+  active: {
+    backgroundColor: 'red'
+  }
+}
+const _localCssInstance2 = {
+  root: {
+    marginTop: 16,
+    borderRadius: 8
+  }
+}
+const _localCssInstance = {
+  root: {
+    paddingTop: 8,
+    paddingRight: 16,
+    paddingBottom: 8,
+    paddingLeft: 16
+  }
+}
+export default function Card() {
+  const __CSS_LOCAL__ = _localCssInstance
+  return (
+    <View styleName="root active">
+      <Line />
+    </View>
+  )
+}
+
+function Line() {
+  const __CSS_LOCAL__ = _localCssInstance2
+  return <View styleName="root" />
+}
+
+
+`;
+
+exports[`@startupjs/babel-plugin-rn-stylename-inline Global css. Several components: Global css. Several components 1`] = `
+
+import React from 'react'
+import { css } from 'startupjs'
+import { View } from 'react-native'
+
+export default function Card () {
+  return <View styleName='card active'><Line /></View>
+}
+
+function Line () {
+  return <View styleName='line' />
+}
+
+css\`
+  .card {
+    padding: 8px 16px;
+  }
+  .line {
+    margin-top: 16px;
+    border-radius: 8px;
+  }
+  .active {
+    background-color: red;
+  }
+\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import React from 'react'
+import { View } from 'react-native'
+const __CSS_GLOBAL__ = {
+  card: {
+    paddingTop: 8,
+    paddingRight: 16,
+    paddingBottom: 8,
+    paddingLeft: 16
+  },
+  line: {
+    marginTop: 16,
+    borderRadius: 8
+  },
+  active: {
+    backgroundColor: 'red'
+  }
+}
+export default function Card() {
+  return (
+    <View styleName="card active">
+      <Line />
+    </View>
+  )
+}
+
+function Line() {
+  return <View styleName="line" />
+}
+
+
+`;
+
+exports[`@startupjs/babel-plugin-rn-stylename-inline Global css. Simple: Global css. Simple 1`] = `
+
+import React from 'react'
+import { css, observer } from 'startupjs'
+
+export default observer(function Card () {
+  return <View styleName='card' />
+})
+
+css\`
+  .card {
+    color: red;
+    background-color: green;
+  }
+\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import React from 'react'
+import { observer } from 'startupjs'
+const __CSS_GLOBAL__ = {
+  card: {
+    color: 'red',
+    backgroundColor: 'green'
+  }
+}
+export default observer(function Card() {
+  return <View styleName="card" />
+})
+
+
+`;
+
+exports[`@startupjs/babel-plugin-rn-stylename-inline Global styl. Several components: Global styl. Several components 1`] = `
+
+import React from 'react'
+import { styl } from 'startupjs'
+import { View } from 'react-native'
+
+export default function Card () {
+  return <View styleName='card active'><Line /></View>
+}
+
+function Line () {
+  return <View styleName='line' />
+}
+
+styl\`
+  .card
+    padding 8px 16px
+  .line
+    margin-top 16px
+    border-radius 8px
+  .active
+    background-color red
+\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import React from 'react'
+import { View } from 'react-native'
+const __CSS_GLOBAL__ = {
+  card: {
+    paddingTop: 8,
+    paddingRight: 16,
+    paddingBottom: 8,
+    paddingLeft: 16
+  },
+  line: {
+    marginTop: 16,
+    borderRadius: 8
+  },
+  active: {
+    backgroundColor: '#f00'
+  }
+}
+export default function Card() {
+  return (
+    <View styleName="card active">
+      <Line />
+    </View>
+  )
+}
+
+function Line() {
+  return <View styleName="line" />
+}
+
+
+`;
+
+exports[`@startupjs/babel-plugin-rn-stylename-inline Global styl. Simple: Global styl. Simple 1`] = `
+
+import React from 'react'
+import { styl, observer } from 'startupjs'
+
+export default observer(function Card () {
+  return <View styleName='card' />
+})
+
+styl\`
+  .card
+    color red
+    background-color green
+\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import React from 'react'
+import { observer } from 'startupjs'
+const __CSS_GLOBAL__ = {
+  card: {
+    color: '#f00',
+    backgroundColor: '#008000'
+  }
+}
+export default observer(function Card() {
+  return <View styleName="card" />
+})
+
+
+`;
+
+exports[`@startupjs/babel-plugin-rn-stylename-inline Should remove css and styl from startupjs import: Should remove css and styl from startupjs import 1`] = `
+
+import React from 'react'
+import { css, observer, styl } from 'startupjs'
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import React from 'react'
+import { observer } from 'startupjs'
+
+
+`;
+
+exports[`@startupjs/babel-plugin-rn-stylename-inline Should remove the whole lib if no other things are left in startupjs: Should remove the whole lib if no other things are left in startupjs 1`] = `
+
+import React from 'react'
+import { css, styl } from 'startupjs'
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import React from 'react'
+
+
+`;

--- a/packages/babel-plugin-rn-stylename-inline/__tests__/index.spec.js
+++ b/packages/babel-plugin-rn-stylename-inline/__tests__/index.spec.js
@@ -1,0 +1,182 @@
+const pluginTester = require('babel-plugin-tester').default
+const plugin = require('../index')
+const { name: pluginName } = require('../package.json')
+
+pluginTester({
+  plugin,
+  pluginName,
+  snapshot: true,
+  pluginOptions: {},
+  babelOptions: {
+    plugins: ['@babel/plugin-syntax-jsx']
+  },
+  tests: {
+    'Should remove css and styl from startupjs import': /* js */`
+      import React from 'react'
+      import { css, observer, styl } from 'startupjs'
+    `,
+    'Should remove the whole lib if no other things are left in startupjs': /* js */`
+      import React from 'react'
+      import { css, styl } from 'startupjs'
+    `,
+    'Global css. Simple': /* js */`
+      import React from 'react'
+      import { css, observer } from 'startupjs'
+
+      export default observer(function Card () {
+        return <View styleName='card' />
+      })
+
+      css\`
+        .card {
+          color: red;
+          background-color: green;
+        }
+      \`
+    `,
+    'Global styl. Simple': /* js */`
+      import React from 'react'
+      import { styl, observer } from 'startupjs'
+
+      export default observer(function Card () {
+        return <View styleName='card' />
+      })
+
+      styl\`
+        .card
+          color red
+          background-color green
+      \`
+    `,
+    'Global css. Several components': /* js */`
+      import React from 'react'
+      import { css } from 'startupjs'
+      import { View } from 'react-native'
+
+      export default function Card () {
+        return <View styleName='card active'><Line /></View>
+      }
+
+      function Line () {
+        return <View styleName='line' />
+      }
+
+      css\`
+        .card {
+          padding: 8px 16px;
+        }
+        .line {
+          margin-top: 16px;
+          border-radius: 8px;
+        }
+        .active {
+          background-color: red;
+        }
+      \`
+    `,
+    'Global styl. Several components': /* js */`
+      import React from 'react'
+      import { styl } from 'startupjs'
+      import { View } from 'react-native'
+
+      export default function Card () {
+        return <View styleName='card active'><Line /></View>
+      }
+
+      function Line () {
+        return <View styleName='line' />
+      }
+
+      styl\`
+        .card
+          padding 8px 16px
+        .line
+          margin-top 16px
+          border-radius 8px
+        .active
+          background-color red
+      \`
+    `,
+    'Global and local css. Several components': /* js */`
+      import React from 'react'
+      import { css } from 'startupjs'
+      import { View } from 'react-native'
+
+      export default function Card () {
+        return <View styleName='root active'><Line /></View>
+
+        css\`
+          .root {
+            padding: 8px 16px;
+          }
+        \`
+      }
+
+      function Line () {
+        return <View styleName='root' />
+
+        css\`
+          .root {
+            margin-top: 16px;
+            border-radius: 8px;
+          }
+        \`
+      }
+
+      css\`
+        .active {
+          background-color: red;
+        }
+      \`
+    `,
+    'Global and local css and styl. Several components': /* js */`
+      import React from 'react'
+      import { css, styl } from 'startupjs'
+      import { View } from 'react-native'
+
+      export default function Card () {
+        return <View styleName='root active'><Line /></View>
+
+        styl\`
+          .root
+            padding 8px 16px
+        \`
+      }
+
+      function Line () {
+        return <View styleName='root' />
+
+        css\`
+          .root {
+            margin-top: 16px;
+            border-radius: 8px;
+          }
+        \`
+      }
+
+      styl\`
+        .active
+          background-color red
+      \`
+    `,
+    'Aliasing css and styl': /* js */`
+      import React from 'react'
+      import { css as myCss, styl as myStyl, observer } from 'startupjs'
+
+      export default observer(function Card () {
+        myStyl\`
+          .card
+            color blue
+        \`
+        return <View styleName='card' />
+      })
+
+      myCss\`
+        .card {
+          color: red;
+          background-color: green;
+        }
+      \`
+    `
+  }
+})

--- a/packages/babel-plugin-rn-stylename-inline/compilers/css.js
+++ b/packages/babel-plugin-rn-stylename-inline/compilers/css.js
@@ -1,0 +1,13 @@
+// TODO: Move loaders into standalone libs
+const cssLoader = require('@startupjs/bundler/lib/cssToReactNativeLoader')
+const callLoader = require('@startupjs/bundler/lib/callLoader')
+const { stripExport } = require('./helpers')
+
+module.exports = function compileCss (src) {
+  return stripExport(
+    callLoader(
+      cssLoader,
+      src
+    )
+  )
+}

--- a/packages/babel-plugin-rn-stylename-inline/compilers/helpers.js
+++ b/packages/babel-plugin-rn-stylename-inline/compilers/helpers.js
@@ -1,0 +1,3 @@
+exports.stripExport = function stripExport (source) {
+  return source.replace(/^(?:export\s+default\s*|module\.exports\s*=\s*)/, '')
+}

--- a/packages/babel-plugin-rn-stylename-inline/compilers/index.js
+++ b/packages/babel-plugin-rn-stylename-inline/compilers/index.js
@@ -1,0 +1,7 @@
+const css = require('./css')
+const styl = require('./styl')
+
+module.exports = {
+  css,
+  styl
+}

--- a/packages/babel-plugin-rn-stylename-inline/compilers/styl.js
+++ b/packages/babel-plugin-rn-stylename-inline/compilers/styl.js
@@ -1,0 +1,14 @@
+// TODO: Move loaders into standalone libs
+const stylLoader = require('@startupjs/bundler/lib/stylusToCssLoader')
+const callLoader = require('@startupjs/bundler/lib/callLoader')
+const compileCss = require('./css')
+
+module.exports = function compileStyl (src, filename, options) {
+  src = callLoader(
+    stylLoader,
+    src,
+    filename,
+    options
+  )
+  return compileCss(src)
+}

--- a/packages/babel-plugin-rn-stylename-inline/index.js
+++ b/packages/babel-plugin-rn-stylename-inline/index.js
@@ -93,6 +93,7 @@ function insertAfterImports ($program, expressionStatement) {
 }
 
 function validateTemplate ($template, usedCompilers = {}) {
+  if (!$template.get('tag').isIdentifier()) return
   const { node: { tag, quasi } } = $template
   if (!usedCompilers[tag.name]) return
   if (quasi.expressions.length > 0) {

--- a/packages/babel-plugin-rn-stylename-inline/index.js
+++ b/packages/babel-plugin-rn-stylename-inline/index.js
@@ -1,0 +1,123 @@
+const template = require('@babel/template').default
+const parser = require('@babel/parser')
+const t = require('@babel/types')
+const { GLOBAL_NAME, LOCAL_NAME } = require('@startupjs/babel-plugin-rn-stylename-to-style/constants.cjs')
+const compilers = require('./compilers')
+const MAGIC_LIBRARY = 'startupjs'
+
+const buildConst = template(`
+  const %%variable%% = %%value%%
+`)
+
+module.exports = function (babel) {
+  let usedCompilers
+  let skip
+  let $program
+
+  return {
+    post () {
+      usedCompilers = undefined
+      skip = undefined
+      $program = undefined
+    },
+    visitor: {
+      Program: {
+        enter ($this, state) {
+          usedCompilers = getUsedCompilers($this)
+          if (Object.keys(usedCompilers).length === 0) {
+            skip = true
+          }
+          $program = $this
+        }
+      },
+      TaggedTemplateExpression: ($this, state) => {
+        if (skip) return
+
+        // I. validate template
+        if (!validateTemplate($this, usedCompilers)) return
+
+        // II. compile template
+        const source = $this.node.quasi.quasis[0]?.value?.raw || ''
+        const compiler = $this.node.tag.name
+        const filename = state.file?.opts?.filename
+        const platform = state.opts?.platform
+        const compiledString = usedCompilers[compiler](source, filename, { platform })
+        const compiledExpression = parser.parseExpression(compiledString)
+
+        // III. find parent function or program
+        const $function = $this.getFunctionParent()
+
+        // IV. LOCAL. if parent is function -- handle local
+        if ($function) {
+          // 1. define a `const` variable at the top of the file
+          //    with the unique identifier
+          const localIdentifier = $program.scope.generateUidIdentifier('localCssInstance')
+          insertAfterImports($program, buildConst({
+            variable: localIdentifier,
+            value: compiledExpression
+          }))
+
+          // 2. reassign this unique identifier to a constant LOCAL_NAME
+          //    in the scope of current function
+          $function.get('body').unshiftContainer('body', buildConst({
+            variable: t.identifier(LOCAL_NAME),
+            value: localIdentifier
+          }))
+
+        // V. GLOBAL. if parent is program -- handle global
+        } else {
+          // 1. define a `const` variable at the top of the file
+          //    with the constant GLOBAL_NAME
+          insertAfterImports($program, buildConst({
+            variable: t.identifier(GLOBAL_NAME),
+            value: compiledExpression
+          }))
+        }
+
+        // VI. Remove template expression after processing
+        $this.remove()
+
+        // TODO: Throw error if global styles were already added or
+        //       local styles were already added to the same function scope
+      }
+    }
+  }
+}
+
+function insertAfterImports ($program, expressionStatement) {
+  const lastImport = $program
+    .get('body')
+    .filter($i => $i.isImportDeclaration())
+    .pop()
+  lastImport.insertAfter(expressionStatement)
+}
+
+function validateTemplate ($template, usedCompilers = {}) {
+  const { node: { tag, quasi } } = $template
+  if (!usedCompilers[tag.name]) return
+  if (quasi.expressions.length > 0) {
+    throw $template.buildCodeFrameError(`
+      Expression interpolations are not supported in css\`\` and styl\`\`.
+    `)
+  }
+  return true
+}
+
+function getUsedCompilers ($program) {
+  const res = {}
+  for (const $import of $program.get('body')) {
+    if (!$import.isImportDeclaration()) continue
+    if ($import.node.source.value !== MAGIC_LIBRARY) continue
+    for (const $specifier of $import.get('specifiers')) {
+      if (!$specifier.isImportSpecifier()) continue
+      const { local, imported } = $specifier.node
+      if (compilers[imported.name]) {
+        res[local.name] = compilers[imported.name]
+        $specifier.remove()
+      }
+    }
+    if ($import.get('specifiers').length === 0) $import.remove()
+    break
+  }
+  return res
+}

--- a/packages/babel-plugin-rn-stylename-inline/package.json
+++ b/packages/babel-plugin-rn-stylename-inline/package.json
@@ -1,21 +1,20 @@
 {
-  "name": "@startupjs/babel-plugin-rn-stylename-to-style",
+  "name": "@startupjs/babel-plugin-rn-stylename-inline",
   "version": "0.23.20",
   "publishConfig": {
     "access": "public"
   },
-  "description": "Dynamically resolve styleName in RN with support for multi-class selectors (for easier modifiers)",
+  "description": "Use styleName attributes with inline css and styl template strings",
   "keywords": [
     "babel",
     "babel-plugin",
-    "react-native",
-    "stylename",
-    "style"
+    "react",
+    "lazy",
+    "import"
   ],
-  "main": "index.cjs",
-  "type": "module",
+  "main": "index.js",
   "scripts": {
-    "test": "mocha && jest"
+    "test": "jest"
   },
   "author": "Pavel Zhukov",
   "license": "MIT",
@@ -24,22 +23,18 @@
     "url": "https://github.com/startupjs/startupjs"
   },
   "files": [
-    "dimensions.js",
-    "process.js",
     "index.js",
     "README.md"
   ],
   "dependencies": {
+    "@babel/parser": "^7.0.0",
     "@babel/template": "^7.4.0",
     "@babel/types": "^7.0.0",
-    "@nx-js/observer-util": "^4.1.3",
-    "react-native-dynamic-style-processor": "^0.21.0"
+    "@startupjs/bundler": "^0.23.0"
   },
   "devDependencies": {
     "@babel/plugin-syntax-jsx": "^7.0.0",
     "babel-plugin-tester": "^9.1.0",
-    "@startupjs/css-to-react-native-transform": "^1.9.0-0",
-    "jest": "^26.0.1",
-    "mocha": "^8.1.1"
+    "jest": "^26.0.1"
   }
 }

--- a/packages/babel-plugin-rn-stylename-to-style/__tests__/__snapshots__/index.spec.js.snap
+++ b/packages/babel-plugin-rn-stylename-to-style/__tests__/__snapshots__/index.spec.js.snap
@@ -16,7 +16,7 @@ function Test ({ style, active, submit, disabled }) {
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import _temp from './index.styl'
+import _css from './index.styl'
 
 var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
 
@@ -34,21 +34,21 @@ function Test({ style, active, submit, disabled }) {
             active
           }
         ],
-        _temp,
+        _css,
         {
           style: style
         }
       )}
     >
       <span
-        {..._processStyleName(['title'], _temp, {
+        {..._processStyleName(['title'], _css, {
           style: titleStyle
         })}
       >
         Title
       </span>
       <span
-        {..._processStyleName(['description'], _temp, {
+        {..._processStyleName(['description'], _css, {
           style: {
             color: 'green'
           }
@@ -62,7 +62,7 @@ function Test({ style, active, submit, disabled }) {
             submit,
             disabled
           },
-          _temp,
+          _css,
           {
             style: {
               color: 'pink'
@@ -92,7 +92,7 @@ function Test ({ style, active, submit, disabled, titleStyle }) {
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import _temp from './index.styl'
+import _css from './index.styl'
 
 var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
 
@@ -107,7 +107,7 @@ function Test({ style, active, submit, disabled, titleStyle }) {
               active
             }
           ],
-          _temp
+          _css
         ),
         [
           titleStyle,
@@ -124,7 +124,7 @@ function Test({ style, active, submit, disabled, titleStyle }) {
             active
           }
         ],
-        _temp,
+        _css,
         {
           style: style
         }
@@ -132,14 +132,14 @@ function Test({ style, active, submit, disabled, titleStyle }) {
     >
       <Content
         footerStyle={[
-          _processStyleName('footer', _temp),
+          _processStyleName('footer', _css),
           {
             color: 'blue'
           }
         ]}
         center
         title="text"
-        {..._processStyleName('text', _temp, {
+        {..._processStyleName('text', _css, {
           style: {
             color: 'red'
           }
@@ -165,7 +165,7 @@ function Test ({ style, active, submit, disabled }) {
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import _temp from './index.styl'
+import _css from './index.styl'
 
 var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
 
@@ -180,7 +180,7 @@ function Test({ style, active, submit, disabled }) {
             active
           }
         ],
-        _temp,
+        _css,
         {
           style: style
         }
@@ -189,7 +189,7 @@ function Test({ style, active, submit, disabled }) {
       <span
         center
         title="text"
-        {..._processStyleName('text', _temp, {
+        {..._processStyleName('text', _css, {
           style: {
             color: 'red'
           }
@@ -218,7 +218,7 @@ function Test ({ style }) {
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import _temp from './index.styl'
+import _css from './index.styl'
 
 var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
 
@@ -229,7 +229,7 @@ function Test({ style }) {
   }
   return (
     <div
-      {..._processStyleName('root active', _temp, {
+      {..._processStyleName('root active', _css, {
         style: [
           style,
           {
@@ -239,14 +239,14 @@ function Test({ style }) {
       })}
     >
       <span
-        {..._processStyleName('title', _temp, {
+        {..._processStyleName('title', _css, {
           style: titleStyle
         })}
       >
         Title
       </span>
       <span
-        {..._processStyleName('description', _temp, {
+        {..._processStyleName('description', _css, {
           style: {
             color: 'green'
           }
@@ -254,7 +254,7 @@ function Test({ style }) {
       >
         Description
       </span>
-      <button {..._processStyleName('submit disabled', _temp, {})}>Submit</button>
+      <button {..._processStyleName('submit disabled', _css, {})}>Submit</button>
     </div>
   )
 }
@@ -277,16 +277,16 @@ function Test () {
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import _temp from './index.styl'
+import _css from './index.styl'
 
 var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
 
 function Test() {
   return (
-    <div {..._processStyleName('root active', _temp, {})}>
-      <span {..._processStyleName('title', _temp, {})}>Title</span>
-      <span {..._processStyleName('description', _temp, {})}>Description</span>
-      <button {..._processStyleName('submit disabled', _temp, {})}>Submit</button>
+    <div {..._processStyleName('root active', _css, {})}>
+      <span {..._processStyleName('title', _css, {})}>Title</span>
+      <span {..._processStyleName('description', _css, {})}>Description</span>
+      <button {..._processStyleName('submit disabled', _css, {})}>Submit</button>
     </div>
   )
 }
@@ -307,7 +307,7 @@ function Test ({ style, active, submit, disabled, titleStyle }) {
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import _temp from './index.styl'
+import _css from './index.styl'
 
 var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
 
@@ -322,7 +322,7 @@ function Test({ style, active, submit, disabled, titleStyle }) {
             active
           }
         ],
-        _temp,
+        _css,
         {
           style: style,
           titleStyle: [
@@ -337,13 +337,226 @@ function Test({ style, active, submit, disabled, titleStyle }) {
       <Content
         center
         title="text"
-        {..._processStyleName('text', _temp, {
+        {..._processStyleName('text', _css, {
           style: {
             color: 'red'
           },
           footerStyle: {
             color: 'blue'
           }
+        })}
+      />
+    </Card>
+  )
+}
+
+
+`;
+
+exports[`@startupjs/babel-plugin-rn-stylename-to-style part attribute. No props: part attribute. No props 1`] = `
+
+import './index.styl'
+function Test () {
+  return (
+    <Card
+      part='card'
+      style={{ color: 'blue' }}
+      titleStyle={{ color: 'red' }}
+    >
+      <Content
+        styleName='content'
+        part='content active'
+        style={{ fontWeight: 'bold' }}
+        bodyStyle={{ color: 'blue' }}
+      />
+    </Card>
+  )
+}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import _css from './index.styl'
+
+var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
+
+function Test(_props) {
+  return (
+    <Card
+      {..._processStyleName('', _css, {
+        style: [
+          {
+            color: 'blue'
+          },
+          _props.cardStyle
+        ],
+        titleStyle: {
+          color: 'red'
+        }
+      })}
+    >
+      <Content
+        {..._processStyleName('content', _css, {
+          style: [
+            {
+              fontWeight: 'bold'
+            },
+            _props.contentStyle,
+            _props.activeStyle
+          ],
+          bodyStyle: {
+            color: 'blue'
+          }
+        })}
+      />
+    </Card>
+  )
+}
+
+
+`;
+
+exports[`@startupjs/babel-plugin-rn-stylename-to-style part attribute. With anon function within named fn: part attribute. With anon function within named fn 1`] = `
+
+import './index.styl'
+const Test = ({ style, cardStyle: myCardStyle, contentStyle, title }) => {
+  function render () {
+    return (
+      <Card
+        part='card'
+        style={{ color: 'blue' }}
+        titleStyle={{ color: 'red' }}
+      >
+        <Content part='content active' />
+      </Card>
+    )
+  }
+  return render()
+}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import _css from './index.styl'
+
+var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
+
+const Test = ({ style, cardStyle: myCardStyle, contentStyle, title, activeStyle: _activeStyle }) => {
+  function render() {
+    return (
+      <Card
+        {..._processStyleName('', _css, {
+          style: [
+            {
+              color: 'blue'
+            },
+            myCardStyle
+          ],
+          titleStyle: {
+            color: 'red'
+          }
+        })}
+      >
+        <Content
+          {..._processStyleName('', _css, {
+            style: [contentStyle, _activeStyle]
+          })}
+        />
+      </Card>
+    )
+  }
+
+  return render()
+}
+
+
+`;
+
+exports[`@startupjs/babel-plugin-rn-stylename-to-style part attribute. With destructed props: part attribute. With destructed props 1`] = `
+
+import './index.styl'
+function Test ({ style, cardStyle, title }) {
+  return (
+    <Card
+      part='card'
+      style={{ color: 'blue' }}
+      titleStyle={{ color: 'red' }}
+    >
+      <Content part='content active' />
+    </Card>
+  )
+}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import _css from './index.styl'
+
+var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
+
+function Test({ style, cardStyle, title, contentStyle: _contentStyle, activeStyle: _activeStyle }) {
+  return (
+    <Card
+      {..._processStyleName('', _css, {
+        style: [
+          {
+            color: 'blue'
+          },
+          cardStyle
+        ],
+        titleStyle: {
+          color: 'red'
+        }
+      })}
+    >
+      <Content
+        {..._processStyleName('', _css, {
+          style: [_contentStyle, _activeStyle]
+        })}
+      />
+    </Card>
+  )
+}
+
+
+`;
+
+exports[`@startupjs/babel-plugin-rn-stylename-to-style part attribute. With named props: part attribute. With named props 1`] = `
+
+import './index.styl'
+function Test (props) {
+  return (
+    <Card
+      part='card'
+      style={{ color: 'blue' }}
+      titleStyle={{ color: 'red' }}
+    >
+      <Content part='content active' />
+    </Card>
+  )
+}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import _css from './index.styl'
+
+var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
+
+function Test(props) {
+  return (
+    <Card
+      {..._processStyleName('', _css, {
+        style: [
+          {
+            color: 'blue'
+          },
+          props.cardStyle
+        ],
+        titleStyle: {
+          color: 'red'
+        }
+      })}
+    >
+      <Content
+        {..._processStyleName('', _css, {
+          style: [props.contentStyle, props.activeStyle]
         })}
       />
     </Card>

--- a/packages/babel-plugin-rn-stylename-to-style/__tests__/__snapshots__/index.spec.js.snap
+++ b/packages/babel-plugin-rn-stylename-to-style/__tests__/__snapshots__/index.spec.js.snap
@@ -18,7 +18,7 @@ function Test ({ style, active, submit, disabled }) {
 
 import _css from './index.styl'
 
-var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
+const _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
 
 function Test({ style, active, submit, disabled }) {
   const titleStyle = {
@@ -110,7 +110,7 @@ function Test ({ style, active, submit, disabled, titleStyle }) {
 
 import _css from './index.styl'
 
-var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
+const _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
 
 function Test({ style, active, submit, disabled, titleStyle }) {
   return (
@@ -191,7 +191,7 @@ function Test ({ style, active, submit, disabled }) {
 
 import _css from './index.styl'
 
-var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
+const _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
 
 function Test({ style, active, submit, disabled }) {
   return (
@@ -252,7 +252,7 @@ function Test ({ style }) {
 
 import _css from './index.styl'
 
-var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
+const _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
 
 function Test({ style }) {
   const titleStyle = {
@@ -339,7 +339,7 @@ function Test () {
 
 import _css from './index.styl'
 
-var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
+const _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
 
 function Test() {
   return (
@@ -407,7 +407,7 @@ function Test ({ style, active, submit, disabled, titleStyle }) {
 
 import _css from './index.styl'
 
-var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
+const _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
 
 function Test({ style, active, submit, disabled, titleStyle }) {
   return (
@@ -478,7 +478,7 @@ function Test ({ title, style }) {
 
 import _css from './index.styl'
 
-var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
+const _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
 
 function Test({ title, style, contentStyle: _contentStyle, activeStyle: _activeStyle }) {
   return (
@@ -538,7 +538,7 @@ function Test ({ title }) {
 
 import _css from './index.styl'
 
-var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
+const _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
 
 function Test({ title, style: _style, contentStyle: _contentStyle, activeStyle: _activeStyle }) {
   return (
@@ -603,7 +603,7 @@ function Test () {
 
 import _css from './index.styl'
 
-var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
+const _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
 
 function Test(_props) {
   return (
@@ -675,7 +675,7 @@ const Test = ({ style, cardStyle: myCardStyle, contentStyle, title }) => {
 
 import _css from './index.styl'
 
-var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
+const _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
 
 const Test = ({ style, cardStyle: myCardStyle, contentStyle, title, activeStyle: _activeStyle }) => {
   function render() {
@@ -739,7 +739,7 @@ function Test ({ style, cardStyle, title }) {
 
 import _css from './index.styl'
 
-var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
+const _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
 
 function Test({ style, cardStyle, title, contentStyle: _contentStyle, activeStyle: _activeStyle }) {
   return (
@@ -799,7 +799,7 @@ function Test (props) {
 
 import _css from './index.styl'
 
-var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
+const _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
 
 function Test(props) {
   return (

--- a/packages/babel-plugin-rn-stylename-to-style/__tests__/__snapshots__/index.spec.js.snap
+++ b/packages/babel-plugin-rn-stylename-to-style/__tests__/__snapshots__/index.spec.js.snap
@@ -1,0 +1,281 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`@startupjs/babel-plugin-rn-stylename-to-style Arrays and objects: Arrays and objects 1`] = `
+
+import './index.styl'
+function Test ({ style, active, submit, disabled }) {
+  const titleStyle = { color: 'red', fontWeight: 'bold' }
+  return (
+    <div style={style} styleName={['root', {active}]}>
+      <span styleName={['title']} style={titleStyle}>Title</span>
+      <span styleName={['description']} style={{ color: 'green' }}>Description</span>
+      <button style={{ color: 'pink' }} styleName={{submit, disabled}}>Submit</button>
+    </div>
+  )
+}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import _temp from './index.styl'
+
+var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
+
+function Test({ style, active, submit, disabled }) {
+  const titleStyle = {
+    color: 'red',
+    fontWeight: 'bold'
+  }
+  return (
+    <div
+      {..._processStyleName(
+        [
+          'root',
+          {
+            active
+          }
+        ],
+        _temp,
+        {
+          style: style
+        }
+      )}
+    >
+      <span
+        {..._processStyleName(['title'], _temp, {
+          style: titleStyle
+        })}
+      >
+        Title
+      </span>
+      <span
+        {..._processStyleName(['description'], _temp, {
+          style: {
+            color: 'green'
+          }
+        })}
+      >
+        Description
+      </span>
+      <button
+        {..._processStyleName(
+          {
+            submit,
+            disabled
+          },
+          _temp,
+          {
+            style: {
+              color: 'pink'
+            }
+          }
+        )}
+      >
+        Submit
+      </button>
+    </div>
+  )
+}
+
+
+`;
+
+exports[`@startupjs/babel-plugin-rn-stylename-to-style Puts compiled attribute to the end of attributes list: Puts compiled attribute to the end of attributes list 1`] = `
+
+import './index.styl'
+function Test ({ style, active, submit, disabled }) {
+  return (
+    <div style={style} styleName={['root', {active}]} title='container'>
+      <span styleName='text' style={{ color: 'red' }} center title='text' />
+    </div>
+  )
+}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import _temp from './index.styl'
+
+var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
+
+function Test({ style, active, submit, disabled }) {
+  return (
+    <div
+      title="container"
+      {..._processStyleName(
+        [
+          'root',
+          {
+            active
+          }
+        ],
+        _temp,
+        {
+          style: style
+        }
+      )}
+    >
+      <span
+        center
+        title="text"
+        {..._processStyleName('text', _temp, {
+          style: {
+            color: 'red'
+          }
+        })}
+      />
+    </div>
+  )
+}
+
+
+`;
+
+exports[`@startupjs/babel-plugin-rn-stylename-to-style Regular string with existing style: Regular string with existing style 1`] = `
+
+import './index.styl'
+function Test ({ style }) {
+  const titleStyle = { color: 'red', fontWeight: 'bold' }
+  return (
+    <div style={[style, { backgroundColor: 'black' }]} styleName='root active'>
+      <span styleName='title' style={titleStyle}>Title</span>
+      <span styleName='description' style={{ color: 'green' }}>Description</span>
+      <button styleName='submit disabled'>Submit</button>
+    </div>
+  )
+}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import _temp from './index.styl'
+
+var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
+
+function Test({ style }) {
+  const titleStyle = {
+    color: 'red',
+    fontWeight: 'bold'
+  }
+  return (
+    <div
+      {..._processStyleName('root active', _temp, {
+        style: [
+          style,
+          {
+            backgroundColor: 'black'
+          }
+        ]
+      })}
+    >
+      <span
+        {..._processStyleName('title', _temp, {
+          style: titleStyle
+        })}
+      >
+        Title
+      </span>
+      <span
+        {..._processStyleName('description', _temp, {
+          style: {
+            color: 'green'
+          }
+        })}
+      >
+        Description
+      </span>
+      <button {..._processStyleName('submit disabled', _temp, {})}>Submit</button>
+    </div>
+  )
+}
+
+
+`;
+
+exports[`@startupjs/babel-plugin-rn-stylename-to-style Regular string: Regular string 1`] = `
+
+import './index.styl'
+function Test () {
+  return (
+    <div styleName='root active'>
+      <span styleName='title'>Title</span>
+      <span styleName='description'>Description</span>
+      <button styleName='submit disabled'>Submit</button>
+    </div>
+  )
+}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import _temp from './index.styl'
+
+var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
+
+function Test() {
+  return (
+    <div {..._processStyleName('root active', _temp, {})}>
+      <span {..._processStyleName('title', _temp, {})}>Title</span>
+      <span {..._processStyleName('description', _temp, {})}>Description</span>
+      <button {..._processStyleName('submit disabled', _temp, {})}>Submit</button>
+    </div>
+  )
+}
+
+
+`;
+
+exports[`@startupjs/babel-plugin-rn-stylename-to-style With ::part() styles: With ::part() styles 1`] = `
+
+import './index.styl'
+function Test ({ style, active, submit, disabled, titleStyle }) {
+  return (
+    <Card style={style} styleName={['root', {active}]} titleStyle={[titleStyle, { color: 'green' }]} title='container'>
+      <Content styleName='text' style={{ color: 'red' }} footerStyle={{ color: 'blue' }} center title='text' />
+    </Card>
+  )
+}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import _temp from './index.styl'
+
+var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
+
+function Test({ style, active, submit, disabled, titleStyle }) {
+  return (
+    <Card
+      title="container"
+      {..._processStyleName(
+        [
+          'root',
+          {
+            active
+          }
+        ],
+        _temp,
+        {
+          style: style,
+          titleStyle: [
+            titleStyle,
+            {
+              color: 'green'
+            }
+          ]
+        }
+      )}
+    >
+      <Content
+        center
+        title="text"
+        {..._processStyleName('text', _temp, {
+          style: {
+            color: 'red'
+          },
+          footerStyle: {
+            color: 'blue'
+          }
+        })}
+      />
+    </Card>
+  )
+}
+
+
+`;

--- a/packages/babel-plugin-rn-stylename-to-style/__tests__/__snapshots__/index.spec.js.snap
+++ b/packages/babel-plugin-rn-stylename-to-style/__tests__/__snapshots__/index.spec.js.snap
@@ -79,6 +79,79 @@ function Test({ style, active, submit, disabled }) {
 
 `;
 
+exports[`@startupjs/babel-plugin-rn-stylename-to-style DEPRECATED! With ::part() styles and deprecated *StyleName props: DEPRECATED! With ::part() styles and deprecated *StyleName props 1`] = `
+
+import './index.styl'
+function Test ({ style, active, submit, disabled, titleStyle }) {
+  return (
+    <Card style={style} styleName={['root', {active}]} titleStyleName={['title', {active}]} titleStyle={[titleStyle, { color: 'green' }]} title='container'>
+      <Content styleName='text' style={{ color: 'red' }} footerStyleName='footer' footerStyle={{ color: 'blue' }} center title='text' />
+    </Card>
+  )
+}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import _temp from './index.styl'
+
+var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
+
+function Test({ style, active, submit, disabled, titleStyle }) {
+  return (
+    <Card
+      titleStyle={[
+        _processStyleName(
+          [
+            'title',
+            {
+              active
+            }
+          ],
+          _temp
+        ),
+        [
+          titleStyle,
+          {
+            color: 'green'
+          }
+        ]
+      ]}
+      title="container"
+      {..._processStyleName(
+        [
+          'root',
+          {
+            active
+          }
+        ],
+        _temp,
+        {
+          style: style
+        }
+      )}
+    >
+      <Content
+        footerStyle={[
+          _processStyleName('footer', _temp),
+          {
+            color: 'blue'
+          }
+        ]}
+        center
+        title="text"
+        {..._processStyleName('text', _temp, {
+          style: {
+            color: 'red'
+          }
+        })}
+      />
+    </Card>
+  )
+}
+
+
+`;
+
 exports[`@startupjs/babel-plugin-rn-stylename-to-style Puts compiled attribute to the end of attributes list: Puts compiled attribute to the end of attributes list 1`] = `
 
 import './index.styl'

--- a/packages/babel-plugin-rn-stylename-to-style/__tests__/__snapshots__/index.spec.js.snap
+++ b/packages/babel-plugin-rn-stylename-to-style/__tests__/__snapshots__/index.spec.js.snap
@@ -353,6 +353,102 @@ function Test({ style, active, submit, disabled, titleStyle }) {
 
 `;
 
+exports[`@startupjs/babel-plugin-rn-stylename-to-style magic 'root' part with existing style prop: magic 'root' part with existing style prop 1`] = `
+
+import './index.styl'
+function Test ({ title, style }) {
+  return (
+    <Card
+      part='root'
+      style={{ color: 'blue' }}
+      titleStyle={{ color: 'red' }}
+    >
+      <Content part='content active' />
+    </Card>
+  )
+}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import _css from './index.styl'
+
+var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
+
+function Test({ title, style, contentStyle: _contentStyle, activeStyle: _activeStyle }) {
+  return (
+    <Card
+      {..._processStyleName('', _css, {
+        style: [
+          {
+            color: 'blue'
+          },
+          style
+        ],
+        titleStyle: {
+          color: 'red'
+        }
+      })}
+    >
+      <Content
+        {..._processStyleName('', _css, {
+          style: [_contentStyle, _activeStyle]
+        })}
+      />
+    </Card>
+  )
+}
+
+
+`;
+
+exports[`@startupjs/babel-plugin-rn-stylename-to-style magic 'root' part: magic 'root' part 1`] = `
+
+import './index.styl'
+function Test ({ title }) {
+  return (
+    <Card
+      part='root'
+      style={{ color: 'blue' }}
+      titleStyle={{ color: 'red' }}
+    >
+      <Content part='content active' />
+    </Card>
+  )
+}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import _css from './index.styl'
+
+var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/process').process
+
+function Test({ title, style: _style, contentStyle: _contentStyle, activeStyle: _activeStyle }) {
+  return (
+    <Card
+      {..._processStyleName('', _css, {
+        style: [
+          {
+            color: 'blue'
+          },
+          _style
+        ],
+        titleStyle: {
+          color: 'red'
+        }
+      })}
+    >
+      <Content
+        {..._processStyleName('', _css, {
+          style: [_contentStyle, _activeStyle]
+        })}
+      />
+    </Card>
+  )
+}
+
+
+`;
+
 exports[`@startupjs/babel-plugin-rn-stylename-to-style part attribute. No props: part attribute. No props 1`] = `
 
 import './index.styl'

--- a/packages/babel-plugin-rn-stylename-to-style/__tests__/__snapshots__/index.spec.js.snap
+++ b/packages/babel-plugin-rn-stylename-to-style/__tests__/__snapshots__/index.spec.js.snap
@@ -35,24 +35,38 @@ function Test({ style, active, submit, disabled }) {
           }
         ],
         _css,
+        typeof __CSS_GLOBAL__ !== 'undefined' && __CSS_GLOBAL__,
+        typeof __CSS_LOCAL__ !== 'undefined' && __CSS_LOCAL__,
         {
           style: style
         }
       )}
     >
       <span
-        {..._processStyleName(['title'], _css, {
-          style: titleStyle
-        })}
+        {..._processStyleName(
+          ['title'],
+          _css,
+          typeof __CSS_GLOBAL__ !== 'undefined' && __CSS_GLOBAL__,
+          typeof __CSS_LOCAL__ !== 'undefined' && __CSS_LOCAL__,
+          {
+            style: titleStyle
+          }
+        )}
       >
         Title
       </span>
       <span
-        {..._processStyleName(['description'], _css, {
-          style: {
-            color: 'green'
+        {..._processStyleName(
+          ['description'],
+          _css,
+          typeof __CSS_GLOBAL__ !== 'undefined' && __CSS_GLOBAL__,
+          typeof __CSS_LOCAL__ !== 'undefined' && __CSS_LOCAL__,
+          {
+            style: {
+              color: 'green'
+            }
           }
-        })}
+        )}
       >
         Description
       </span>
@@ -63,6 +77,8 @@ function Test({ style, active, submit, disabled }) {
             disabled
           },
           _css,
+          typeof __CSS_GLOBAL__ !== 'undefined' && __CSS_GLOBAL__,
+          typeof __CSS_LOCAL__ !== 'undefined' && __CSS_LOCAL__,
           {
             style: {
               color: 'pink'
@@ -125,6 +141,8 @@ function Test({ style, active, submit, disabled, titleStyle }) {
           }
         ],
         _css,
+        typeof __CSS_GLOBAL__ !== 'undefined' && __CSS_GLOBAL__,
+        typeof __CSS_LOCAL__ !== 'undefined' && __CSS_LOCAL__,
         {
           style: style
         }
@@ -139,11 +157,17 @@ function Test({ style, active, submit, disabled, titleStyle }) {
         ]}
         center
         title="text"
-        {..._processStyleName('text', _css, {
-          style: {
-            color: 'red'
+        {..._processStyleName(
+          'text',
+          _css,
+          typeof __CSS_GLOBAL__ !== 'undefined' && __CSS_GLOBAL__,
+          typeof __CSS_LOCAL__ !== 'undefined' && __CSS_LOCAL__,
+          {
+            style: {
+              color: 'red'
+            }
           }
-        })}
+        )}
       />
     </Card>
   )
@@ -181,6 +205,8 @@ function Test({ style, active, submit, disabled }) {
           }
         ],
         _css,
+        typeof __CSS_GLOBAL__ !== 'undefined' && __CSS_GLOBAL__,
+        typeof __CSS_LOCAL__ !== 'undefined' && __CSS_LOCAL__,
         {
           style: style
         }
@@ -189,11 +215,17 @@ function Test({ style, active, submit, disabled }) {
       <span
         center
         title="text"
-        {..._processStyleName('text', _css, {
-          style: {
-            color: 'red'
+        {..._processStyleName(
+          'text',
+          _css,
+          typeof __CSS_GLOBAL__ !== 'undefined' && __CSS_GLOBAL__,
+          typeof __CSS_LOCAL__ !== 'undefined' && __CSS_LOCAL__,
+          {
+            style: {
+              color: 'red'
+            }
           }
-        })}
+        )}
       />
     </div>
   )
@@ -229,32 +261,60 @@ function Test({ style }) {
   }
   return (
     <div
-      {..._processStyleName('root active', _css, {
-        style: [
-          style,
-          {
-            backgroundColor: 'black'
-          }
-        ]
-      })}
+      {..._processStyleName(
+        'root active',
+        _css,
+        typeof __CSS_GLOBAL__ !== 'undefined' && __CSS_GLOBAL__,
+        typeof __CSS_LOCAL__ !== 'undefined' && __CSS_LOCAL__,
+        {
+          style: [
+            style,
+            {
+              backgroundColor: 'black'
+            }
+          ]
+        }
+      )}
     >
       <span
-        {..._processStyleName('title', _css, {
-          style: titleStyle
-        })}
+        {..._processStyleName(
+          'title',
+          _css,
+          typeof __CSS_GLOBAL__ !== 'undefined' && __CSS_GLOBAL__,
+          typeof __CSS_LOCAL__ !== 'undefined' && __CSS_LOCAL__,
+          {
+            style: titleStyle
+          }
+        )}
       >
         Title
       </span>
       <span
-        {..._processStyleName('description', _css, {
-          style: {
-            color: 'green'
+        {..._processStyleName(
+          'description',
+          _css,
+          typeof __CSS_GLOBAL__ !== 'undefined' && __CSS_GLOBAL__,
+          typeof __CSS_LOCAL__ !== 'undefined' && __CSS_LOCAL__,
+          {
+            style: {
+              color: 'green'
+            }
           }
-        })}
+        )}
       >
         Description
       </span>
-      <button {..._processStyleName('submit disabled', _css, {})}>Submit</button>
+      <button
+        {..._processStyleName(
+          'submit disabled',
+          _css,
+          typeof __CSS_GLOBAL__ !== 'undefined' && __CSS_GLOBAL__,
+          typeof __CSS_LOCAL__ !== 'undefined' && __CSS_LOCAL__,
+          {}
+        )}
+      >
+        Submit
+      </button>
     </div>
   )
 }
@@ -283,10 +343,48 @@ var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/p
 
 function Test() {
   return (
-    <div {..._processStyleName('root active', _css, {})}>
-      <span {..._processStyleName('title', _css, {})}>Title</span>
-      <span {..._processStyleName('description', _css, {})}>Description</span>
-      <button {..._processStyleName('submit disabled', _css, {})}>Submit</button>
+    <div
+      {..._processStyleName(
+        'root active',
+        _css,
+        typeof __CSS_GLOBAL__ !== 'undefined' && __CSS_GLOBAL__,
+        typeof __CSS_LOCAL__ !== 'undefined' && __CSS_LOCAL__,
+        {}
+      )}
+    >
+      <span
+        {..._processStyleName(
+          'title',
+          _css,
+          typeof __CSS_GLOBAL__ !== 'undefined' && __CSS_GLOBAL__,
+          typeof __CSS_LOCAL__ !== 'undefined' && __CSS_LOCAL__,
+          {}
+        )}
+      >
+        Title
+      </span>
+      <span
+        {..._processStyleName(
+          'description',
+          _css,
+          typeof __CSS_GLOBAL__ !== 'undefined' && __CSS_GLOBAL__,
+          typeof __CSS_LOCAL__ !== 'undefined' && __CSS_LOCAL__,
+          {}
+        )}
+      >
+        Description
+      </span>
+      <button
+        {..._processStyleName(
+          'submit disabled',
+          _css,
+          typeof __CSS_GLOBAL__ !== 'undefined' && __CSS_GLOBAL__,
+          typeof __CSS_LOCAL__ !== 'undefined' && __CSS_LOCAL__,
+          {}
+        )}
+      >
+        Submit
+      </button>
     </div>
   )
 }
@@ -323,6 +421,8 @@ function Test({ style, active, submit, disabled, titleStyle }) {
           }
         ],
         _css,
+        typeof __CSS_GLOBAL__ !== 'undefined' && __CSS_GLOBAL__,
+        typeof __CSS_LOCAL__ !== 'undefined' && __CSS_LOCAL__,
         {
           style: style,
           titleStyle: [
@@ -337,14 +437,20 @@ function Test({ style, active, submit, disabled, titleStyle }) {
       <Content
         center
         title="text"
-        {..._processStyleName('text', _css, {
-          style: {
-            color: 'red'
-          },
-          footerStyle: {
-            color: 'blue'
+        {..._processStyleName(
+          'text',
+          _css,
+          typeof __CSS_GLOBAL__ !== 'undefined' && __CSS_GLOBAL__,
+          typeof __CSS_LOCAL__ !== 'undefined' && __CSS_LOCAL__,
+          {
+            style: {
+              color: 'red'
+            },
+            footerStyle: {
+              color: 'blue'
+            }
           }
-        })}
+        )}
       />
     </Card>
   )
@@ -377,22 +483,34 @@ var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/p
 function Test({ title, style, contentStyle: _contentStyle, activeStyle: _activeStyle }) {
   return (
     <Card
-      {..._processStyleName('', _css, {
-        style: [
-          {
-            color: 'blue'
-          },
-          style
-        ],
-        titleStyle: {
-          color: 'red'
+      {..._processStyleName(
+        '',
+        _css,
+        typeof __CSS_GLOBAL__ !== 'undefined' && __CSS_GLOBAL__,
+        typeof __CSS_LOCAL__ !== 'undefined' && __CSS_LOCAL__,
+        {
+          style: [
+            {
+              color: 'blue'
+            },
+            style
+          ],
+          titleStyle: {
+            color: 'red'
+          }
         }
-      })}
+      )}
     >
       <Content
-        {..._processStyleName('', _css, {
-          style: [_contentStyle, _activeStyle]
-        })}
+        {..._processStyleName(
+          '',
+          _css,
+          typeof __CSS_GLOBAL__ !== 'undefined' && __CSS_GLOBAL__,
+          typeof __CSS_LOCAL__ !== 'undefined' && __CSS_LOCAL__,
+          {
+            style: [_contentStyle, _activeStyle]
+          }
+        )}
       />
     </Card>
   )
@@ -425,22 +543,34 @@ var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/p
 function Test({ title, style: _style, contentStyle: _contentStyle, activeStyle: _activeStyle }) {
   return (
     <Card
-      {..._processStyleName('', _css, {
-        style: [
-          {
-            color: 'blue'
-          },
-          _style
-        ],
-        titleStyle: {
-          color: 'red'
+      {..._processStyleName(
+        '',
+        _css,
+        typeof __CSS_GLOBAL__ !== 'undefined' && __CSS_GLOBAL__,
+        typeof __CSS_LOCAL__ !== 'undefined' && __CSS_LOCAL__,
+        {
+          style: [
+            {
+              color: 'blue'
+            },
+            _style
+          ],
+          titleStyle: {
+            color: 'red'
+          }
         }
-      })}
+      )}
     >
       <Content
-        {..._processStyleName('', _css, {
-          style: [_contentStyle, _activeStyle]
-        })}
+        {..._processStyleName(
+          '',
+          _css,
+          typeof __CSS_GLOBAL__ !== 'undefined' && __CSS_GLOBAL__,
+          typeof __CSS_LOCAL__ !== 'undefined' && __CSS_LOCAL__,
+          {
+            style: [_contentStyle, _activeStyle]
+          }
+        )}
       />
     </Card>
   )
@@ -478,31 +608,43 @@ var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/p
 function Test(_props) {
   return (
     <Card
-      {..._processStyleName('', _css, {
-        style: [
-          {
-            color: 'blue'
-          },
-          _props.cardStyle
-        ],
-        titleStyle: {
-          color: 'red'
-        }
-      })}
-    >
-      <Content
-        {..._processStyleName('content', _css, {
+      {..._processStyleName(
+        '',
+        _css,
+        typeof __CSS_GLOBAL__ !== 'undefined' && __CSS_GLOBAL__,
+        typeof __CSS_LOCAL__ !== 'undefined' && __CSS_LOCAL__,
+        {
           style: [
             {
-              fontWeight: 'bold'
+              color: 'blue'
             },
-            _props.contentStyle,
-            _props.activeStyle
+            _props.cardStyle
           ],
-          bodyStyle: {
-            color: 'blue'
+          titleStyle: {
+            color: 'red'
           }
-        })}
+        }
+      )}
+    >
+      <Content
+        {..._processStyleName(
+          'content',
+          _css,
+          typeof __CSS_GLOBAL__ !== 'undefined' && __CSS_GLOBAL__,
+          typeof __CSS_LOCAL__ !== 'undefined' && __CSS_LOCAL__,
+          {
+            style: [
+              {
+                fontWeight: 'bold'
+              },
+              _props.contentStyle,
+              _props.activeStyle
+            ],
+            bodyStyle: {
+              color: 'blue'
+            }
+          }
+        )}
       />
     </Card>
   )
@@ -539,22 +681,34 @@ const Test = ({ style, cardStyle: myCardStyle, contentStyle, title, activeStyle:
   function render() {
     return (
       <Card
-        {..._processStyleName('', _css, {
-          style: [
-            {
-              color: 'blue'
-            },
-            myCardStyle
-          ],
-          titleStyle: {
-            color: 'red'
+        {..._processStyleName(
+          '',
+          _css,
+          typeof __CSS_GLOBAL__ !== 'undefined' && __CSS_GLOBAL__,
+          typeof __CSS_LOCAL__ !== 'undefined' && __CSS_LOCAL__,
+          {
+            style: [
+              {
+                color: 'blue'
+              },
+              myCardStyle
+            ],
+            titleStyle: {
+              color: 'red'
+            }
           }
-        })}
+        )}
       >
         <Content
-          {..._processStyleName('', _css, {
-            style: [contentStyle, _activeStyle]
-          })}
+          {..._processStyleName(
+            '',
+            _css,
+            typeof __CSS_GLOBAL__ !== 'undefined' && __CSS_GLOBAL__,
+            typeof __CSS_LOCAL__ !== 'undefined' && __CSS_LOCAL__,
+            {
+              style: [contentStyle, _activeStyle]
+            }
+          )}
         />
       </Card>
     )
@@ -590,22 +744,34 @@ var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/p
 function Test({ style, cardStyle, title, contentStyle: _contentStyle, activeStyle: _activeStyle }) {
   return (
     <Card
-      {..._processStyleName('', _css, {
-        style: [
-          {
-            color: 'blue'
-          },
-          cardStyle
-        ],
-        titleStyle: {
-          color: 'red'
+      {..._processStyleName(
+        '',
+        _css,
+        typeof __CSS_GLOBAL__ !== 'undefined' && __CSS_GLOBAL__,
+        typeof __CSS_LOCAL__ !== 'undefined' && __CSS_LOCAL__,
+        {
+          style: [
+            {
+              color: 'blue'
+            },
+            cardStyle
+          ],
+          titleStyle: {
+            color: 'red'
+          }
         }
-      })}
+      )}
     >
       <Content
-        {..._processStyleName('', _css, {
-          style: [_contentStyle, _activeStyle]
-        })}
+        {..._processStyleName(
+          '',
+          _css,
+          typeof __CSS_GLOBAL__ !== 'undefined' && __CSS_GLOBAL__,
+          typeof __CSS_LOCAL__ !== 'undefined' && __CSS_LOCAL__,
+          {
+            style: [_contentStyle, _activeStyle]
+          }
+        )}
       />
     </Card>
   )
@@ -638,22 +804,34 @@ var _processStyleName = require('@startupjs/babel-plugin-rn-stylename-to-style/p
 function Test(props) {
   return (
     <Card
-      {..._processStyleName('', _css, {
-        style: [
-          {
-            color: 'blue'
-          },
-          props.cardStyle
-        ],
-        titleStyle: {
-          color: 'red'
+      {..._processStyleName(
+        '',
+        _css,
+        typeof __CSS_GLOBAL__ !== 'undefined' && __CSS_GLOBAL__,
+        typeof __CSS_LOCAL__ !== 'undefined' && __CSS_LOCAL__,
+        {
+          style: [
+            {
+              color: 'blue'
+            },
+            props.cardStyle
+          ],
+          titleStyle: {
+            color: 'red'
+          }
         }
-      })}
+      )}
     >
       <Content
-        {..._processStyleName('', _css, {
-          style: [props.contentStyle, props.activeStyle]
-        })}
+        {..._processStyleName(
+          '',
+          _css,
+          typeof __CSS_GLOBAL__ !== 'undefined' && __CSS_GLOBAL__,
+          typeof __CSS_LOCAL__ !== 'undefined' && __CSS_LOCAL__,
+          {
+            style: [props.contentStyle, props.activeStyle]
+          }
+        )}
       />
     </Card>
   )

--- a/packages/babel-plugin-rn-stylename-to-style/__tests__/index.spec.js
+++ b/packages/babel-plugin-rn-stylename-to-style/__tests__/index.spec.js
@@ -82,6 +82,70 @@ pluginTester({
           </Card>
         )
       }
+    `,
+    'part attribute. No props': /* js */`
+      import './index.styl'
+      function Test () {
+        return (
+          <Card
+            part='card'
+            style={{ color: 'blue' }}
+            titleStyle={{ color: 'red' }}
+          >
+            <Content
+              styleName='content'
+              part='content active'
+              style={{ fontWeight: 'bold' }}
+              bodyStyle={{ color: 'blue' }}
+            />
+          </Card>
+        )
+      }
+    `,
+    'part attribute. With destructed props': /* js */`
+      import './index.styl'
+      function Test ({ style, cardStyle, title }) {
+        return (
+          <Card
+            part='card'
+            style={{ color: 'blue' }}
+            titleStyle={{ color: 'red' }}
+          >
+            <Content part='content active' />
+          </Card>
+        )
+      }
+    `,
+    'part attribute. With named props': /* js */`
+      import './index.styl'
+      function Test (props) {
+        return (
+          <Card
+            part='card'
+            style={{ color: 'blue' }}
+            titleStyle={{ color: 'red' }}
+          >
+            <Content part='content active' />
+          </Card>
+        )
+      }
+    `,
+    'part attribute. With anon function within named fn': /* js */`
+      import './index.styl'
+      const Test = ({ style, cardStyle: myCardStyle, contentStyle, title }) => {
+        function render () {
+          return (
+            <Card
+              part='card'
+              style={{ color: 'blue' }}
+              titleStyle={{ color: 'red' }}
+            >
+              <Content part='content active' />
+            </Card>
+          )
+        }
+        return render()
+      }
     `
   }
 })

--- a/packages/babel-plugin-rn-stylename-to-style/__tests__/index.spec.js
+++ b/packages/babel-plugin-rn-stylename-to-style/__tests__/index.spec.js
@@ -72,6 +72,16 @@ pluginTester({
           </Card>
         )
       }
+    `,
+    'DEPRECATED! With ::part() styles and deprecated *StyleName props': /* js */`
+      import './index.styl'
+      function Test ({ style, active, submit, disabled, titleStyle }) {
+        return (
+          <Card style={style} styleName={['root', {active}]} titleStyleName={['title', {active}]} titleStyle={[titleStyle, { color: 'green' }]} title='container'>
+            <Content styleName='text' style={{ color: 'red' }} footerStyleName='footer' footerStyle={{ color: 'blue' }} center title='text' />
+          </Card>
+        )
+      }
     `
   }
 })

--- a/packages/babel-plugin-rn-stylename-to-style/__tests__/index.spec.js
+++ b/packages/babel-plugin-rn-stylename-to-style/__tests__/index.spec.js
@@ -1,0 +1,77 @@
+const pluginTester = require('babel-plugin-tester').default
+const plugin = require('../index.cjs')
+const packageJson = require('../package.json')
+
+const { name: pluginName } = packageJson
+
+pluginTester({
+  plugin,
+  pluginName,
+  snapshot: true,
+  pluginOptions: {
+    extensions: ['styl', 'css']
+  },
+  babelOptions: {
+    plugins: ['@babel/plugin-syntax-jsx']
+  },
+  tests: {
+    'Regular string': /* js */`
+      import './index.styl'
+      function Test () {
+        return (
+          <div styleName='root active'>
+            <span styleName='title'>Title</span>
+            <span styleName='description'>Description</span>
+            <button styleName='submit disabled'>Submit</button>
+          </div>
+        )
+      }
+    `,
+    'Regular string with existing style': /* js */`
+      import './index.styl'
+      function Test ({ style }) {
+        const titleStyle = { color: 'red', fontWeight: 'bold' }
+        return (
+          <div style={[style, { backgroundColor: 'black' }]} styleName='root active'>
+            <span styleName='title' style={titleStyle}>Title</span>
+            <span styleName='description' style={{ color: 'green' }}>Description</span>
+            <button styleName='submit disabled'>Submit</button>
+          </div>
+        )
+      }
+    `,
+    'Arrays and objects': /* js */`
+      import './index.styl'
+      function Test ({ style, active, submit, disabled }) {
+        const titleStyle = { color: 'red', fontWeight: 'bold' }
+        return (
+          <div style={style} styleName={['root', {active}]}>
+            <span styleName={['title']} style={titleStyle}>Title</span>
+            <span styleName={['description']} style={{ color: 'green' }}>Description</span>
+            <button style={{ color: 'pink' }} styleName={{submit, disabled}}>Submit</button>
+          </div>
+        )
+      }
+    `,
+    'Puts compiled attribute to the end of attributes list': /* js */`
+      import './index.styl'
+      function Test ({ style, active, submit, disabled }) {
+        return (
+          <div style={style} styleName={['root', {active}]} title='container'>
+            <span styleName='text' style={{ color: 'red' }} center title='text' />
+          </div>
+        )
+      }
+    `,
+    'With ::part() styles': /* js */`
+      import './index.styl'
+      function Test ({ style, active, submit, disabled, titleStyle }) {
+        return (
+          <Card style={style} styleName={['root', {active}]} titleStyle={[titleStyle, { color: 'green' }]} title='container'>
+            <Content styleName='text' style={{ color: 'red' }} footerStyle={{ color: 'blue' }} center title='text' />
+          </Card>
+        )
+      }
+    `
+  }
+})

--- a/packages/babel-plugin-rn-stylename-to-style/__tests__/index.spec.js
+++ b/packages/babel-plugin-rn-stylename-to-style/__tests__/index.spec.js
@@ -146,6 +146,34 @@ pluginTester({
         }
         return render()
       }
+    `,
+    'magic \'root\' part': /* js */`
+      import './index.styl'
+      function Test ({ title }) {
+        return (
+          <Card
+            part='root'
+            style={{ color: 'blue' }}
+            titleStyle={{ color: 'red' }}
+          >
+            <Content part='content active' />
+          </Card>
+        )
+      }
+    `,
+    'magic \'root\' part with existing style prop': /* js */`
+      import './index.styl'
+      function Test ({ title, style }) {
+        return (
+          <Card
+            part='root'
+            style={{ color: 'blue' }}
+            titleStyle={{ color: 'red' }}
+          >
+            <Content part='content active' />
+          </Card>
+        )
+      }
     `
   }
 })

--- a/packages/babel-plugin-rn-stylename-to-style/constants.cjs
+++ b/packages/babel-plugin-rn-stylename-to-style/constants.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  GLOBAL_NAME: '__CSS_GLOBAL__',
+  LOCAL_NAME: '__CSS_LOCAL__'
+}

--- a/packages/babel-plugin-rn-stylename-to-style/index.cjs
+++ b/packages/babel-plugin-rn-stylename-to-style/index.cjs
@@ -74,6 +74,7 @@ module.exports = function (babel) {
     // While searching, skip named functions which start from lowercase
     while (true) {
       closestFnPath = closestFnPath.getFunctionParent()
+      if (!closestFnPath) break // if we reached Program
       if (!(
         (
           t.isFunctionDeclaration(closestFnPath.node) ||
@@ -87,7 +88,7 @@ module.exports = function (babel) {
         break
       }
     }
-    if (t.isProgram(closestFnPath.node)) {
+    if (!closestFnPath) {
       throw partAttrPath.buildCodeFrameError(`
         Closest react functional component not found for 'part' attribute.
         Or your component is named lowercase.'
@@ -152,15 +153,6 @@ module.exports = function (babel) {
 
     // Check if styleName exists and if it can be processed
     if (styleName != null) {
-      if (!specifier) {
-        throw jsxOpeningElementPath.buildCodeFrameError(`
-          styleName attribute can't be processed. No styles file found.
-
-          Most likely you've forgot to import your styles file:
-
-            import './index.styl'
-        `)
-      }
       if (!(
         t.isStringLiteral(styleName.node.value) ||
         t.isJSXExpressionContainer(styleName.node.value)

--- a/packages/babel-plugin-rn-stylename-to-style/index.cjs
+++ b/packages/babel-plugin-rn-stylename-to-style/index.cjs
@@ -21,33 +21,9 @@ const buildRequire = template(`
   const %%name%% = require('${PROCESS_PATH}').process
 `)
 
-function getExt (node) {
-  return nodePath.extname(node.source.value).replace(/^\./, '')
-}
-
-function convertStyleName (name) {
-  return name.replace(/Name$/, '')
-}
-
-function convertPartName (partName) {
-  if (partName === 'root') return 'style'
-  return partName + 'Style'
-}
-
 module.exports = function (babel) {
   let styleHash = {}
   let specifier
-
-  function isRequire (node) {
-    return (
-      node &&
-      node.declarations &&
-      node.declarations[0] &&
-      node.declarations[0].init &&
-      node.declarations[0].init.callee &&
-      node.declarations[0].init.callee.name === 'require'
-    )
-  }
 
   function getStyleFromExpression (expression, state) {
     state.hasTransformedClassName = true
@@ -375,4 +351,21 @@ module.exports = function (babel) {
       }
     }
   }
+}
+
+function isRequire (node) {
+  return node?.declarations?.[0]?.init?.callee?.name === 'require'
+}
+
+function getExt (node) {
+  return nodePath.extname(node.source.value).replace(/^\./, '')
+}
+
+function convertStyleName (name) {
+  return name.replace(/Name$/, '')
+}
+
+function convertPartName (partName) {
+  if (partName === 'root') return 'style'
+  return partName + 'Style'
 }

--- a/packages/babel-plugin-rn-stylename-to-style/index.cjs
+++ b/packages/babel-plugin-rn-stylename-to-style/index.cjs
@@ -14,6 +14,7 @@ function convertStyleName (name) {
 }
 
 function convertPartName (partName) {
+  if (partName === 'root') return 'style'
   return partName + 'Style'
 }
 

--- a/packages/babel-plugin-rn-stylename-to-style/index.cjs
+++ b/packages/babel-plugin-rn-stylename-to-style/index.cjs
@@ -9,7 +9,7 @@ const ROOT_STYLE_PROP_NAME = 'style'
 
 const { GLOBAL_NAME, LOCAL_NAME } = require('./constants.cjs')
 
-const buildSafeVar = template(`
+const buildSafeVar = template.expression(`
   typeof %%variable%% !== 'undefined' && %%variable%%
 `)
 
@@ -169,8 +169,8 @@ module.exports = function (babel) {
         specifier
           ? t.identifier(specifier.local.name)
           : t.objectExpression([]),
-        buildSafeVar({ variable: t.identifier(GLOBAL_NAME) }).expression,
-        buildSafeVar({ variable: t.identifier(LOCAL_NAME) }).expression,
+        buildSafeVar({ variable: t.identifier(GLOBAL_NAME) }),
+        buildSafeVar({ variable: t.identifier(LOCAL_NAME) }),
         t.objectExpression(inlineStyles)
       ]
     )

--- a/packages/babel-plugin-rn-stylename-to-style/matcher.js
+++ b/packages/babel-plugin-rn-stylename-to-style/matcher.js
@@ -1,0 +1,111 @@
+const ROOT_STYLE_PROP_NAME = 'style'
+const PART_REGEX = /::?part\(([^)]+)\)/
+
+const isArray = Array.isArray || function (arg) {
+  return Object.prototype.toString.call(arg) === '[object Array]'
+}
+
+export default function matcher (styleName, cssStyles, inlineStyles) {
+  // inlineStyles is used as an implicit indication of:
+  // w/ inlineStyles -- process all styles and return an object with style props
+  // w/o inlineStyles -- default inline styles addition is done externally,
+  //                     return styles object directly
+  const pure = !inlineStyles
+
+  // Process styleName through the `classnames`-like function.
+  // This allows to specify styleName as an array or an object,
+  // not just the string.
+  styleName = cc(styleName)
+
+  const htmlClasses = (styleName || '').split(' ').filter(Boolean)
+  const styleProps = getStyleProps(htmlClasses, cssStyles, pure)
+
+  // If inline styles exist, add them to the end to give them priority over
+  // styles from CSS file.
+  if (inlineStyles) {
+    for (const propName in inlineStyles) {
+      if (styleProps[propName]) {
+        styleProps[propName].push(inlineStyles[propName])
+      } else {
+        styleProps[propName] = inlineStyles[propName]
+      }
+    }
+    return styleProps
+  } else {
+    return styleProps[ROOT_STYLE_PROP_NAME]
+  }
+}
+
+// Process all styles, including the ::part() ones.
+function getStyleProps (htmlClasses, cssStyles, rootOnly) {
+  const res = {
+    [ROOT_STYLE_PROP_NAME]: []
+  }
+  for (const selector in cssStyles) {
+    // Find out which part (or root) this selector is targeting
+    const match = selector.match(PART_REGEX)
+    const attr = match ? getPropName(match[1]) : ROOT_STYLE_PROP_NAME
+
+    // Don't process part if rootOnly is specified
+    if (rootOnly && attr !== ROOT_STYLE_PROP_NAME) continue
+
+    // Strip ::part() if it exists
+    const pureSelector = selector.replace(PART_REGEX, '')
+
+    // Check if the selector is matching our list of existing classes
+    const cssClasses = pureSelector.split('.')
+    if (!arrayContainedInArray(cssClasses, htmlClasses)) continue
+
+    // Push selector's style to the according part's array of styles.
+    // We have a nested array structure here to account for the selector specificity.
+    // This way styles for selector with 3 classes take priority
+    // over selectors with 2 classes, etc.
+
+    // Note: Specificity here does not strictly equal the standard
+    //       since we only use classes to increase the specificity.
+    //       In future this might change when we add support for tags, but for now
+    //       it is a single digit increment starting from 0 and equalling the amount
+    //       of classes in the selector.
+    const specificity = cssClasses.length - 1
+    if (!res[attr]) res[attr] = []
+    if (!res[attr][specificity]) res[attr][specificity] = []
+    res[attr][specificity].push(cssStyles[selector])
+  }
+  return res
+}
+
+function getPropName (name) {
+  return name + 'Style'
+}
+
+function arrayContainedInArray (cssClasses, htmlClasses) {
+  for (var i = 0; i < cssClasses.length; i++) {
+    if (htmlClasses.indexOf(cssClasses[i]) === -1) return false
+  }
+  return true
+};
+
+// classcat 4.0.2
+// https://github.com/jorgebucaran/classcat
+
+function cc (names) {
+  let i
+  let len
+  let tmp = typeof names
+  let out = ''
+
+  if (tmp === 'string' || tmp === 'number') return names || ''
+
+  if (isArray(names) && names.length > 0) {
+    for (i = 0, len = names.length; i < len; i++) {
+      if ((tmp = cc(names[i])) !== '') out += (out && ' ') + tmp
+    }
+  } else {
+    for (i in names) {
+      // eslint-disable-next-line no-prototype-builtins
+      if (names.hasOwnProperty(i) && names[i]) out += (out && ' ') + i
+    }
+  }
+
+  return out
+}

--- a/packages/babel-plugin-rn-stylename-to-style/package.json
+++ b/packages/babel-plugin-rn-stylename-to-style/package.json
@@ -30,6 +30,8 @@
     "README.md"
   ],
   "dependencies": {
+    "@babel/template": "^7.4.0",
+    "@babel/types": "^7.0.0",
     "@nx-js/observer-util": "^4.1.3",
     "react-native-dynamic-style-processor": "^0.21.0"
   },

--- a/packages/babel-plugin-rn-stylename-to-style/package.json
+++ b/packages/babel-plugin-rn-stylename-to-style/package.json
@@ -15,7 +15,7 @@
   "main": "index.cjs",
   "type": "module",
   "scripts": {
-    "test": "jest && mocha"
+    "test": "mocha && jest"
   },
   "author": "Pavel Zhukov",
   "license": "MIT",

--- a/packages/babel-plugin-rn-stylename-to-style/package.json
+++ b/packages/babel-plugin-rn-stylename-to-style/package.json
@@ -12,8 +12,11 @@
     "stylename",
     "style"
   ],
-  "main": "index.js",
-  "scripts": {},
+  "main": "index.cjs",
+  "type": "module",
+  "scripts": {
+    "test": "jest && mocha"
+  },
   "author": "Pavel Zhukov",
   "license": "MIT",
   "repository": {
@@ -29,5 +32,11 @@
   "dependencies": {
     "@nx-js/observer-util": "^4.1.3",
     "react-native-dynamic-style-processor": "^0.21.0"
+  },
+  "devDependencies": {
+    "babel-plugin-tester": "^9.1.0",
+    "@startupjs/css-to-react-native-transform": "^1.9.0-0",
+    "jest": "^26.0.1",
+    "mocha": "^8.1.1"
   }
 }

--- a/packages/babel-plugin-rn-stylename-to-style/process.js
+++ b/packages/babel-plugin-rn-stylename-to-style/process.js
@@ -2,18 +2,20 @@ import { process as dynamicProcess } from 'react-native-dynamic-style-processor/
 import dimensions from './dimensions'
 import matcher from './matcher'
 
-export function process (styleName, cssStyles, inlineStyles) {
-  // If @media is used, force trigger access to the observable value.
-  // Whenever that value changes the according components will
-  // automatically rerender.
-  // The change is triggered globally using the useMediaChange() hook
-  // in @startupjs/app, which sets up the Dimensions 'change' listener
-  // eslint-disable-next-line no-unused-expressions
-  if (hasMedia(cssStyles)) dimensions.width
+export function process (
+  styleName,
+  cssStyles,
+  globalStyles,
+  localStyles,
+  inlineStyleProps
+) {
+  cssStyles = transformStyles(cssStyles)
+  globalStyles = transformStyles(globalStyles)
+  localStyles = transformStyles(localStyles)
 
-  cssStyles = dynamicProcess(cssStyles)
-
-  return matcher(styleName, cssStyles, inlineStyles)
+  return matcher(
+    styleName, cssStyles, globalStyles, localStyles, inlineStyleProps
+  )
 }
 
 function hasMedia (cssStyles) {
@@ -21,5 +23,22 @@ function hasMedia (cssStyles) {
     if (/^@media/.test(selector)) {
       return true
     }
+  }
+}
+
+function transformStyles (styles) {
+  if (styles) {
+    // If @media is used, force trigger access to the observable value.
+    // Whenever that value changes the according components will
+    // automatically rerender.
+    // The change is triggered globally using the useMediaChange() hook
+    // in @startupjs/app, which sets up the Dimensions 'change' listener
+    // eslint-disable-next-line no-unused-expressions
+    if (hasMedia(styles)) dimensions.width
+
+    // dynamically process @media queries and vh/vw units
+    return dynamicProcess(styles)
+  } else {
+    return {}
   }
 }

--- a/packages/babel-plugin-rn-stylename-to-style/process.js
+++ b/packages/babel-plugin-rn-stylename-to-style/process.js
@@ -1,12 +1,8 @@
 import { process as dynamicProcess } from 'react-native-dynamic-style-processor/src'
 import dimensions from './dimensions'
+import matcher from './matcher'
 
-const isArray = Array.isArray || function (arg) {
-  return Object.prototype.toString.call(arg) === '[object Array]'
-}
-
-export function process (styleName, cssStyles) {
-  if (/magic/.test(JSON.stringify(styleName))) console.log('>>>>> MAGIC', JSON.stringify(styleName))
+export function process (styleName, cssStyles, inlineStyles) {
   // If @media is used, force trigger access to the observable value.
   // Whenever that value changes the according components will
   // automatically rerender.
@@ -17,21 +13,7 @@ export function process (styleName, cssStyles) {
 
   cssStyles = dynamicProcess(cssStyles)
 
-  // Process styleName through the `classnames`-like function.
-  // This allows to specify styleName as an array or an object,
-  // not just the string.
-  styleName = cc(styleName)
-
-  let htmlClasses = (styleName || '').split(' ').filter(Boolean)
-  if (htmlClasses.length > 1) {
-    htmlClasses = addMultiClasses(htmlClasses, cssStyles)
-  }
-  const res = []
-  for (let i = 0; i < htmlClasses.length; i++) {
-    const htmlClass = htmlClasses[i]
-    if (cssStyles[htmlClass]) res.push(cssStyles[htmlClass])
-  }
-  return res
+  return matcher(styleName, cssStyles, inlineStyles)
 }
 
 function hasMedia (cssStyles) {
@@ -40,56 +22,4 @@ function hasMedia (cssStyles) {
       return true
     }
   }
-}
-
-function addMultiClasses (htmlClasses, cssStyles) {
-  const resByAmount = {}
-  let maxAmount = 0
-  for (const selector in cssStyles) {
-    if (!/\./.test(selector)) continue
-    const cssClasses = selector.split('.')
-    if (arrayContainedInArray(cssClasses, htmlClasses)) {
-      const amount = cssClasses.length
-      if (amount > maxAmount) maxAmount = amount
-      if (!resByAmount[amount]) resByAmount[amount] = []
-      resByAmount[amount].push(selector)
-    }
-  }
-  for (let j = 0; j <= maxAmount; j++) {
-    if (!resByAmount[j]) continue
-    htmlClasses = htmlClasses.concat(resByAmount[j])
-  }
-  return htmlClasses
-}
-
-function arrayContainedInArray (cssClasses, htmlClasses) {
-  for (var i = 0; i < cssClasses.length; i++) {
-    if (htmlClasses.indexOf(cssClasses[i]) === -1) return false
-  }
-  return true
-};
-
-// classcat 4.0.2
-// https://github.com/jorgebucaran/classcat
-
-function cc (names) {
-  let i
-  let len
-  let tmp = typeof names
-  let out = ''
-
-  if (tmp === 'string' || tmp === 'number') return names || ''
-
-  if (isArray(names) && names.length > 0) {
-    for (i = 0, len = names.length; i < len; i++) {
-      if ((tmp = cc(names[i])) !== '') out += (out && ' ') + tmp
-    }
-  } else {
-    for (i in names) {
-      // eslint-disable-next-line no-prototype-builtins
-      if (names.hasOwnProperty(i) && names[i]) out += (out && ' ') + i
-    }
-  }
-
-  return out
 }

--- a/packages/babel-plugin-rn-stylename-to-style/test/matcher.mjs
+++ b/packages/babel-plugin-rn-stylename-to-style/test/matcher.mjs
@@ -99,6 +99,49 @@ describe('Root styles only', () => {
       ]
     })
   })
+  it('empty root. Pipe inline styles only', () => {
+    assert.deepStrictEqual(p(
+      '',
+      /* css */`
+        .root {
+          color: red;
+          font-weight: bold;
+          padding-left: 10px;
+        }
+        .dummy {
+          color: green;
+        }
+        .root.dummy {
+          color: red;
+        }
+      `,
+      {
+        style: [
+          {
+            marginLeft: 10
+          }, {
+            marginRight: 20
+          }
+        ],
+        cardStyle: {
+          marginRight: 10
+        }
+      }
+    ), {
+      style: [
+        [ // inline styles
+          {
+            marginLeft: 10
+          }, {
+            marginRight: 20
+          }
+        ]
+      ],
+      cardStyle: {
+        marginRight: 10
+      }
+    })
+  })
   it('multiple classes', () => {
     assert.deepStrictEqual(p(
       'root active card',

--- a/packages/babel-plugin-rn-stylename-to-style/test/matcher.mjs
+++ b/packages/babel-plugin-rn-stylename-to-style/test/matcher.mjs
@@ -1,0 +1,329 @@
+import assert from 'assert'
+import matcher from '../matcher.js'
+import css2rn from '@startupjs/css-to-react-native-transform'
+
+function p (styleName, cssStyles, inlineStyles) {
+  return matcher(
+    styleName,
+    css2rn.default(cssStyles, { parseMediaQueries: true, parsePartSelectors: true }),
+    inlineStyles
+  )
+}
+
+describe('Pure usage without attributes', () => {
+  it('simple', () => {
+    assert.deepStrictEqual(p(
+      'root',
+      /* css */`
+        .root {
+          color: red;
+          font-weight: bold;
+          padding-left: 10px;
+        }
+        .dummy {
+          color: green;
+        }
+        .root.dummy {
+          color: red;
+        }
+      `
+    ), [
+      [{ // specificity 0 selectors (same as specificity 10 in CSS)
+        color: 'red',
+        fontWeight: 'bold',
+        paddingLeft: 10
+      }]
+    ])
+  })
+})
+
+describe('Root styles only', () => {
+  it('simple', () => {
+    assert.deepStrictEqual(p(
+      'root',
+      /* css */`
+        .root {
+          color: red;
+          font-weight: bold;
+          padding-left: 10px;
+        }
+        .dummy {
+          color: green;
+        }
+        .root.dummy {
+          color: red;
+        }
+      `,
+      {}
+    ), {
+      style: [
+        [{ // specificity 0 selectors (same as specificity 10 in CSS)
+          color: 'red',
+          fontWeight: 'bold',
+          paddingLeft: 10
+        }]
+      ]
+    })
+  })
+  it('with inline styles', () => {
+    assert.deepStrictEqual(p(
+      'root',
+      /* css */`
+        .root {
+          color: red;
+          font-weight: bold;
+          padding-left: 10px;
+        }
+        .dummy {
+          color: green;
+        }
+        .root.dummy {
+          color: red;
+        }
+      `,
+      {
+        style: {
+          marginLeft: 10
+        }
+      }
+    ), {
+      style: [
+        [{ // specificity 0
+          color: 'red',
+          fontWeight: 'bold',
+          paddingLeft: 10
+        }],
+        { // inline styles
+          marginLeft: 10
+        }
+      ]
+    })
+  })
+  it('multiple classes', () => {
+    assert.deepStrictEqual(p(
+      'root active card',
+      /* css */`
+        .active {
+          opacity: 0.8;
+        }
+        .card {
+          border-radius: 8px;
+        }
+        .card.active {
+          opacity: 0.9;
+        }
+        .root {
+          color: red;
+          font-weight: bold;
+          padding-left: 10px;
+        }
+        .root.active {
+          opacity: 1;
+        }
+        .root.card.active {
+          color: green;
+        }
+        .dummy {
+          color: green;
+        }
+        .root.dummy {
+          color: red;
+        }
+        .root.card.dummy {
+          color: red;
+        }
+      `,
+      {
+        style: {
+          marginLeft: 10
+        }
+      }
+    ), {
+      style: [
+        [{ // specificity 0 (1 class)
+          opacity: 0.8
+        }, {
+          borderRadius: 8
+        }, {
+          color: 'red',
+          fontWeight: 'bold',
+          paddingLeft: 10
+        }],
+        [{ // specificity 1 (2 classes)
+          opacity: 0.9
+        }, {
+          opacity: 1
+        }],
+        [{ // specificity 2 (3 classes)
+          color: 'green'
+        }],
+        { // inline styles
+          marginLeft: 10
+        }
+      ]
+    })
+  })
+})
+
+describe('Parts', () => {
+  it('simple', () => {
+    assert.deepStrictEqual(p(
+      'root',
+      /* css */`
+        .root {
+          color: red;
+          font-weight: bold;
+          padding-left: 10px;
+        }
+        .root::part(input) {
+          background-color: black;
+          color: blue;
+        }
+      `,
+      {}
+    ), {
+      style: [
+        [{
+          color: 'red',
+          fontWeight: 'bold',
+          paddingLeft: 10
+        }]
+      ],
+      inputStyle: [
+        [{
+          backgroundColor: 'black',
+          color: 'blue'
+        }]
+      ]
+    })
+  })
+  it('multiple classes', () => {
+    assert.deepStrictEqual(p(
+      'root active card',
+      /* css */`
+        .active {
+          opacity: 0.8;
+        }
+        .card {
+          border-radius: 8px;
+        }
+        .card.active {
+          opacity: 0.9;
+        }
+        .card::part(header) {
+          background-color: green;
+        }
+        .card.active::part(header) {
+          background-color: red;
+        }
+        .card.active::part(footer) {
+          color: orange;
+        }
+        .root {
+          color: red;
+          font-weight: bold;
+          padding-left: 10px;
+        }
+        .root::part(header) {
+          font-size: 20px;
+        }
+        .root::part(footer) {
+          font-size: 22px;
+        }
+        .root.active {
+          opacity: 1;
+        }
+        .root.active::part(footer) {
+          background-color: pink;
+        }
+        .root.card.active {
+          color: green;
+        }
+        .root.card.active::part(footer) {
+          background-color: violet;
+        }
+        .dummy {
+          color: green;
+        }
+        .dummy::part(header) {
+          color: magenta;
+        }
+        .root.dummy {
+          color: red;
+        }
+        .root.card.dummy {
+          color: red;
+        }
+      `,
+      {
+        style: {
+          marginLeft: 10
+        },
+        headerStyle: {
+          marginLeft: 12
+        },
+        footerStyle: {
+          marginLeft: 14
+        },
+        dummyStyle: {
+          marginLeft: 16
+        }
+      }
+    ), {
+      style: [
+        [{ // specificity 0 (1 class)
+          opacity: 0.8
+        }, {
+          borderRadius: 8
+        }, {
+          color: 'red',
+          fontWeight: 'bold',
+          paddingLeft: 10
+        }],
+        [{ // specificity 1 (2 classes)
+          opacity: 0.9
+        }, {
+          opacity: 1
+        }],
+        [{ // specificity 2 (3 classes)
+          color: 'green'
+        }],
+        { // inline styles
+          marginLeft: 10
+        }
+      ],
+      headerStyle: [
+        [{ // specificity 0
+          backgroundColor: 'green'
+        }, {
+          fontSize: 20
+        }],
+        [{ // specificity 1
+          backgroundColor: 'red'
+        }],
+        { // inline styles
+          marginLeft: 12
+        }
+      ],
+      footerStyle: [
+        [{ // specificity 0
+          fontSize: 22
+        }],
+        [{ // specificity 1
+          color: 'orange'
+        }, {
+          backgroundColor: 'pink'
+        }],
+        [{ // specificity 2
+          backgroundColor: 'violet'
+        }],
+        { // inline styles
+          marginLeft: 14
+        }
+      ],
+      dummyStyle: {
+        marginLeft: 16
+      }
+    })
+  })
+})

--- a/packages/babel-preset-startupjs/index.js
+++ b/packages/babel-preset-startupjs/index.js
@@ -58,10 +58,14 @@ const nativeReactCssModulesPlatformExtensionsPlugin = () =>
     extensions: ['styl', 'css']
   }]
 
-const nativeReactCssModulesPlugin = () =>
+const nativeReactCssModulesPlugins = ({ platform } = {}) => [
   [require('@startupjs/babel-plugin-rn-stylename-to-style'), {
     extensions: ['styl', 'css']
+  }],
+  [require('@startupjs/babel-plugin-rn-stylename-inline'), {
+    platform
   }]
+]
 
 const webPassClassnamePlugin = () =>
   require('babel-plugin-react-native-web-pass-classname')
@@ -75,7 +79,7 @@ const CONFIG_NATIVE_DEVELOPMENT = {
   plugins: [
     dotenvPlugin(),
     nativeReactCssModulesPlatformExtensionsPlugin(),
-    nativeReactCssModulesPlugin()
+    ...nativeReactCssModulesPlugins()
   ]
 }
 
@@ -86,7 +90,7 @@ const CONFIG_NATIVE_PRODUCTION = {
   plugins: [
     dotenvPlugin({ production: true }),
     nativeReactCssModulesPlatformExtensionsPlugin(),
-    nativeReactCssModulesPlugin()
+    ...nativeReactCssModulesPlugins()
   ]
 }
 
@@ -105,7 +109,7 @@ const CONFIG_WEB_UNIVERSAL_DEVELOPMENT = {
   plugins: [
     [require('react-refresh/babel'), { skipEnvCheck: true }],
     dotenvPlugin({ mockBaseUrl: true }),
-    nativeReactCssModulesPlugin()
+    ...nativeReactCssModulesPlugins({ platform: 'web' })
   ]
 }
 
@@ -119,7 +123,7 @@ const CONFIG_WEB_UNIVERSAL_PRODUCTION = {
     ASYNC && require('@startupjs/babel-plugin-startupjs'),
     ASYNC && require('@startupjs/babel-plugin-import-to-react-lazy'),
     dotenvPlugin({ production: true, mockBaseUrl: true }),
-    nativeReactCssModulesPlugin()
+    ...nativeReactCssModulesPlugins({ platform: 'web' })
   ].filter(Boolean)
 }
 

--- a/packages/babel-preset-startupjs/package.json
+++ b/packages/babel-preset-startupjs/package.json
@@ -26,6 +26,7 @@
     "@startupjs/babel-plugin-react-css-modules": "1701.0.1",
     "@startupjs/babel-plugin-react-pug-classnames": "^0.23.0",
     "@startupjs/babel-plugin-rn-stylename-to-style": "^0.23.20",
+    "@startupjs/babel-plugin-rn-stylename-inline": "^0.23.20",
     "@startupjs/babel-plugin-startupjs": "^0.23.0",
     "babel-plugin-module-resolver": "^3.2.0",
     "babel-plugin-react-native-platform-specific-extensions": "^1.1.1",

--- a/packages/bundler/lib/callLoader.js
+++ b/packages/bundler/lib/callLoader.js
@@ -1,0 +1,4 @@
+// Simple mock to be able to call simple webpack loaders with filename substitution.
+module.exports = function callLoader (loader, source, filename, options = {}) {
+  return loader.call({ resourcePath: filename, query: options }, source)
+}

--- a/packages/bundler/lib/cssToReactNativeLoader.js
+++ b/packages/bundler/lib/cssToReactNativeLoader.js
@@ -1,7 +1,7 @@
 // ref: https://github.com/kristerkari/react-native-css-transformer
-const css2rn = require('css-to-react-native-transform').default
+const css2rn = require('@startupjs/css-to-react-native-transform').default
 
 module.exports = function cssToReactNative (source) {
-  const cssObject = css2rn(source, { parseMediaQueries: true })
+  const cssObject = css2rn(source, { parseMediaQueries: true, parsePartSelectors: true })
   return 'module.exports = ' + JSON.stringify(cssObject)
 }

--- a/packages/bundler/lib/rnTransformer.js
+++ b/packages/bundler/lib/rnTransformer.js
@@ -5,6 +5,7 @@ const svgTransformer = require('react-native-svg-transformer')
 const mdx = require('@mdx-js/mdx')
 const mdxExamplesLoader = require('./mdxExamplesLoader')
 const replaceObserverLoader = require('./replaceObserverLoader')
+const callLoader = require('./callLoader')
 
 const DEFAULT_MDX_RENDERER = `
 import React from 'react'
@@ -36,9 +37,4 @@ module.exports.transform = function ({ src, filename, options = {} }) {
   } else {
     return upstreamTransformer.transform({ src, filename, options })
   }
-}
-
-// Simple mock to be able to call simple webpack loaders with filename substitution.
-function callLoader (loader, source, filename, options = {}) {
-  return loader.call({ resourcePath: filename, query: options }, source)
 }

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -26,7 +26,7 @@
     "babel-loader": "^8.0.6",
     "babel-preset-startupjs": "^0.23.27",
     "css-loader": "^1.0.0",
-    "css-to-react-native-transform": "^1.8.1",
+    "@startupjs/css-to-react-native-transform": "^1.9.0-0",
     "file-loader": "^2.0.0",
     "friendly-errors-webpack-plugin": "^1.7.0",
     "generic-names": "^1.0.3",

--- a/packages/startupjs/index.js
+++ b/packages/startupjs/index.js
@@ -3,3 +3,6 @@ export * from '@startupjs/hooks'
 // HINT: `isomorphic` means that the code can be executed both
 //        on the server and on the client
 export * from '@startupjs/isomorphic-helpers'
+// dummy babel macro functions for @startupjs/babel-plugin-rn-stylename-inline
+export function css () {}
+export function styl () {}

--- a/packages/ui/components/typography/Typography.ru.mdx
+++ b/packages/ui/components/typography/Typography.ru.mdx
@@ -8,6 +8,7 @@ import Span from './Span'
 import Br from '../Br'
 import Content from '../Content'
 import { Sandbox } from '@startupjs/docs'
+import './index.styl'
 
 # Typography (типография)
 

--- a/packages/ui/docs/hooksAndHelpers.js
+++ b/packages/ui/docs/hooksAndHelpers.js
@@ -6,8 +6,8 @@ import useMediaRu from '../hooks/useMedia.ru.mdx'
 export default {
   type: 'collapse',
   title: {
-    en: 'Hooks / Helpers',
-    ru: 'Хуки и хелперы'
+    en: 'Helpers',
+    ru: 'Хелперы'
   },
   icon: faCode,
   items: {

--- a/packages/vite-plugin-startupjs/includeExclude.js
+++ b/packages/vite-plugin-startupjs/includeExclude.js
@@ -5,6 +5,7 @@ exports.include = [
   'react-native-dynamic-style-processor',
   '@startupjs/babel-plugin-rn-stylename-to-style/process',
   '@startupjs/babel-plugin-rn-stylename-to-style/dimensions',
+  '@startupjs/babel-plugin-rn-stylename-to-style/matcher',
   'uuid',
   'arraydiff',
   'sharedb/lib/client',

--- a/packages/vite-plugin-startupjs/lib/cssToReactNativeLoader.js
+++ b/packages/vite-plugin-startupjs/lib/cssToReactNativeLoader.js
@@ -1,7 +1,7 @@
 // ref: https://github.com/kristerkari/react-native-css-transformer
-const css2rn = require('css-to-react-native-transform').default
+const css2rn = require('@startupjs/css-to-react-native-transform').default
 
 module.exports = function cssToReactNative (source) {
-  const cssObject = css2rn(source, { parseMediaQueries: true })
+  const cssObject = css2rn(source, { parseMediaQueries: true, parsePartSelectors: true })
   return 'module.exports = ' + JSON.stringify(cssObject)
 }

--- a/packages/vite-plugin-startupjs/package.json
+++ b/packages/vite-plugin-startupjs/package.json
@@ -22,7 +22,7 @@
     "@startupjs/react-is": "^16.13.1-1",
     "@startupjs/react-native-fontawesome": "^0.2.5-3",
     "babel-plugin-transform-react-pug": "^7.0.1",
-    "css-to-react-native-transform": "^1.8.1",
+    "@startupjs/css-to-react-native-transform": "^1.9.0-0",
     "eventemitter3": "^3.0.0",
     "lodash-es": "^4.17.15",
     "vite-plugin-react": "2.0.3"

--- a/styleguide/package.json
+++ b/styleguide/package.json
@@ -7,7 +7,6 @@
     "android": "react-native run-android && (npm run adb || true) && npm run log-android",
     "ios": "react-native run-ios --simulator \"iPhone 8\"",
     "start": "startupjs start",
-    "test": "jest",
     "metro": "react-native start --reset-cache",
     "web": "startupjs web",
     "server": "startupjs server",
@@ -41,10 +40,6 @@
   },
   "devDependencies": {
     "babel-jest": "^24.9.0",
-    "jest": "^24.9.0",
     "react-test-renderer": "16.9.0"
-  },
-  "jest": {
-    "preset": "react-native"
   }
 }


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/CSS/::part

## 1. Preprocess `part` attribute.

- Each `part` gets its styles from the `{part}Style` prop.
- `part='root'` is magic -- it's linked to the pure `style` prop.

Here is an example `<Card>` component which specifies its root container, title and footer as stylizable parts:

```jsx
// Card.js

function Card ({ title }) {
  return (
    <View part='root'>
      <Text part='header'>{title}</Text>
      <Text part='footer'>Copyright</Text>
    </View>
  )
}
```

**↓ ↓ ↓ ↓ ↓ ↓**

```jsx
function Card ({ title, style, headerStyle, footerStyle }) {
  return (
    <View style={style}>
      <Text style={headerStyle}>{title}</Text>
      <Text style={footerStyle}>Copyright</Text>
    </View>
  )
}
```

## 2. Preprocess `::part()` selector from CSS file to style any component which uses `part` attributes.

Following an example `<Card>` component above, we can call `<Card>` from the `<App>` and customize its parts styles:

```jsx
// App.js

import Card from './Card'
import './index.styl'

function App (users) {
  return users.map(user => (
    <Card styleName='user' title={user.name} />
  ))
}
```

```styl
// index.styl

.user
  margin-top 16px

  &:part(header)
    background-color black
    color white

  &:part(footer)
    font-weight bold
```

## 3. Add scoped styles support with an API similar to `styled-components`

Adds support for in-JS template strings `css\`\`` and `styl\`\``

### File-level scope (global to file)

```jsx
import React from 'react'
import { View } from 'react-native'
import { css } from 'startupjs'

export default function Card () {
  return <View styleName='card active'><Line /></View>
}
function Line () {
  return <View styleName='line' />
}
css`
  .card {
    padding: 8px 16px;
  }
  .line {
    margin-top: 16px;
    border-radius: 8px;
  }
  .active {
    background-color: red;
  }
`
```

### Local component scope (inside particular react component function)

```jsx
import React from 'react'
import { View } from 'react-native'
import { css, styl } from 'startupjs'

export default function Card () {
  return <View styleName='root active'><Line /></View>
  // .root will be scoped only to this specific component
  styl`
    .root
      padding: 8px 16px
  `
}
function Line () {
  return <View styleName='root' />
  // .root will be scoped only to this specific component
  css`
    .root {
      margin-top: 16px;
      border-radius: 8px;
    }
  `
}
// you can use global- and local- scoped styles together
styl`
  .active
    background-color red
`
```
