### PR TITLE
fix(PasswordInput): remove secureTextEntry property

### DIFF
--- a/docs/migration-guides/0.34.md
+++ b/docs/migration-guides/0.34.md
@@ -1,0 +1,6 @@
+# Upgrade 0.33 to 0.34
+
+Change `startupjs` and all `@startupjs/*` dependencies in your `package.json` to `^0.34`.
+
+## BREAKING CHANGES
+- **PasswordInput**: remove property `secureTextEntry`.

--- a/docs/migration-guides/index.js
+++ b/docs/migration-guides/index.js
@@ -1,3 +1,4 @@
+export { default as _0_34 } from './0.34.md'
 export { default as _0_33 } from './0.33.md'
 export { default as _0_32 } from './0.32.md'
 export { default as _0_31 } from './0.31.md'

--- a/packages/ui/components/forms/PasswordInput/PasswordInput.en.mdx
+++ b/packages/ui/components/forms/PasswordInput/PasswordInput.en.mdx
@@ -1,4 +1,4 @@
-import { useValue } from 'startupjs'
+import { useState } from 'react'
 import Br from '../../Br'
 import PasswordInput from '../PasswordInput'
 import TextInput from '../TextInput'
@@ -16,12 +16,9 @@ import { PasswordInput } from from '@startupjs/ui'
 
 PasswordInput inherits the properties of the [TextInput](/docs/forms/TextInput).
 
-`SecureTextEntry` property with a value of `false` opens the input text by default.
-
 ```jsx example
-const [nickname, $nickname] = useValue('')
-const [password, $password] = useValue('')
-const [passwordRepeat, $passwordRepeat] = useValue('')
+const [nickname, setNickname] = useState('')
+const [password, setPassword] = useState('')
 
 return (
   <>
@@ -29,20 +26,13 @@ return (
       label='Nickname'
       autoCompleteType='username'
       value={nickname}
-      onChangeText={text => $nickname.set(text)}
+      onChangeText={setNickname}
     />
     <Br />
     <PasswordInput
-      label='Hidden password'
+      label='Password'
       value={password}
-      onChangeText={text => $password.set(text)}
-    />
-    <Br />
-    <PasswordInput
-      label='Opened password'
-      secureTextEntry={false}
-      value={passwordRepeat}
-      onChangeText={text => $passwordRepeat.set(text)}
+      onChangeText={setPassword}
     />
   </>
 )

--- a/packages/ui/components/forms/PasswordInput/PasswordInput.en.mdx
+++ b/packages/ui/components/forms/PasswordInput/PasswordInput.en.mdx
@@ -1,0 +1,53 @@
+import { useValue } from 'startupjs'
+import Br from '../../Br'
+import PasswordInput from '../PasswordInput'
+import TextInput from '../TextInput'
+import { Sandbox } from '@startupjs/docs'
+
+# PasswordInput
+
+PasswordInput provides a text field for entering a password with a button to hide the entered text.
+
+```jsx
+import { PasswordInput } from from '@startupjs/ui'
+```
+
+## Example
+
+PasswordInput inherits the properties of the [TextInput](/docs/forms/TextInput).
+
+`SecureTextEntry` property with a value of `false` opens the input text by default.
+
+```jsx example
+const [nickname, $nickname] = useValue('')
+const [password, $password] = useValue('')
+const [passwordRepeat, $passwordRepeat] = useValue('')
+
+return (
+  <>
+    <TextInput
+      label='Nickname'
+      autoCompleteType='username'
+      value={nickname}
+      onChangeText={text => $nickname.set(text)}
+    />
+    <Br />
+    <PasswordInput
+      label='Hidden password'
+      value={password}
+      onChangeText={text => $password.set(text)}
+    />
+    <Br />
+    <PasswordInput
+      label='Opened password'
+      secureTextEntry={false}
+      value={passwordRepeat}
+      onChangeText={text => $passwordRepeat.set(text)}
+    />
+  </>
+)
+```
+
+## Sandbox
+
+<Sandbox Component={PasswordInput} />

--- a/packages/ui/components/forms/PasswordInput/PasswordInput.ru.mdx
+++ b/packages/ui/components/forms/PasswordInput/PasswordInput.ru.mdx
@@ -1,0 +1,48 @@
+import { useValue } from 'startupjs'
+import Br from '../../Br'
+import PasswordInput from '../PasswordInput'
+import TextInput from '../TextInput'
+
+# PasswordInput
+
+PasswordInput предоставляет текстовое поле для ввода пароля c кнопкой скрытия вводимого текста.
+
+```jsx
+import { PasswordInput } from from '@startupjs/ui'
+```
+
+## Пример
+
+PasswordInput наследует свойства компонента [TextInput](/docs/components/TextInput).
+
+Свойство `secureTextEntry` со значением `false` открывает вводимый текст по умолчанию.
+
+```jsx example
+const [nickname, $nickname] = useValue('')
+const [password, $password] = useValue('')
+const [passwordRepeat, $passwordRepeat] = useValue('')
+
+return (
+  <>
+    <TextInput
+      label='Nickname'
+      autoCompleteType='username'
+      value={nickname}
+      onChangeText={text => $nickname.set(text)}
+    />
+    <Br />
+    <PasswordInput
+      label='Hidden password'
+      value={password}
+      onChangeText={text => $password.set(text)}
+    />
+    <Br />
+    <PasswordInput
+      label='Opened password'
+      secureTextEntry={false}
+      value={passwordRepeat}
+      onChangeText={text => $passwordRepeat.set(text)}
+    />
+  </>
+)
+```

--- a/packages/ui/components/forms/PasswordInput/PasswordInput.ru.mdx
+++ b/packages/ui/components/forms/PasswordInput/PasswordInput.ru.mdx
@@ -1,7 +1,8 @@
-import { useValue } from 'startupjs'
+import { useState } from 'react'
 import Br from '../../Br'
 import PasswordInput from '../PasswordInput'
 import TextInput from '../TextInput'
+import { Sandbox } from '@startupjs/docs'
 
 # PasswordInput
 
@@ -15,12 +16,9 @@ import { PasswordInput } from from '@startupjs/ui'
 
 PasswordInput наследует свойства компонента [TextInput](/docs/components/TextInput).
 
-Свойство `secureTextEntry` со значением `false` открывает вводимый текст по умолчанию.
-
 ```jsx example
