### PR TITLE
feat(data): :sparkles: Add to backend racer-schema.

### DIFF
--- a/packages/backend/index.js
+++ b/packages/backend/index.js
@@ -60,7 +60,7 @@ module.exports = async (options) => {
         extraDbs: options.extraDbs
       })
 
-    // redis alternative
+      // redis alternative
     } else if (conf.get('WSBUS_URL') && !conf.get('NO_WSBUS')) {
       if (!wsbusPubSub) throw new Error("Please install the 'sharedb-wsbus-pubsub' package to use it")
       let pubsub = wsbusPubSub(conf.get('WSBUS_URL'))
@@ -70,7 +70,7 @@ module.exports = async (options) => {
         pubsub: pubsub,
         extraDbs: options.extraDbs
       })
-    // For development
+      // For development
     } else {
       return racer.createBackend({
         db: shareMongo,
@@ -94,8 +94,18 @@ module.exports = async (options) => {
     options.accessControl(backend)
   }
 
-  if (options.schema != null) {
-    racerSchema(backend, options.schema)
+  if (global.STARTUP_JS_ORM && Object.keys(global.STARTUP_JS_ORM).length > 0) {
+    const schemaPerCollection = { schemas: {}, formats: {}, validators: {} }
+
+    for (const path in global.STARTUP_JS_ORM) {
+      const { schema } = global.STARTUP_JS_ORM[path].OrmEntity
+
+      if (schema) {
+        schemaPerCollection.schemas[path.replace('.*', '')] = schema
+      }
+    }
+
+    racerSchema(backend, schemaPerCollection)
   }
 
   if (options.hooks != null) {


### PR DESCRIPTION
# Adds [JSON Schema](https://json-schema.org/understanding-json-schema/) validation to Mongo collections

## Installation

1. in `server/index.js` add `validateSchema: true` to `startupjsServer()` options
2. Go to one of your ORM document entities (for example, `UserModel`, which targets `users.*`) and add a static method `schema`:

```js
import { BaseModel } from 'startupjs/orm'

export default class UserModel extends BaseModel {
  static schema = {
    firstName: { type: 'string' },
    lastName: { type: 'string' },
    age: {
      type: 'number',
      multipleOf: 1,
      minimum: 0,
      maximum: 130
    }
  }
}
```

## Notes

1. Schema is checked on both client-side and server-side.
2. Schema validation only works in development. So there won't be any performance overheads when `NODE_ENV` is `production`
3. Only ORMs targeting documents path `<collection>.*` are gonna be parsed for `schema` definitions.