### PR TITLE
refactor(shadows): change the way shadows are specified in config (BREAKING). Popover, Dropdown: fix wrapperStyle property to be named correctly (BREAKING).

### DIFF
--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -25,7 +25,6 @@ try {
 const DEPENDENCIES = [
   // Install alpha version of startupjs when running the alpha of cli
   `startupjs@${STARTUPJS_VERSION}`,
-  'react-native-web@^0.14.3',
   'react-native-svg@^12.1.0',
   'nconf@^0.10.0',
   'react',

--- a/packages/startupjs/package.json
+++ b/packages/startupjs/package.json
@@ -21,6 +21,7 @@
     "@startupjs/patches": "^0.25.0",
     "@startupjs/react-sharedb": "^0.25.0",
     "@startupjs/server": "^0.25.1",
-    "babel-preset-startupjs": "^0.25.1"
+    "babel-preset-startupjs": "^0.25.1",
+    "react-native-web": "^0.14.3"
   }
 }

--- a/packages/ui/components/Modal/index.styl
+++ b/packages/ui/components/Modal/index.styl
@@ -2,13 +2,6 @@ _overlayBg = $UI.colors.darkLighter
 _modalBg = $UI.colors.white
 _gutter = $UI.gutters.m
 
-// web modal open animation
-// TODO: animation not working on mount
-.layout
-  +web()
-    &.visible
-      animation ShowModal .3s forwards
-
 // layout styles
 .root
   height 100%
@@ -48,6 +41,7 @@ _gutter = $UI.gutters.m
     max-width 776px
     min-width 280px
     border-radius 4px
+    shadow(4)
 
   &.fullscreen
     height 100%
@@ -59,9 +53,3 @@ _gutter = $UI.gutters.m
   width 100%
   height 100%
   overflow hidden
-
-@keyframes ShowModal
-  0%
-    opacity 0
-  100%
-    opacity 1

--- a/packages/ui/components/Modal/layout.js
+++ b/packages/ui/components/Modal/layout.js
@@ -4,9 +4,7 @@ import { View, TouchableOpacity } from 'react-native'
 import ModalHeader from './ModalHeader'
 import ModalContent from './ModalContent'
 import ModalActions from './ModalActions'
