### PR TITLE
add readOnly prop for inputs

### DIFF
--- a/packages/ui/components/forms/Checkbox/Checkbox.en.mdx
+++ b/packages/ui/components/forms/Checkbox/Checkbox.en.mdx
@@ -29,6 +29,12 @@ return (
       value={true}
       disabled
     />
+    <Br />
+    <Checkbox
+      label='Readonly example'
+      value={true}
+      readOnly
+    />
   </Div>
 )
 ```
@@ -53,6 +59,13 @@ return (
       label='Switch disbabled example'
       value={true}
       disabled
+    />
+    <Br />
+    <Checkbox
+      variant='switch'
+      label='Switch readonly example'
+      value={true}
+      readOnly
     />
   </Div>
 )

--- a/packages/ui/components/forms/Checkbox/Checkbox.ru.mdx
+++ b/packages/ui/components/forms/Checkbox/Checkbox.ru.mdx
@@ -29,6 +29,12 @@ return (
       value={true}
       disabled
     />
+    <Br />
+    <Checkbox
+      label='Readonly example'
+      value={true}
+      readOnly
+    />
   </Div>
 )
 ```
@@ -53,6 +59,13 @@ return (
       label='Switch disbabled example'
       value={true}
       disabled
+    />
+    <Br />
+    <Checkbox
+      variant='switch'
+      label='Switch readonly example'
+      value={true}
+      readOnly
     />
   </Div>
 )

--- a/packages/ui/components/forms/Checkbox/index.js
+++ b/packages/ui/components/forms/Checkbox/index.js
@@ -14,6 +14,11 @@ const INPUT_COMPONENTS = {
   switch: Switch
 }
 
