### PR TITLE
feat(Button): remove shadowed from variant property

### DIFF
--- a/docs/migration-guides/0.34.md
+++ b/docs/migration-guides/0.34.md
@@ -37,3 +37,6 @@ protected ReactActivityDelegate createReactActivityDelegate() {
 ```
 
 - you can see all changes [here](https://github.com/satya164/react-native-tab-view/releases).
+
+`startupjs/ui/Button`
+- remove `shadowed` from `variant` property

--- a/packages/ui/components/Button/index.js
+++ b/packages/ui/components/Button/index.js
@@ -84,10 +84,6 @@ function Button ({
       extraHoverStyle = { backgroundColor: colorToRGBA(_color, 0.05) }
       extraActiveStyle = { backgroundColor: colorToRGBA(_color, 0.25) }
       break
-    case 'shadowed':
-      rootStyle.backgroundColor = colors.white
-      rootExtraProps.level = 2
-      break
   }
 
   let padding
@@ -172,7 +168,7 @@ Button.propTypes = {
   textStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   color: PropTypes.oneOf(Object.keys(colors)),
   children: PropTypes.node,
-  variant: PropTypes.oneOf(['flat', 'outlined', 'text', 'shadowed']),
+  variant: PropTypes.oneOf(['flat', 'outlined', 'text']),
   size: PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl', 'xxl']),
   shape: Div.propTypes.shape,
   icon: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),


### PR DESCRIPTION
BREAKING CHANGE: startupjs/ui/Button
- remove `shadowed` from `variant` property