-import STYLES from './index.styl'
-
-const { shadows } = STYLES
+import './index.styl'
 
 function Modal ({
   style,
@@ -88,7 +86,7 @@ function Modal ({
           onPress=onBackdropPress || onDismiss
         )
       ModalElement.modal(
-        style=[isWindowLayout ? shadows[4] : {}, modalStyle]
+        style=modalStyle
         styleName=[variant]
       )
         = header

--- a/packages/ui/components/Modal/modal.web.js
+++ b/packages/ui/components/Modal/modal.web.js
@@ -31,8 +31,7 @@ export default function Modal ({
 
   return ReactDOM.createPortal(
     pug`
-      Layout.layout(
-        styleName={visible}
+      Layout(
         modalStyle=style
         ...props
       )

--- a/packages/ui/components/popups/Dropdown/index.js
+++ b/packages/ui/components/popups/Dropdown/index.js
@@ -12,18 +12,10 @@ import Drawer from '../Drawer'
 import Popover from '../Popover'
 import DropdownCaption from './Caption'
 import DropdownItem from './Item'
-import { u, observer } from 'startupjs'
-import STYLES from './index.styl'
-
-const { shadows } = STYLES
+import { observer } from 'startupjs'
+import './index.styl'
 
 const { UIManager } = NativeModules
-
-// DEPERCATED: move _popoverStyleWrapper to styleName
-const DEFAULT_STYLE_WRAPPER = {
-  borderRadius: u(0.5),
-  ...shadows[2]
-}
 
 function Dropdown ({
   drawerListTitle,
@@ -32,7 +24,7 @@ function Dropdown ({
   popoverWidth,
   popoverHeight,
   popoverMaxHeight,
-  popoverStyleWrapper,
+  popoverWrapperStyle,
   styleActiveItem,
   activeValue,
   onChange,
@@ -108,11 +100,6 @@ function Dropdown ({
     })
   }
 
-  const _popoverStyleWrapper = {
-    ...DEFAULT_STYLE_WRAPPER,
-    ...popoverStyleWrapper
-  }
-
   if (!caption) {
     caption = <DropdownCaption _activeLabel={activeLabel} />
   } else {
@@ -129,7 +116,8 @@ function Dropdown ({
         height=popoverHeight
         width=popoverWidth
         hasWidthCaption=!popoverWidth
-        styleWrapper=_popoverStyleWrapper
+        wrapperStyle=popoverWrapperStyle
+        wrapperStyleName='popoverWrapper'
       )
         if caption
           Popover.Caption
@@ -167,8 +155,7 @@ Dropdown.defaultProps = {
   drawerVariant: 'buttons',
   drawerListTitle: '',
   activeValue: '',
-  hasMobileDrawer: true,
-  popoverStyleWrapper: {}
+  hasMobileDrawer: true
 }
 
 Dropdown.propTypes = {

--- a/packages/ui/components/popups/Dropdown/index.styl
+++ b/packages/ui/components/popups/Dropdown/index.styl
@@ -38,5 +38,6 @@
     border-radius 1u
     background-color $UI.colors.white
 
-:export
-  shadows: $UI.shadows
+.popoverWrapper
+  border-radius 0.5u
+  shadow(2)

--- a/packages/ui/components/popups/Popover/Popover.en.mdx
+++ b/packages/ui/components/popups/Popover/Popover.en.mdx
@@ -43,7 +43,7 @@ return (
 ## Dimensions
 - maxHeight: maximum possible height Popover
 ```jsx example
-const [visible, setVisible] = useState('')
+const [visible, setVisible] = useState()
 const [content, setContent] = useState([1,2])
 return (
   <Popover
@@ -55,8 +55,8 @@ return (
       <Button onPress={()=> setVisible(true)}>Open</Button>
     </Popover.Caption>
     <ScrollView>
-      {content.map(item=>(
-        <View style={{ padding: 20 }}>
+      {content.map(item => (
+        <View key={item} style={{ padding: 20 }}>
           <Text>Content {item}</Text>
         </View>
       ))}
@@ -76,7 +76,7 @@ return (
 
 - height: fixed, constant height
 ```jsx example
-const [visible, setVisible] = useState('')
+const [visible, setVisible] = useState()
 const [content, setContent] = useState([1,2])
 return (
   <Popover
@@ -88,8 +88,8 @@ return (
       <Button onPress={()=> setVisible(true)}>Open</Button>
     </Popover.Caption>
     <ScrollView>
-      {content.map(item=>(
-        <View style={{ padding: 20 }}>
+      {content.map(item => (
+        <View key={item} style={{ padding: 20 }}>
           <Text>Content {item}</Text>
         </View>
       ))}
@@ -109,7 +109,7 @@ return (
 
 - width: fixed, constant width (default 200px)
 ```jsx example
-const [visible, setVisible] = useState('')
+const [visible, setVisible] = useState()
 const [content, setContent] = useState([1,2])
 return (
   <Popover
@@ -129,7 +129,7 @@ return (
 
 - hasWidthCaption: set the width by Caption (boolean)
 ```jsx example
-const [visible, setVisible] = useState('')
+const [visible, setVisible] = useState()
 const [content, setContent] = useState([1,2])
 return (
   <Popover
@@ -149,7 +149,7 @@ return (
 
 If maxHeight and height are not set, the height is adjusted to the content
 ```jsx example
-const [visible, setVisible] = useState('')
+const [visible, setVisible] = useState()
 const [content, setContent] = useState([1,2,3])
 return (
   <Popover
@@ -160,8 +160,8 @@ return (
       <Button onPress={()=> setVisible(true)}>Открыть</Button>
     </Popover.Caption>
     <ScrollView>
-      {content.map(item=>(
-        <View style={{ padding: 20 }}>
+      {content.map(item => (
+        <View key={item} style={{ padding: 20 }}>
           <Text>Content {item}</Text>
         </View>
       ))}
@@ -184,13 +184,13 @@ You can set vertical (top, center, bottom) and horizontal (left, center, right) 
 - positionHorizontal: prop is responsible for displaying horizontally
 - positionVertical: prop is responsible for displaying vertically
 ```jsx example
-const [visible, setVisible] = useState('')
+const [visible, setVisible] = useState()
 return (
   <Row style={{ flexWrap: 'wrap' }}>
     <View style={{ marginBottom: 16 }}>
       <Popover
         visible={visible === 'bottom-right'}
-        onDismiss={()=> setVisible('')}
+        onDismiss={()=> setVisible(null)}
       >
         <Popover.Caption style={{ width: 150, marginRight: 16 }}>
           <Button onPress={()=> setVisible('bottom-right')}>
@@ -206,7 +206,7 @@ return (
       <Popover
         visible={visible === 'bottom-center'}
         positionHorizontal="center"
-        onDismiss={()=> setVisible('')}
+        onDismiss={()=> setVisible(null)}
       >
         <Popover.Caption style={{ width: 150, marginRight: 16 }}>
           <Button onPress={()=> setVisible('bottom-center')}>
@@ -222,7 +222,7 @@ return (
       <Popover
         visible={visible === 'bottom-left'}
         positionHorizontal="left"
-        onDismiss={()=> setVisible('')}
+        onDismiss={()=> setVisible(null)}
       >
         <Popover.Caption style={{ width: 150, marginRight: 16 }}>
           <Button onPress={()=> setVisible('bottom-left')}>
@@ -239,7 +239,7 @@ return (
         visible={visible === 'center-right'}
         positionHorizontal="right"
         positionVertical="center"
-        onDismiss={()=> setVisible('')}
+        onDismiss={()=> setVisible(null)}
       >
         <Popover.Caption style={{ width: 150, marginRight: 16 }}>
           <Button onPress={()=> setVisible('center-right')}>
@@ -256,7 +256,7 @@ return (
         visible={visible === 'center-center'}
         positionHorizontal="center"
         positionVertical="center"
-        onDismiss={()=> setVisible('')}
+        onDismiss={()=> setVisible(null)}
       >
         <Popover.Caption style={{ width: 150, marginRight: 16 }}>
           <Button onPress={()=> setVisible('center-center')}>
@@ -273,7 +273,7 @@ return (
         visible={visible === 'center-left'}
         positionHorizontal="left"
         positionVertical="center"
-        onDismiss={()=> setVisible('')}
+        onDismiss={()=> setVisible(null)}
       >
         <Popover.Caption style={{ width: 150, marginRight: 16 }}>
           <Button onPress={()=> setVisible('center-left')}>
@@ -290,7 +290,7 @@ return (
         visible={visible === 'top-right'}
         positionHorizontal="right"
         positionVertical="top"
-        onDismiss={()=> setVisible('')}
+        onDismiss={()=> setVisible(null)}
       >
         <Popover.Caption style={{ width: 150, marginRight: 16 }}>
           <Button onPress={()=> setVisible('top-right')}>
@@ -307,7 +307,7 @@ return (
         visible={visible === 'top-center'}
         positionHorizontal="center"
         positionVertical="top"
-        onDismiss={()=> setVisible('')}
+        onDismiss={()=> setVisible(null)}
       >
         <Popover.Caption style={{ width: 150, marginRight: 16 }}>
           <Button onPress={()=> setVisible('top-center')}>
@@ -324,7 +324,7 @@ return (
         visible={visible === 'top-left'}
         positionHorizontal="left"
         positionVertical="top"
-        onDismiss={()=> setVisible('')}
+        onDismiss={()=> setVisible(null)}
       >
         <Popover.Caption style={{ width: 150, marginRight: 16 }}>
           <Button onPress={()=> setVisible('top-left')}>
@@ -344,13 +344,13 @@ return (
 animateType - prop responsible for the animation type
 There are three types of animation when opening: default, slide, scale
 ```jsx example
-const [visible, setVisible] = useState('')
+const [visible, setVisible] = useState()
 return (
   <Row>
     <View>
       <Popover
         visible={visible === 'default'}
-        onDismiss={()=> setVisible('')}
+        onDismiss={()=> setVisible(null)}
       >
         <Popover.Caption style={{ width: 150, marginRight: 16 }}>
           <Button onPress={()=> setVisible('default')}>
@@ -367,7 +367,7 @@ return (
         visible={visible === 'slide'}
         animateType='slide'
         positionHorizontal='center'
-        onDismiss={()=> setVisible('')}
+        onDismiss={()=> setVisible(null)}
       >
         <Popover.Caption style={{ width: 150, marginRight: 16 }}>
           <Button onPress={()=> setVisible('slide')}>
@@ -384,7 +384,7 @@ return (
         visible={visible === 'scale'}
         animateType='scale'
         hasWidthCaption={false}
-        onDismiss={()=> setVisible('')}
+        onDismiss={()=> setVisible(null)}
       >
         <Popover.Caption style={{ width: 150, marginRight: 16 }}>
           <Button onPress={()=> setVisible('scale')}>
@@ -403,13 +403,13 @@ return (
 ## Styling
 - hasArrow: use arrow (default false)
 ```jsx example
-const [visible, setVisible] = useState('')
+const [visible, setVisible] = useState()
 return (
   <View>
     <Popover
       visible={visible}
       hasArrow={true}
-      onDismiss={()=> setVisible('')}
+      onDismiss={()=> setVisible(null)}
     >
       <Popover.Caption style={{ width: 150, marginRight: 16 }}>
         <Button onPress={()=> setVisible('default')}>
@@ -424,14 +424,14 @@ return (
 )
 ```
 
-- styleWrapper: styles for wrapper
+- wrapperStyle: styles for wrapper
 ```jsx example
-const [visible, setVisible] = useState('')
+const [visible, setVisible] = useState()
 return (
   <View>
     <Popover
       visible={visible}
-      styleWrapper={{ backgroundColor: 'black' }}
+      wrapperStyle={{ backgroundColor: 'black' }}
       onDismiss={()=> setVisible(false)}
     >
       <Popover.Caption style={{ width: 150, marginRight: 16 }}>
@@ -449,7 +449,7 @@ return (
 
 - styleOverlay: styles for overlay
 ```jsx example
-const [visible, setVisible] = useState('')
+const [visible, setVisible] = useState()
 return (
   <View>
     <Popover

--- a/packages/ui/components/popups/Popover/Popover.ru.mdx
+++ b/packages/ui/components/popups/Popover/Popover.ru.mdx
@@ -190,7 +190,7 @@ return (
     <View style={{ marginBottom: 16 }}>
       <Popover
         visible={visible === 'bottom-right'}
-        onDismiss={()=> setVisible('')}
+        onDismiss={()=> setVisible(null)}
       >
         <Popover.Caption style={{ width: 150, marginRight: 16 }}>
           <Button onPress={()=> setVisible('bottom-right')}>
@@ -206,7 +206,7 @@ return (
       <Popover
         visible={visible === 'bottom-center'}
         positionHorizontal="center"
-        onDismiss={()=> setVisible('')}
+        onDismiss={()=> setVisible(null)}
       >
         <Popover.Caption style={{ width: 150, marginRight: 16 }}>
           <Button onPress={()=> setVisible('bottom-center')}>
@@ -222,7 +222,7 @@ return (
       <Popover
         visible={visible === 'bottom-left'}
         positionHorizontal="left"
-        onDismiss={()=> setVisible('')}
+        onDismiss={()=> setVisible(null)}
       >
         <Popover.Caption style={{ width: 150, marginRight: 16 }}>
           <Button onPress={()=> setVisible('bottom-left')}>
@@ -239,7 +239,7 @@ return (
         visible={visible === 'center-right'}
         positionHorizontal="right"
         positionVertical="center"
-        onDismiss={()=> setVisible('')}
+        onDismiss={()=> setVisible(null)}
       >
         <Popover.Caption style={{ width: 150, marginRight: 16 }}>
           <Button onPress={()=> setVisible('center-right')}>
@@ -256,7 +256,7 @@ return (
         visible={visible === 'center-center'}
         positionHorizontal="center"
         positionVertical="center"
-        onDismiss={()=> setVisible('')}
+        onDismiss={()=> setVisible(null)}
       >
         <Popover.Caption style={{ width: 150, marginRight: 16 }}>
           <Button onPress={()=> setVisible('center-center')}>
@@ -273,7 +273,7 @@ return (
         visible={visible === 'center-left'}
         positionHorizontal="left"
         positionVertical="center"
-        onDismiss={()=> setVisible('')}
+        onDismiss={()=> setVisible(null)}
       >
         <Popover.Caption style={{ width: 150, marginRight: 16 }}>
           <Button onPress={()=> setVisible('center-left')}>
@@ -290,7 +290,7 @@ return (
         visible={visible === 'top-right'}
         positionHorizontal="right"
         positionVertical="top"
-        onDismiss={()=> setVisible('')}
+        onDismiss={()=> setVisible(null)}
       >
         <Popover.Caption style={{ width: 150, marginRight: 16 }}>
           <Button onPress={()=> setVisible('top-right')}>
@@ -307,7 +307,7 @@ return (
         visible={visible === 'top-center'}
         positionHorizontal="center"
         positionVertical="top"
-        onDismiss={()=> setVisible('')}
+        onDismiss={()=> setVisible(null)}
       >
         <Popover.Caption style={{ width: 150, marginRight: 16 }}>
           <Button onPress={()=> setVisible('top-center')}>
@@ -324,7 +324,7 @@ return (
         visible={visible === 'top-left'}
         positionHorizontal="left"
         positionVertical="top"
-        onDismiss={()=> setVisible('')}
+        onDismiss={()=> setVisible(null)}
       >
         <Popover.Caption style={{ width: 150, marginRight: 16 }}>
           <Button onPress={()=> setVisible('top-left')}>
@@ -344,13 +344,13 @@ return (
 animateType - проп отвечающий за тип анимации
 Есть три типа анимации при открытии: default, slide, scale
 ```jsx example
-const [visible, setVisible] = useState('')
+const [visible, setVisible] = useState()
 return (
   <Row>
     <View>
       <Popover
         visible={visible === 'default'}
-        onDismiss={()=> setVisible('')}
+        onDismiss={()=> setVisible(null)}
       >
         <Popover.Caption style={{ width: 150, marginRight: 16 }}>
           <Button onPress={()=> setVisible('default')}>
@@ -367,7 +367,7 @@ return (
         visible={visible === 'slide'}
         animateType='slide'
         positionHorizontal='center'
-        onDismiss={()=> setVisible('')}
+        onDismiss={()=> setVisible(null)}
       >
         <Popover.Caption style={{ width: 150, marginRight: 16 }}>
           <Button onPress={()=> setVisible('slide')}>
@@ -384,7 +384,7 @@ return (
         visible={visible === 'scale'}
         animateType='scale'
         hasWidthCaption={false}
-        onDismiss={()=> setVisible('')}
+        onDismiss={()=> setVisible(null)}
       >
         <Popover.Caption style={{ width: 150, marginRight: 16 }}>
           <Button onPress={()=> setVisible('scale')}>
@@ -424,14 +424,14 @@ return (
 )
 ```
 
-- styleWrapper: стили для wrapper
+- wrapperStyle: стили для wrapper
 ```jsx example
 const [visible, setVisible] = useState(false)
 return (
   <View>
     <Popover
       visible={visible}
-      styleWrapper={{ backgroundColor: 'black' }}
+      wrapperStyle={{ backgroundColor: 'black' }}
       onDismiss={()=> setVisible(false)}
     >
       <Popover.Caption style={{ width: 150, marginRight: 16 }}>

--- a/packages/ui/components/popups/Popover/index.js
+++ b/packages/ui/components/popups/Popover/index.js
@@ -1,3 +1,9 @@
+// TODO:
+// - Remove .getNode(), it's not longer needed on RN 0.62+ and gonna be removed.
+//   (ref: https://reactnative.dev/blog/2020/03/26/version-0.62#deprecations)
+//   This requires a breaking change asking people to upgrade their projects
+//   to RN 0.62+
+
 import React, { useState, useEffect, useLayoutEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import {
@@ -103,13 +109,13 @@ function Popover ({
   }, [children])
 
   const showInit = () => {
-    if (!refContent.current) {
+    if (!refContent.current || !refContent.current.getNode || !refContent.current.getNode()) {
       return
     }
 
     setIsRender(true)
     setTimeout(() => {
-      refContent.current.measure((ex, ey, refWidth, refHeight, cx, cy) => {
+      refContent.current.getNode().measure((ex, ey, refWidth, refHeight, cx, cy) => {
         let curHeight = height || refHeight
         curHeight = (curHeight > maxHeight) ? maxHeight : curHeight
 
@@ -159,11 +165,11 @@ function Popover ({
   }
 
   const hideInit = () => {
-    if (!refContent.current) {
+    if (!refContent.current || !refContent.current.getNode || !refContent.current.getNode()) {
       return
     }
 
-    refContent.current.measure((ex, ey, refWidth, refHeight, cx, cy) => {
+    refContent.current.getNode().measure((ex, ey, refWidth, refHeight, cx, cy) => {
       animateHeight.setValue(refHeight)
       setIsAfterAnimate(false)
       hide()

--- a/packages/ui/components/popups/Popover/index.js
+++ b/packages/ui/components/popups/Popover/index.js
@@ -10,9 +10,7 @@ import {
 } from 'react-native'
 import { observer } from 'startupjs'
 import Modal from '../../Modal'
-import STYLES from './index.styl'
-
-const { shadows } = STYLES
+import './index.styl'
 
 const SHTAMP_RENDER_STYLE = {
   overflow: 'hidden',
@@ -40,7 +38,7 @@ function Popover ({
   width,
   onDismiss,
   onRequestOpen,
-  styleWrapper,
+  wrapperStyle,
   styleOverlay,
   backdropStyle,
   children
@@ -105,13 +103,13 @@ function Popover ({
   }, [children])
 
   const showInit = () => {
-    if (!refContent.current || !refContent.current.getNode || !refContent.current.getNode()) {
+    if (!refContent.current) {
       return
     }
 
     setIsRender(true)
     setTimeout(() => {
-      refContent.current.getNode().measure((ex, ey, refWidth, refHeight, cx, cy) => {
+      refContent.current.measure((ex, ey, refWidth, refHeight, cx, cy) => {
         let curHeight = height || refHeight
         curHeight = (curHeight > maxHeight) ? maxHeight : curHeight
 
@@ -161,11 +159,11 @@ function Popover ({
   }
 
   const hideInit = () => {
-    if (!refContent.current || !refContent.current.getNode || !refContent.current.getNode()) {
+    if (!refContent.current) {
       return
     }
 
-    refContent.current.getNode().measure((ex, ey, refWidth, refHeight, cx, cy) => {
+    refContent.current.measure((ex, ey, refWidth, refHeight, cx, cy) => {
       animateHeight.setValue(refHeight)
       setIsAfterAnimate(false)
       hide()
@@ -295,28 +293,25 @@ function Popover ({
   }
 
   const Wrapper = coords === null ? View : Modal
-  const _styleWrapper = coords === null ? {
+  const _wrapperStyle = coords === null ? {
     position: 'absolute',
     opacity: 0,
     left: 0,
     top: 0,
-    width,
-    ...styleWrapper
+    width
   } : {
     left: getLeftPosition(),
     top: animateTop,
     opacity: animateOpacity,
-    width: animateWidth,
-    ...shadows[3],
-    ...styleWrapper
+    width: animateWidth
   }
 
-  if (hasWidthCaption) _styleWrapper.width = captionSize.width
-  if ((!isAfterAnimate && coords) || height) _styleWrapper.height = animateHeight
-  else if (maxHeight) _styleWrapper.maxHeight = maxHeight
-  else if (!height) _styleWrapper.height = 'auto'
+  if (hasWidthCaption) _wrapperStyle.width = captionSize.width
+  if ((!isAfterAnimate && coords) || height) _wrapperStyle.height = animateHeight
+  else if (maxHeight) _wrapperStyle.maxHeight = maxHeight
+  else if (!height) _wrapperStyle.height = 'auto'
 
-  if (!isRender) _styleWrapper.height = 0
+  if (!isRender) _wrapperStyle.height = 0
   const _styleOverlay = { ...styleOverlay, opacity: animateOpacityOverlay }
 
   return pug`
@@ -367,7 +362,7 @@ function Popover ({
           Animated.View.popover(
             pointerEvents='box-none'
             ref=refContent
-            style=_styleWrapper
+            style=[_wrapperStyle, wrapperStyle]
           )= renderContent
   `
 }
@@ -383,7 +378,7 @@ Popover.defaultProps = {
 }
 
 Popover.propTypes = {
-  visible: PropTypes.bool.isRequired,
+  visible: PropTypes.bool,
   onDismiss: PropTypes.func,
   positionHorizontal: PropTypes.oneOf(['left', 'center', 'right']),
   positionVertical: PropTypes.oneOf(['bottom', 'center', 'top']),

--- a/packages/ui/components/popups/Popover/index.styl
+++ b/packages/ui/components/popups/Popover/index.styl
@@ -32,6 +32,3 @@
 
 .arrowCenterRight
   border-right-color $UI.colors.white
-
-:export
-  shadows: $UI.shadows

--- a/packages/ui/styles/shadows.styl
+++ b/packages/ui/styles/shadows.styl
@@ -1,58 +1,30 @@
 $UI.shadows = merge({
-  '0': {},
+  '0': {
+    box-shadow: none
+    elevation: 0
+  },
   '1': {
-    shadowColor: '#000',
-    shadowOffset: {
-      width: 0,
-      height: 1
-    },
-    shadowOpacity: 0.2,
-    shadowRadius: 2.22,
-
+    box-shadow: 0 1px 2px rgba(black, 0.2)
     elevation: 3
   },
   '2': {
-    shadowColor: '#000',
-    shadowOffset: {
-      width: 0,
-      height: 3
-    },
-    shadowOpacity: 0.15,
-    shadowRadius: 4.65,
-
+    box-shadow: 0 3px 5px rgba(black, 0.15)
     elevation: 6
   },
   '3': {
-    shadowColor: '#000',
-    shadowOffset: {
-      width: 0,
-      height: 5
-    },
-    shadowOpacity: 0.15,
-    shadowRadius: 8.27,
-
+    box-shadow: 0 5px 8px rgba(black, 0.15)
     elevation: 12
   },
   '4': {
-    shadowColor: '#000',
-    shadowOffset: {
-      width: 0,
-      height: 8
-    },
-    shadowOpacity: 0.2,
-    shadowRadius: 12,
-
+    box-shadow: 0 8px 12px rgba(black, 0.2)
     elevation: 18
   }
 }, $UI.shadows, true)
 
-shadow(level=1)
-  _shadow = $UI.shadows[''+level]
+shadow(level = 1)
+  _shadow = $UI.shadows['' + level]
   if (_shadow) {
-    box-shadow: unit($UI.shadows[''+level].shadowOffset.width, px) unit($UI.shadows[''+level].shadowOffset.height, px) unit($UI.shadows[''+level].shadowRadius, px) rgba(convert($UI.shadows[''+level].shadowColor), $UI.shadows[''+level].shadowOpacity)
-    elevation: $UI.shadows[''+level].elevation
-  }
-  else {
-    box-shadow none
-    elevation 0
+    {_shadow}
+  } else {
+    error('ERROR! Wrong shadow level ' + level + ' passed to shadow() mixin. Such level does not exist in $UI.shadows')
   }

--- a/styleguide/package.json
+++ b/styleguide/package.json
@@ -36,7 +36,6 @@
     "react-native-code-push": "^5.7.0",
     "react-native-collapsible": "1.5.2",
     "react-native-svg": "^12.1.0",
-    "react-native-web": "0.14.3",
     "startupjs": "^0.25.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16600,10 +16600,10 @@ react-native-svg@^12.1.0:
     css-select "^2.1.0"
     css-tree "^1.0.0-alpha.39"
 
-react-native-web@0.14.3:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/react-native-web/-/react-native-web-0.14.3.tgz#a52fdd13583546517849954d497ba38ddc2e2e3f"
-  integrity sha512-On3cPbVhNgHtMK+f/V6mVE1EJUc6m9hl0sBmaWT9I3PXdrZD0n7GY5SYZFVsJw6kKW8Ge89+q8LJPXRYkI3hWw==
+react-native-web@^0.14.3:
+  version "0.14.4"
+  resolved "https://registry.yarnpkg.com/react-native-web/-/react-native-web-0.14.4.tgz#b26abe160dd77239907761da033424944aead9a9"
+  integrity sha512-xbsFK/BOR9VEwep/LeFi8V8BgbWvlJRrEIAnEgCxU95+sCR3Hty9dH/JSGeclMqlwBLW3WlEBRGtUAl6ybTcjA==
   dependencies:
     array-find-index "^1.0.2"
     create-react-class "^15.6.2"


### PR DESCRIPTION
## BREAKING CHANGES

### `$UI.shadows`
- Format of specifying shadows has changed. Instead of RN-type of shadows configuration, it now uses CSS shadows:

    ```styl
    // BEFORE:
    '1': {
      shadowColor: '#000',
      shadowOffset: {
        width: 0,
        height: 1
      },
      shadowOpacity: 0.2,
      shadowRadius: 2.22,
      elevation: 3
    }

    // AFTER:
    '1': {
      box-shadow: 0 1px 2px rgba(black, 0.2)
      elevation: 3
    },
    ```

    If you did override default UI configuration for shadows (`$UI.shadows` variable), you'll have to update it to new format.

### Popover

- rename prop `styleWrapper` to `wrapperStyle`

### Dropdown

- rename prop `popoverStyleWrapper` to `popoverWrapperStyle`

### `react-native-web`

- `react-native-web` version is now managed internally by `startupjs` package itself. Remove `react-native-web` from `package.json` of your project.