### PR TITLE
doc(Tabs): fix error

### DIFF
--- a/packages/ui/components/Tabs/Tabs.en.mdx
+++ b/packages/ui/components/Tabs/Tabs.en.mdx
@@ -2,7 +2,6 @@ import Tabs from '../Tabs'
 import Div from '../Div'
 import ExampleTab from './tabExample/'
 import { Sandbox } from '@startupjs/docs'
-import { useState, useEffect } from 'react'
 import { useValue } from 'startupjs'
 
 # Tabs

--- a/packages/ui/components/Tabs/Tabs.ru.mdx
+++ b/packages/ui/components/Tabs/Tabs.ru.mdx
@@ -2,6 +2,7 @@ import Tabs from '../Tabs'
 import Div from '../Div'
 import ExampleTab from './tabExample/'
 import { Sandbox } from '@startupjs/docs'
+import { useValue } from 'startupjs'
 
 # Tabs (табы)
 


### PR DESCRIPTION
On the tabs Russian documentation page, the page crashed with an error