+const READONLY_ICONS = {
+  TRUE: '✔',
+  FALSE: '✘'
+}
+
 function CheckboxInput ({
   style,
   className,
@@ -22,6 +27,7 @@ function CheckboxInput ({
   value,
   layout,
   disabled,
+  readOnly,
   onChange,
   hoverStyle,
   activeStyle,
@@ -36,6 +42,18 @@ function CheckboxInput ({
 
   function renderInput (standalone) {
     const Input = INPUT_COMPONENTS[variant]
+
+    if (readOnly) {
+      return pug`
+        Row.checkbox-icon-wrap(
+          styleName=[variant]
+        )
+          Span.checkbox-icon(
+            styleName={readOnly}
+          )=value ? READONLY_ICONS.TRUE : READONLY_ICONS.FALSE
+      `
+    }
+
     return pug`
       Input(
         style=standalone ? style : {}
@@ -58,7 +76,7 @@ function CheckboxInput ({
       className=className
       vAlign='center'
       disabled=disabled
-      onPress=onPress
+      onPress=!readOnly && onPress
       hoverStyle=hoverStyle
       activeStyle=activeStyle
     )
@@ -74,7 +92,8 @@ function CheckboxInput ({
 CheckboxInput.defaultProps = {
   variant: 'checkbox',
   value: false,
-  disabled: false
+  disabled: false,
+  readOnly: false
 }
 
 CheckboxInput.propTypes = {
@@ -84,6 +103,7 @@ CheckboxInput.propTypes = {
   value: propTypes.bool,
   layout: propTypes.oneOf(['pure', 'rows']),
   disabled: propTypes.bool,
+  readOnly: propTypes.bool,
   onChange: propTypes.func
 }
 

--- a/packages/ui/components/forms/Checkbox/index.styl
+++ b/packages/ui/components/forms/Checkbox/index.styl
@@ -1,9 +1,7 @@
 $checkboxBorderColor = $UI.colors.darkLight
 $checkedColor = $UI.colors.primary
 $switchBg = $UI.colors.dark
-
-.root
-  cursor pointer
+$readonlyColor = $UI.colors.mainText
 
 .label
   margin-left 1u
@@ -24,11 +22,23 @@ $switchBg = $UI.colors.dark
     background-color $checkedColor
     border-color $checkedColor
 
+.checkbox-icon-wrap
+  justify-content center
+  border none
+  &.switch
+    background-color none
+
 .checkbox-icon
   display none
 
   &.checked
     display flex
+
+  &.readOnly
+    display flex
+    font(l)
+    line-height 2u
+    color $readonlyColor
 
 .checkbox-animation
   display none

--- a/packages/ui/components/forms/Multiselect/Multiselect.en.mdx
+++ b/packages/ui/components/forms/Multiselect/Multiselect.en.mdx
@@ -13,7 +13,7 @@ import { Multiselect } from '@startupjs/ui'
 ```
 
 ```jsx example
-const [cities, setCities] = useState(['la'])
+const [cities, setCities] = useState(['la', 'tk'])
 // options also can be an array of primitives ['apple', 'banana', 'cherry']
 return (
   <Div>
@@ -22,6 +22,17 @@ return (
       placeholder='Select cities'
       value={cities}
       onChange={setCities}
+      options={[
+        { label: 'New York', value: 'ny' },
+        { label: 'Los Angeles', value: 'la' },
+        { label: 'Tokyo', value: 'tk' }
+      ]}
+    />
+    <Br />
+    <Multiselect
+      label='Example readonly Multiselect'
+      readOnly
+      value={cities}
       options={[
         { label: 'New York', value: 'ny' },
         { label: 'Los Angeles', value: 'la' },

--- a/packages/ui/components/forms/Multiselect/index.js
+++ b/packages/ui/components/forms/Multiselect/index.js
@@ -17,6 +17,7 @@ const Multiselect = ({
   activeColor,
   disabled,
   popoverWidth,
+  readOnly,
   error
 }) => {
   const [showOpts, setShowOpts] = useState(false)
@@ -41,6 +42,7 @@ const Multiselect = ({
   function hideOptsMenu () {
     setShowOpts(false)
   }
+
   return pug`
     MultiselectComponent(
       options=_options
@@ -55,6 +57,7 @@ const Multiselect = ({
       tagVariant=tagVariant
       activeColor=activeColor
       disabled=disabled
+      readOnly=readOnly
       popoverWidth=popoverWidth
       error=error
     )
@@ -72,6 +75,7 @@ Multiselect.propTypes = {
   tagVariant: PropTypes.string,
   activeColor: PropTypes.string,
   disabled: PropTypes.bool,
+  readOnly: PropTypes.bool,
   popoverWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   error: PropTypes.string
 }
@@ -83,6 +87,7 @@ Multiselect.defaultProps = {
   tagVariant: 'flat',
   activeColor: 'primary',
   disabled: false,
+  readOnly: false,
   popoverWidth: u(30)
 }
 

--- a/packages/ui/components/forms/Multiselect/index.styl
+++ b/packages/ui/components/forms/Multiselect/index.styl
@@ -23,6 +23,10 @@ _primaryColor = $UI.colors.primary
     border-color _primaryColor
   &.error
     border-color _errorColor
+  &.readOnly
+    border none
+    background-color none
+    padding 0
 
 .placeholder
   opacity .5

--- a/packages/ui/components/forms/Multiselect/input.js
+++ b/packages/ui/components/forms/Multiselect/input.js
@@ -13,6 +13,7 @@ function MultiselectInput ({
   tagVariant,
   activeColor,
   disabled,
+  readOnly,
   showOpts,
   error
 }) {
@@ -27,6 +28,7 @@ function MultiselectInput ({
       )= record.label
     `
   }
+
   return pug`
     Div.inputRoot
       if label
@@ -36,14 +38,16 @@ function MultiselectInput ({
           variant='description'
         )= label
       Row.input(
-        styleName={ disabled, focused: showOpts, error }
-        onPress=disabled ? void 0 : showOptsMenu
+        styleName={ disabled, focused: showOpts, error, readOnly }
+        onPress=disabled || readOnly ? void 0 : showOptsMenu
       )
-        if !value || !value.length
+        if !value || !value.length && !readOnly
           Span.placeholder= placeholder
+        if !value || !value.length && readOnly
+          Span.placeholder='-'
         each _value, index in value
           =renderTag(_value, index)
-      if error
+      if error && !readOnly
         Span.error(
           size='s'
           variant='description'
@@ -60,6 +64,7 @@ MultiselectInput.propTypes = {
   tagVariant: PropTypes.string,
   activeColor: PropTypes.string,
   disabled: PropTypes.bool,
+  readOnly: PropTypes.bool,
   showOpts: PropTypes.bool,
   error: PropTypes.string
 }

--- a/packages/ui/components/forms/Multiselect/multiselect.web.js
+++ b/packages/ui/components/forms/Multiselect/multiselect.web.js
@@ -18,6 +18,7 @@ const Multiselect = ({
   tagVariant,
   activeColor,
   disabled,
+  readOnly,
   popoverWidth,
   error
 }) => {
@@ -55,6 +56,7 @@ const Multiselect = ({
           activeColor=activeColor
           disabled=disabled
           error=error
+          readOnly=readOnly
         )
       Div.suggestions-web
         each opt in options
@@ -75,6 +77,7 @@ Multiselect.propTypes = {
   tagVariant: PropTypes.string,
   activeColor: PropTypes.string,
   disabled: PropTypes.bool,
+  readOnly: PropTypes.bool,
   popoverWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   error: PropTypes.string
 }

--- a/packages/ui/components/forms/Radio/Radio.en.mdx
+++ b/packages/ui/components/forms/Radio/Radio.en.mdx
@@ -1,6 +1,8 @@
 import { useState } from 'react'
 import Radio from '../Radio'
 import Span from '../../typography/Span'
+import Div from '../../Div'
+import Br from '../../Br'
 import { Sandbox } from '@startupjs/docs'
 
 # Radio
@@ -16,30 +18,55 @@ import { Radio } from from '@startupjs/ui'
 ```jsx example
 const [checked, setChecked] = useState()
 return (
-  <Radio
-    value={checked}
-    onChange={(value) => setChecked(value)}
-    disabled={checked === 'item2'}
-    options={[
-      {
-        value: 'item1',
-        label: 'Item-1 label'
-      },
-      {
-        value: 'item2',
-        label: 'Disable items'
-      },
-      {
-        value: 'item3',
-        label: 'Item-3 label',
-      },
-      {
-        value: 'item4',
-        label: 'Item-4 disabled item',
-        disabled: true
-      }
-    ]}
-  />
+  <Div>
+    <Radio
+      value={checked}
+      onChange={(value) => setChecked(value)}
+      disabled={checked === 'item2'}
+      options={[
+        {
+          value: 'item1',
+          label: 'Item-1 label'
+        },
+        {
+          value: 'item2',
+          label: 'Disable items'
+        },
+        {
+          value: 'item3',
+          label: 'Item-3 label',
+        },
+        {
+          value: 'item4',
+          label: 'Item-4 disabled item',
+          disabled: true
+        }
+      ]}
+    />
+    <Br />
+    <Radio
+      readOnly
+      value={checked}
+      options={[
+        {
+          value: 'item1',
+          label: 'Item-1 label'
+        },
+        {
+          value: 'item2',
+          label: 'Disable items'
+        },
+        {
+          value: 'item3',
+          label: 'Item-3 label'
+        },
+        {
+          value: 'item4',
+          label: 'Item-4 disabled item'
+        }
+      ]}
+    />
+  </Div>
 )
 ```
 

--- a/packages/ui/components/forms/Radio/Radio.ru.mdx
+++ b/packages/ui/components/forms/Radio/Radio.ru.mdx
@@ -1,6 +1,8 @@
 import { useState } from 'react'
 import Radio from '../Radio'
 import Span from '../../typography/Span'
+import Div from '../../Div'
+import Br from '../../Br'
 import { Sandbox } from '@startupjs/docs'
 
 # Radio (радиокнопка)
@@ -16,30 +18,55 @@ import { Radio } from from '@startupjs/ui'
 ```jsx example
 const [checked, setChecked] = useState()
 return (
-  <Radio
-    value={checked}
-    onChange={(value) => setChecked(value)}
-    disabled={checked === 'item2'}
-    options={[
-      {
-        value: 'item1',
-        label: 'Item-1 label'
-      },
-      {
-        value: 'item2',
-        label: 'Disable items'
-      },
-      {
-        value: 'item3',
-        label: 'Item-3 label',
-      },
-      {
-        value: 'item4',
-        label: 'Item-4 disabled item',
-        disabled: true
-      }
-    ]}
-  />
+  <Div>
+    <Radio
+      value={checked}
+      onChange={(value) => setChecked(value)}
+      disabled={checked === 'item2'}
+      options={[
+        {
+          value: 'item1',
+          label: 'Item-1 label'
+        },
+        {
+          value: 'item2',
+          label: 'Disable items'
+        },
+        {
+          value: 'item3',
+          label: 'Item-3 label',
+        },
+        {
+          value: 'item4',
+          label: 'Item-4 disabled item',
+          disabled: true
+        }
+      ]}
+    />
+    <Br />
+    <Radio
+      readOnly
+      value={checked}
+      options={[
+        {
+          value: 'item1',
+          label: 'Item-1 label'
+        },
+        {
+          value: 'item2',
+          label: 'Disable items'
+        },
+        {
+          value: 'item3',
+          label: 'Item-3 label'
+        },
+        {
+          value: 'item4',
+          label: 'Item-4 disabled item'
+        }
+      ]}
+    />
+  </Div>
 )
 ```
 

--- a/packages/ui/components/forms/Radio/index.js
+++ b/packages/ui/components/forms/Radio/index.js
@@ -12,6 +12,7 @@ const Radio = function ({
   options,
   data, // DEPRECATED
   disabled,
+  readOnly,
   onChange
 }) {
   // TODO: DEPRECATED! Remove!
@@ -28,6 +29,7 @@ const Radio = function ({
     ? options.map((o) => {
       return pug`
         Input(
+          readOnly=readOnly
           key=o.value
           checked=o.value === value
           value=o.value
@@ -40,6 +42,7 @@ const Radio = function ({
       return React.cloneElement(child, {
         checked: child.props.value === value,
         disabled,
+        readOnly,
         onPress: value => handleRadioPress(value)
       })
     })
@@ -52,7 +55,8 @@ const Radio = function ({
 
 Radio.defaultProps = {
   options: [],
-  disabled: false
+  disabled: false,
+  readOnly: false
 }
 
 Radio.propTypes = {
@@ -64,6 +68,7 @@ Radio.propTypes = {
   })),
   options: propTypes.array,
   disabled: propTypes.bool,
+  readOnly: propTypes.bool,
   value: propTypes.oneOfType([propTypes.string, propTypes.number]),
   onChange: propTypes.func
 }

--- a/packages/ui/components/forms/Radio/input.js
+++ b/packages/ui/components/forms/Radio/input.js
@@ -19,6 +19,7 @@ const Input = function ({
   children,
   checked,
   disabled,
+  readOnly,
   onPress,
   ...props
 }) {
@@ -53,6 +54,17 @@ const Input = function ({
       ).start()
     }
   }, [checked])
+
+  if (readOnly && checked) {
+    return pug`
+      if typeof children === 'string'
+        Span= children
+      else
+        = children
+    `
+  } else if (readOnly && !checked) {
+    return null
+  }
 
   return pug`
     Row.root(

--- a/packages/ui/components/forms/Select/Select.en.mdx
+++ b/packages/ui/components/forms/Select/Select.en.mdx
@@ -46,6 +46,18 @@ return (
       ]}
       onChange={setCity}
     />
+    <Br />
+    <Select
+      label='Readonly Select example'
+      value={city}
+      readOnly
+      showEmptyValue={false}
+      options={[
+        { label: 'New York', value: 'ny' },
+        { label: 'Los Angeles', value: 'la' },
+        { label: 'Tokyo', value: 'tk' }
+      ]}
+    />
   </Div>
 )
 ```

--- a/packages/ui/components/forms/Select/Select.ru.mdx
+++ b/packages/ui/components/forms/Select/Select.ru.mdx
@@ -46,6 +46,18 @@ return (
       ]}
       onChange={setCity}
     />
+    <Br />
+    <Select
+      label='Readonly Select example'
+      value={city}
+      readOnly
+      showEmptyValue={false}
+      options={[
+        { label: 'New York', value: 'ny' },
+        { label: 'Los Angeles', value: 'la' },
+        { label: 'Tokyo', value: 'tk' }
+      ]}
+    />
   </Div>
 )
 ```

--- a/packages/ui/components/forms/Select/index.js
+++ b/packages/ui/components/forms/Select/index.js
@@ -15,6 +15,7 @@ function Select ({
   showEmptyValue,
   disabled,
   onChange,
+  readOnly,
   ...props
 }) {
   function renderWrapper ({ style }, children) {
@@ -33,6 +34,7 @@ function Select ({
   return pug`
     TextInput(
       style=style
+      readOnly=readOnly
       value=getLabelFromValue(value, options)
       disabled=disabled,
       icon=faAngleDown
@@ -45,11 +47,14 @@ function Select ({
 
 Select.defaultProps = {
   disabled: false,
+  readOnly: false,
   options: [],
   showEmptyValue: true
 }
 
 Select.propTypes = {
+  disabled: propTypes.bool,
+  readOnly: propTypes.bool,
   onChange: propTypes.func,
   options: propTypes.array,
   showEmptyValue: propTypes.bool

--- a/packages/ui/components/forms/TextInput/TextInput.en.mdx
+++ b/packages/ui/components/forms/TextInput/TextInput.en.mdx
@@ -34,6 +34,17 @@ return (
       label='Disabled input example'
       value='Disabled value'
     />
+    <Br />
+    <TextInput
+      readOnly
+      label='Readonly input with label example'
+      value='Readonly value'
+    />
+    <Br />
+    <TextInput
+      readOnly
+      value='Readonly input without label example'
+    />
   </Div>
 )
 ```

--- a/packages/ui/components/forms/TextInput/TextInput.ru.mdx
+++ b/packages/ui/components/forms/TextInput/TextInput.ru.mdx
@@ -34,6 +34,17 @@ return (
       label='Disabled input example'
       value='Disabled value'
     />
+    <Br />
+    <TextInput
+      readOnly
+      label='Readonly input with label example'
+      value='Readonly value'
+    />
+    <Br />
+    <TextInput
+      readOnly
+      value='Readonly input withou label example'
+    />
   </Div>
 )
 ```

--- a/packages/ui/components/forms/TextInput/TextInput.ru.mdx
+++ b/packages/ui/components/forms/TextInput/TextInput.ru.mdx
@@ -43,7 +43,7 @@ return (
     <Br />
     <TextInput
       readOnly
-      value='Readonly input withou label example'
+      value='Readonly input without label example'
     />
   </Div>
 )

--- a/packages/ui/components/forms/TextInput/index.js
+++ b/packages/ui/components/forms/TextInput/index.js
@@ -20,6 +20,8 @@ function TextInput ({
   onBlur,
   onFocus,
   renderWrapper, // @private - used by Select
+  readOnly,
+  size,
   ...props
 }) {
   const _layout = useLayout(layout, label)
@@ -36,6 +38,14 @@ function TextInput ({
   }
 
   function renderInput (standalone) {
+    if (readOnly) {
+      return pug`
+        Span.readonlySpan(
+          styleName=[size]
+        )= value
+      `
+    }
+
     return pug`
       Input(
         style=standalone ? [style, wrapperStyle] : wrapperStyle
@@ -46,6 +56,7 @@ function TextInput ({
         disabled=disabled
         focused=focused
         renderWrapper=renderWrapper
+        size=size
         onBlur=(...args) => {
           _onBlur()
           onBlur && onBlur(...args)
@@ -76,6 +87,7 @@ TextInput.defaultProps = {
   size: 'm',
   value: '', // default value is important to prevent error
   disabled: false,
+  readOnly: false,
   resize: false,
   numberOfLines: 1,
   iconPosition: 'left',
@@ -93,6 +105,7 @@ TextInput.propTypes = {
   size: propTypes.oneOf(['l', 'm', 's']),
   layout: propTypes.oneOf(['pure', 'rows']),
   disabled: propTypes.bool,
+  readOnly: propTypes.bool,
   resize: propTypes.bool,
   numberOfLines: propTypes.number,
   icon: propTypes.oneOfType([propTypes.object, propTypes.func]),

--- a/packages/ui/components/forms/TextInput/index.styl
+++ b/packages/ui/components/forms/TextInput/index.styl
@@ -33,6 +33,14 @@ _inputFontSizeS = 1.75u
   &.focused
     color _focusedColor
 
+.readonlySpan
+  &.s
+    font(s)
+  &.m
+    font(m)
+  &.l
+    font(l)
+
 .input-icon
   position absolute
   top 0


### PR DESCRIPTION
https://trello.com/c/Kkcllz47/85-ui-add-readonly-to-the-input-fields-and-check-if-disabled-is-everywhere

<img width="688" alt="Снимок экрана 2020-10-15 в 15 09 44" src="https://user-images.githubusercontent.com/25533519/96121344-a2be7080-0ef8-11eb-8076-29af3740473d.png">
<img width="677" alt="Снимок экрана 2020-10-15 в 15 09 55" src="https://user-images.githubusercontent.com/25533519/96121356-a520ca80-0ef8-11eb-8468-edbb38ddc071.png">
<img width="676" alt="Снимок экрана 2020-10-15 в 15 10 02" src="https://user-images.githubusercontent.com/25533519/96121358-a5b96100-0ef8-11eb-9d10-3c532cf510c9.png">
<img width="677" alt="Снимок экрана 2020-10-15 в 15 10 30" src="https://user-images.githubusercontent.com/25533519/96121359-a651f780-0ef8-11eb-90e0-9bf99c6d8c74.png">
<img width="671" alt="Снимок экрана 2020-10-15 в 15 10 42" src="https://user-images.githubusercontent.com/25533519/96121361-a6ea8e00-0ef8-11eb-9ce5-796a022c250f.png">