-const [nickname, $nickname] = useValue('')
-const [password, $password] = useValue('')
-const [passwordRepeat, $passwordRepeat] = useValue('')
+const [nickname, setNickname] = useState('')
+const [password, setPassword] = useState('')
 
 return (
   <>
@@ -28,21 +26,18 @@ return (
       label='Nickname'
       autoCompleteType='username'
       value={nickname}
-      onChangeText={text => $nickname.set(text)}
+      onChangeText={setNickname}
     />
     <Br />
     <PasswordInput
-      label='Hidden password'
+      label='Password'
       value={password}
-      onChangeText={text => $password.set(text)}
-    />
-    <Br />
-    <PasswordInput
-      label='Opened password'
-      secureTextEntry={false}
-      value={passwordRepeat}
-      onChangeText={text => $passwordRepeat.set(text)}
+      onChangeText={setPassword}
     />
   </>
 )
 ```
+
+## Sandbox
+
+<Sandbox Component={PasswordInput} />

--- a/packages/ui/components/forms/PasswordInput/index.js
+++ b/packages/ui/components/forms/PasswordInput/index.js
@@ -1,20 +1,11 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { observer } from 'startupjs'
-import PropTypes from 'prop-types'
 import omit from 'lodash/omit'
 import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons'
 import TextInput from '../TextInput'
 
-function PasswordInput ({ secureTextEntry, ...props }) {
+function PasswordInput ({ ...props }) {
   const [textHidden, setTextHidden] = useState(true)
-
-  useEffect(() => {
-    // HACK: it is important for the WEB to pass by default
-    // the secureTextEntry=true property to the TextInput,
-    // because the field will not automatically accept
-    // the password stored for the domain
-    if (typeof secureTextEntry === 'boolean') setTextHidden(secureTextEntry)
-  }, [secureTextEntry])
 
   return pug`
     TextInput(
@@ -23,14 +14,19 @@ function PasswordInput ({ secureTextEntry, ...props }) {
       secureTextEntry=textHidden
       icon=textHidden ? faEye : faEyeSlash
       iconPosition='right'
+      numberOfLines=1
+      resize=false
       onIconPress=() => setTextHidden(!textHidden)
     )
   `
 }
 
+PasswordInput.defaultProps = {
+  ...TextInput.defaultProps
+}
+
 PasswordInput.propTypes = {
-  ...omit(TextInput.propTypes, ['icon', 'iconPosition', 'numberOfLines', 'resize', 'onIconPress']),
-  secureTextEntry: PropTypes.bool
+  ...omit(TextInput.propTypes, ['icon', 'iconPosition', 'numberOfLines', 'resize', 'onIconPress'])
 }
 
 export default observer(PasswordInput)

--- a/packages/ui/components/forms/PasswordInput/index.js
+++ b/packages/ui/components/forms/PasswordInput/index.js
@@ -16,17 +16,18 @@ function PasswordInput ({ ...props }) {
       iconPosition='right'
       numberOfLines=1
       resize=false
+      readonly=false
       onIconPress=() => setTextHidden(!textHidden)
     )
   `
 }
 
 PasswordInput.defaultProps = {
-  ...TextInput.defaultProps
+  ...omit(TextInput.defaultProps, ['iconPosition', 'numberOfLines', 'resize', 'readonly'])
 }
 
 PasswordInput.propTypes = {
-  ...omit(TextInput.propTypes, ['icon', 'iconPosition', 'numberOfLines', 'resize', 'onIconPress'])
+  ...omit(TextInput.propTypes, ['icon', 'iconPosition', 'numberOfLines', 'resize', 'readonly', 'onIconPress'])
 }
 
 export default observer(PasswordInput)

--- a/packages/ui/components/forms/PasswordInput/index.js
+++ b/packages/ui/components/forms/PasswordInput/index.js
@@ -1,20 +1,36 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
+import { observer } from 'startupjs'
+import PropTypes from 'prop-types'
+import omit from 'lodash/omit'
 import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons'
 import TextInput from '../TextInput'
 
-export default function PasswordInput ({
-  secureTextEntry = false,
-  ...props
-}) {
-  const [showText, setShowText] = useState(secureTextEntry)
+function PasswordInput ({ secureTextEntry, ...props }) {
+  const [textHidden, setTextHidden] = useState(true)
+
+  useEffect(() => {
+    // HACK: it is important for the WEB to pass by default
+    // the secureTextEntry=true property to the TextInput,
+    // because the field will not automatically accept
+    // the password stored for the domain
+    if (typeof secureTextEntry === 'boolean') setTextHidden(secureTextEntry)
+  }, [secureTextEntry])
 
   return pug`
     TextInput(
       ...props
-      secureTextEntry=!showText
-      icon=showText ? faEyeSlash : faEye
+      autoCompleteType='password'
+      secureTextEntry=textHidden
+      icon=textHidden ? faEye : faEyeSlash
       iconPosition='right'
-      onIconPress=() => setShowText(!showText)
+      onIconPress=() => setTextHidden(!textHidden)
     )
   `
 }
+
+PasswordInput.propTypes = {
+  ...omit(TextInput.propTypes, ['icon', 'iconPosition', 'numberOfLines', 'resize', 'onIconPress']),
+  secureTextEntry: PropTypes.bool
+}
+
+export default observer(PasswordInput)

--- a/packages/ui/docs/forms.js
+++ b/packages/ui/docs/forms.js
@@ -19,6 +19,8 @@ import MultiselectRu from '../components/forms/Multiselect/Multiselect.ru.mdx'
 import DateTimePickerEn from '../components/forms/DateTimePicker/DateTimePicker.en.mdx'
 import DateTimePickerRu from '../components/forms/DateTimePicker/DateTimePicker.ru.mdx'
 import ArrayInputEn from '../components/forms/ArrayInput/ArrayInput.en.mdx'
+import PasswordInputEn from '../components/forms/PasswordInput/PasswordInput.en.mdx'
+import PasswordInputRu from '../components/forms/PasswordInput/PasswordInput.ru.mdx'
 
 export default {
   type: 'collapse',
@@ -103,6 +105,14 @@ export default {
       component: {
         en: MultiselectEn,
         ru: MultiselectRu
+      }
+    },
+    PasswordInput: {
+      type: 'mdx',
+      title: 'PasswordInput',
+      component: {
+        en: PasswordInputEn,
+        ru: PasswordInputRu
       }
     }
   }


### PR DESCRIPTION
BREAKING CHANGE: `startupjs/ui/PasswordInput` - remove `secureTextEntry` property 