### PR TITLE
readme(react-sharedb-hooks): fix undefined reference in example code

### DIFF
--- a/packages/react-sharedb-hooks/README.md
+++ b/packages/react-sharedb-hooks/README.md
@@ -395,7 +395,7 @@ export default observer(function Game ({gameId}) {
     <div>
       <label>
         Secret:
-        <input type='text' value={code} onChange={updateSecret} />
+        <input type='text' value={secret} onChange={updateSecret} />
       </label>
 
       <label>


### PR DESCRIPTION
Use `secret` instead of undefined `code` in example code.