### PR TITLE
Refactor tag

### DIFF
--- a/docs/migration-guides/0.34.md
+++ b/docs/migration-guides/0.34.md
@@ -39,5 +39,13 @@ protected ReactActivityDelegate createReactActivityDelegate() {
 
 - you can see all changes [here](https://github.com/satya164/react-native-tab-view/releases).
 
+
+`startupjs/ui/tag`
+- inheritance of properties from the **Div** component
+- remove `iconPosition` property. For the icon on the left, use the “icon” property and “iconStyle” to style it, for the icon on the right, use the “secondaryIcon” and “secondaryIconStyle” properties, and all these properties to use two icons.
+- remove loading indication for asynchronous action
+- add `size` property.
+- add to `variant` property `outlined-bg`.
+
 `startupjs/ui/Button`
 - remove `shadowed` from `variant` property

--- a/docs/migration-guides/0.34.md
+++ b/docs/migration-guides/0.34.md
@@ -3,10 +3,11 @@
 Change `startupjs` and all `@startupjs/*` dependencies in your `package.json` to `^0.34`.
 
 ## BREAKING CHANGES
-`startupjs/ui/PasswordInput` - remove property `secureTextEntry`.
+### `startupjs/ui/PasswordInput`
+- remove property `secureTextEntry`
 
-`startupjs/ui/tabs`
-- now requires `react-native-pager-view`. Run the following 
+### `startupjs/ui/Tabs`
+- now requires `react-native-pager-view`. Run the following
 ```js
   yarn add react-native-pager-view
 ```
@@ -39,13 +40,14 @@ protected ReactActivityDelegate createReactActivityDelegate() {
 
 - you can see all changes [here](https://github.com/satya164/react-native-tab-view/releases).
 
+### `startupjs/ui/Tag`
+- remove `iconPosition` property. For the icon on the left, use the `icon` property and `iconStyle` to style it, for the icon on the right, use the `secondaryIcon` and `secondaryIconStyle` properties, and all these properties to use two icons
 
-`startupjs/ui/tag`
-- inheritance of properties from the **Div** component
-- remove `iconPosition` property. For the icon on the left, use the “icon” property and “iconStyle” to style it, for the icon on the right, use the “secondaryIcon” and “secondaryIconStyle” properties, and all these properties to use two icons.
-- remove loading indication for asynchronous action
-- add `size` property.
-- add to `variant` property `outlined-bg`.
+- no more support loading indicator for async action
 
-`startupjs/ui/Button`
+- the default component size has become larger
+
+- add `size` property
+
+### `startupjs/ui/Button`
 - remove `shadowed` from `variant` property

--- a/packages/ui/components/Badge/Badge.en.mdx
+++ b/packages/ui/components/Badge/Badge.en.mdx
@@ -1,7 +1,5 @@
 import { useState } from 'react'
 import Badge from '../Badge'
-import Tag from '../Tag'
-import Content from '../Content'
 import Div from '../Div'
 import Row from '../Row'
 import { faBan, faExclamationTriangle, faTimes, faThumbsUp } from '@fortawesome/free-solid-svg-icons'

--- a/packages/ui/components/Badge/Badge.ru.mdx
+++ b/packages/ui/components/Badge/Badge.ru.mdx
@@ -1,7 +1,5 @@
 import { useState } from 'react'
 import Badge from '../Badge'
-import Tag from '../Tag'
-import Content from '../Content'
 import Div from '../Div'
 import Row from '../Row'
 import { faBan, faExclamationTriangle, faTimes, faThumbsUp } from '@fortawesome/free-solid-svg-icons'

--- a/packages/ui/components/Tag/Tag.en.mdx
+++ b/packages/ui/components/Tag/Tag.en.mdx
@@ -1,13 +1,14 @@
 import { useState } from 'react'
-import Tag from '../Tag'
-import Div from '../Div'
-import Br from '../Br'
 import { faTimesCircle, faCoffee } from '@fortawesome/free-solid-svg-icons'
 import { Sandbox } from '@startupjs/docs'
+import Br from '../Br'
+import Row from '../Row'
+import Tag from '../Tag'
 import './index.mdx.styl'
 
 # Tag
-Inherits [Button props](/docs/components/Button).
+
+Inherits [Div props](/docs/components/Div).
 
 Tags are compact elements that represent an input, attribute, or action. They allow users to enter information, make selections, filter content, or trigger actions. While buttons are expected to appear consistently and with familiar calls to action, tags should appear dynamically as a group of multiple interactive elements.
 
@@ -29,25 +30,38 @@ Color is `primary` by default. It can be changed by passing color name from the 
 
 ```jsx example
 return (
-  <Div>
+  <Row>
     <Tag>Primary (default)</Tag>
-    <Br />
-    <Tag color='success'>Success</Tag>
-    <Br />
-    <Tag color='warning'>Warning</Tag>
-    <Br />
-    <Tag color='error'>Error</Tag>
-  </Div>
+    <Tag color='success' pushed='s'>Success</Tag>
+    <Tag color='warning' pushed='s'>Warning</Tag>
+    <Tag color='error' pushed='s'>Error</Tag>
+  </Row>
+)
+```
+
+## Размеры
+
+The `size` property applies to the size of tag, icons, and text. There are two sizes - `m` and` l` (default is `m`).
+
+```jsx example
+return (
+  <Row vAlign='center'>
+    <Tag>Size 'm' (default)</Tag>
+    <Tag size='l' pushed='s'>Size 'l'</Tag>
+  </Row>
 )
 ```
 
 ## Outlined tags
 
-Outlined tags offer an alternative style by passing `outlined` string on `variant` property to component.
+Outlined tags offer an alternative style, in property `variant` need to pass `outlined` or `outlined-bg` for an outlined tag with a background.
 
 ```jsx example
 return (
-  <Tag variant='outlined'>Outlined tag</Tag>
+  <Row>
+    <Tag variant='outlined'>Outlined tag</Tag>
+    <Tag variant='outlined-bg' pushed='s'>Outlined tag with a background</Tag>
+  </Row>
 )
 ```
 
@@ -57,35 +71,49 @@ Tags can have different corner shapes. It can be changed by changing `shape` pro
 
 ```jsx example
 return (
-  <Div>
+  <Row>
     <Tag>Circle shape</Tag>
-    <Br />
-    <Tag shape='rounded'>Rounded shape</Tag>
-  </Div>
+    <Tag shape='rounded' pushed='s'>Rounded shape</Tag>
+  </Row>
 )
 ```
 
 ## Icons
 
-Icon can be added using `icon` property. Position of icon can be changed by passing `iconPosition` to component (`left` by default). To change icon color use the `iconStyleName` property.
+Left and right icons can be added using the `icon` and `secondaryIcon` properties. To change the color of an icon, use the corresponding `iconStyleName` or `secondaryIconStyleName` property.
 
 In `.styl` file
 ```stylus
 .icon
-  color $UI.colors.primary
+  color $UI.colors.dark
+.secondaryIcon
+  color $UI.colors.error
 ```
 
 ```jsx example
 return (
-  <Div>
-    <Tag variant='outlined' icon={faCoffee} iconStyleName='icon'>
-      Icon on the left (default) with the changed color
+  <Row>
+    <Tag icon={faCoffee}>
+      Icon on the left
     </Tag>
-    <Br />
-    <Tag icon={faCoffee} iconPosition='right'>
+    <Tag
+      secondaryIcon={faCoffee}
+      variant='outlined-bg'
+      pushed='s'
+    >
       Icon on the right
     </Tag>
-  </Div>
+    <Tag
+      iconStyleName='icon'
+      secondaryIconStyleName='secondaryIcon'
+      variant='outlined'
+      icon={faCoffee}
+      secondaryIcon={faTimesCircle}
+      pushed='s'
+    >
+      Two icons
+    </Tag>
+  </Row>
 )
 ```
 

--- a/packages/ui/components/Tag/Tag.en.mdx
+++ b/packages/ui/components/Tag/Tag.en.mdx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
-import { faTimesCircle, faCoffee } from '@fortawesome/free-solid-svg-icons'
+import { faTimesCircle, faStopCircle } from '@fortawesome/free-solid-svg-icons'
 import { Sandbox } from '@startupjs/docs'
 import Br from '../Br'
+import Div from '../Div'
 import Row from '../Row'
 import Tag from '../Tag'
 import './index.mdx.styl'
@@ -20,7 +21,9 @@ import { Tag } from '@startupjs/ui'
 
 ```jsx example
 return (
-  <Tag>Tag</Tag>
+  <Row>
+    <Tag>Tag</Tag>
+  </Row>
 )
 ```
 
@@ -45,10 +48,11 @@ The `size` property applies to the size of tag, icons, and text. There are two s
 
 ```jsx example
 return (
-  <Row vAlign='center'>
+  <Div style={{ alignItems: 'flex-start' }}>
+    <Tag size='s'>Size 's'</Tag>
+    <Br />
     <Tag>Size 'm' (default)</Tag>
-    <Tag size='l' pushed='s'>Size 'l'</Tag>
-  </Row>
+  </Div>
 )
 ```
 
@@ -60,7 +64,7 @@ Outlined tags offer an alternative style, in property `variant` need to pass `ou
 return (
   <Row>
     <Tag variant='outlined'>Outlined tag</Tag>
-    <Tag variant='outlined-bg' pushed='s'>Outlined tag with a background</Tag>
+    <Tag variant='outlined-bg' pushed='s' onPress={() => {}}>Outlined tag with a background</Tag>
   </Row>
 )
 ```
@@ -93,11 +97,11 @@ In `.styl` file
 ```jsx example
 return (
   <Row>
-    <Tag icon={faCoffee}>
+    <Tag icon={faStopCircle}>
       Icon on the left
     </Tag>
     <Tag
-      secondaryIcon={faCoffee}
+      secondaryIcon={faStopCircle}
       variant='outlined-bg'
       pushed='s'
     >
@@ -107,7 +111,7 @@ return (
       iconStyleName='icon'
       secondaryIconStyleName='secondaryIcon'
       variant='outlined'
-      icon={faCoffee}
+      icon={faStopCircle}
       secondaryIcon={faTimesCircle}
       pushed='s'
     >

--- a/packages/ui/components/Tag/Tag.ru.mdx
+++ b/packages/ui/components/Tag/Tag.ru.mdx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
-import { faTimesCircle, faCoffee } from '@fortawesome/free-solid-svg-icons'
+import { faTimesCircle, faStopCircle } from '@fortawesome/free-solid-svg-icons'
 import { Sandbox } from '@startupjs/docs'
 import Br from '../Br'
+import Div from '../Div'
 import Row from '../Row'
 import Tag from '../Tag'
 import './index.mdx.styl'
@@ -20,7 +21,9 @@ import { Tag } from '@startupjs/ui'
 
 ```jsx example
 return (
-  <Tag>Тег</Tag>
+  <Row>
+    <Tag>Тег</Tag>
+  </Row>
 )
 ```
 
@@ -45,10 +48,11 @@ return (
 
 ```jsx example
 return (
-  <Row vAlign='center'>
+  <Div style={{ alignItems: 'flex-start' }}>
+    <Tag size='s'>Размер 's'</Tag>
+    <Br />
     <Tag>Размер 'm' (по умолчанию)</Tag>
-    <Tag size='l' pushed='s'>Размер 'l'</Tag>
-  </Row>
+  </Div>
 )
 ```
 
@@ -93,11 +97,11 @@ In `.styl` file
 ```jsx example
 return (
   <Row>
-    <Tag icon={faCoffee}>
+    <Tag icon={faStopCircle}>
       Иконка слева
     </Tag>
     <Tag
-      secondaryIcon={faCoffee}
+      secondaryIcon={faStopCircle}
       variant='outlined-bg'
       pushed='s'
     >
@@ -107,7 +111,7 @@ return (
       iconStyleName='icon'
       secondaryIconStyleName='secondaryIcon'
       variant='outlined'
-      icon={faCoffee}
+      icon={faStopCircle}
       secondaryIcon={faTimesCircle}
       pushed='s'
     >

--- a/packages/ui/components/Tag/Tag.ru.mdx
+++ b/packages/ui/components/Tag/Tag.ru.mdx
@@ -1,13 +1,14 @@
 import { useState } from 'react'
-import Tag from '../Tag'
-import Div from '../Div'
-import Br from '../Br'
 import { faTimesCircle, faCoffee } from '@fortawesome/free-solid-svg-icons'
 import { Sandbox } from '@startupjs/docs'
+import Br from '../Br'
+import Row from '../Row'
+import Tag from '../Tag'
 import './index.mdx.styl'
 
 # Tag (тег)
-Наследует [Button props](/docs/components/Button).
+
+Наследует [Div props](/docs/components/Div).
 
 Теги - это компактные элементы, представляющие входные данные, атрибут или действие. Они позволяют пользователям вводить информацию, делать выбор, фильтровать контент или инициировать действия. В то время как предполагается, что кнопки будут появляться с призывами к действию, теги должны появляться динамически как группа из нескольких интерактивных элементов.
 
@@ -29,25 +30,38 @@ return (
 
 ```jsx example
 return (
-  <Div>
-    <Tag>Основной (по умолчанию)</Tag>
-    <Br />
-    <Tag color='success'>Успех</Tag>
-    <Br />
-    <Tag color='warning'>Предупреждение</Tag>
-    <Br />
-    <Tag color='error'>Ошибка</Tag>
-  </Div>
+  <Row>
+    <Tag pushed='s'>Primary (default)</Tag>
+    <Tag color='success' pushed='s'>Success</Tag>
+    <Tag color='warning' pushed='s'>Warning</Tag>
+    <Tag color='error' pushed='s'>Error</Tag>
+  </Row>
+)
+```
+
+## Размеры
+
+Свойство `size` применяется к размеру тега, иконок и текста. Есть два размера - `m` и `l` (по умолчанию `m`).
+
+```jsx example
+return (
+  <Row vAlign='center'>
+    <Tag>Размер 'm' (по умолчанию)</Tag>
+    <Tag size='l' pushed='s'>Размер 'l'</Tag>
+  </Row>
 )
 ```
 
 ## Контурные теги
 
-Контурные теги предлагают альтернативный стиль, передвая `outlined` строку в свойство `variant` компонента.
+Контурные теги предлагают альтернативный стиль, в свойство `variant` нужно передать `outlined` или `outlined-bg` для контурного тега с фоном.
 
 ```jsx example
 return (
-  <Tag variant='outlined'>Контурный тег</Tag>
+  <Row>
+    <Tag variant='outlined'>Контурный тег</Tag>
+    <Tag variant='outlined-bg' pushed='s'>Контурный тег с фоном</Tag>
+  </Row>
 )
 ```
 
@@ -57,35 +71,49 @@ return (
 
 ```jsx example
 return (
-  <Div>
-    <Tag>Форма круга</Tag>
-    <Br />
-    <Tag shape='rounded'>Округлая форма</Tag>
-  </Div>
+  <Row>
+    <Tag>Круглая форма (по умолчанию)</Tag>
+    <Tag shape='rounded' pushed='s'>Закругленная форма</Tag>
+  </Row>
 )
 ```
 
 ## Иконки
 
-Иконка может быть добавлена используя `icon` свойство. Положение иконки можно изменить, передав в компонент `iconPosition` (`left` по умолчанию). Чтобы изменить цвет иконки используйте `iconStyleName` свойство.
+Иконки слева и справа могут быть добавлены с помощью свойств `icon` и `secondaryIcon`. Чтобы изменить цвет иконки, используйте соответствующее свойство `iconStyleName` или  `secondaryIconStyleName`.
 
-В `.styl` файле
+In `.styl` file
 ```stylus
 .icon
-  color $UI.colors.primary
+  color $UI.colors.dark
+.secondaryIcon
+  color $UI.colors.error
 ```
 
 ```jsx example
 return (
-  <Div>
-    <Tag variant='outlined' icon={faCoffee} iconStyleName='icon'>
-      Иконка слева (по умолчанию) с измененным цветом
+  <Row>
+    <Tag icon={faCoffee}>
+      Иконка слева
     </Tag>
-    <Br />
-    <Tag icon={faCoffee} iconPosition='right'>
+    <Tag
+      secondaryIcon={faCoffee}
+      variant='outlined-bg'
+      pushed='s'
+    >
       Иконка справа
     </Tag>
-  </Div>
+    <Tag
+      iconStyleName='icon'
+      secondaryIconStyleName='secondaryIcon'
+      variant='outlined'
+      icon={faCoffee}
+      secondaryIcon={faTimesCircle}
+      pushed='s'
+    >
+      Две иконки
+    </Tag>
+  </Row>
 )
 ```
 

--- a/packages/ui/components/Tag/index.js
+++ b/packages/ui/components/Tag/index.js
@@ -1,32 +1,132 @@
 import React from 'react'
+import { StyleSheet } from 'react-native'
 import { observer } from 'startupjs'
 import PropTypes from 'prop-types'
-import Button from '../Button'
+import { colorToRGBA } from '../../helpers'
+import Icon from '../Icon'
+import Row from '../Row'
+import Div from '../Div'
+import Span from '../typography/Span'
+import STYLES from './index.styl'
 
-const size = 'xs'
+const { colors } = STYLES
 
-function Tag (props) {
+const ICON_SIZES = {
+  m: 's',
+  l: 'm'
+}
+
+function Tag ({
+  style,
+  iconStyle,
+  secondaryIconStyle,
+  textStyle,
+  children,
+  color,
+  variant,
+  size,
+  icon,
+  secondaryIcon,
+  disabled,
+  hoverStyle,
+  activeStyle,
+  onPress,
+  ...props
+}) {
+  if (!colors[color]) console.error('Tag component: Color for color property is incorrect. Use colors from $UI.colors')
+
+  const isFlat = variant === 'flat'
+  const _color = colors[color]
+  const rootStyle = { }
+  let extraHoverStyle
+  let extraActiveStyle
+
+  textStyle = StyleSheet.flatten([
+    { color: isFlat ? colors.white : _color },
+    textStyle
+  ])
+  iconStyle = StyleSheet.flatten([
+    { color: isFlat ? colors.white : _color },
+    iconStyle
+  ])
+  secondaryIconStyle = StyleSheet.flatten([
+    { color: isFlat ? colors.white : _color },
+    secondaryIconStyle
+  ])
+
+  switch (variant) {
+    case 'flat':
+      rootStyle.backgroundColor = _color
+      break
+    case 'outlined':
+      rootStyle.borderColor = colorToRGBA(_color, 0.5)
+      extraHoverStyle = { backgroundColor: colorToRGBA(_color, 0.05) }
+      extraActiveStyle = { backgroundColor: colorToRGBA(_color, 0.25) }
+      break
+    case 'outlined-bg':
+      rootStyle.borderColor = _color
+      rootStyle.backgroundColor = colorToRGBA(_color, 0.15)
+      extraHoverStyle = { backgroundColor: colorToRGBA(_color, 0.05) }
+      extraActiveStyle = { backgroundColor: colorToRGBA(_color, 0.35) }
+      break
+  }
+
   return pug`
-    Button(
+    Row.root(
+      style=[rootStyle, style]
+      styleName=[
+        variant,
+        size,
+        { disabled }
+      ]
+      align='center'
+      vAlign='center'
+      variant='highlight'
+      hoverStyle=extraHoverStyle ? [extraHoverStyle, hoverStyle] : hoverStyle
+      activeStyle=extraActiveStyle ? [extraActiveStyle, activeStyle] : activeStyle
+      disabled=disabled
+      onPress=onPress
       ...props
-      size=size
     )
+      if icon
+        Div.iconWrapper.left
+          Icon.icon(
+            style=iconStyle
+            styleName=[variant]
+            icon=icon
+            size=ICON_SIZES[size]
+          )
+
+      if children != null
+        Span.label(
+          style=[textStyle]
+          styleName=[size]
+        )= children
+
+      if secondaryIcon
+        Div.iconWrapper.right
+          Icon.icon(
+            style=secondaryIconStyle
+            styleName=[variant]
+            icon=secondaryIcon
+            size=ICON_SIZES[size]
+          )
   `
 }
 
 Tag.defaultProps = {
-  ...Button.defaultProps,
+  ...Div.defaultProps,
   color: 'primary',
   variant: 'flat',
-  shape: 'circle',
-  size
+  size: 'm',
+  shape: 'circle'
 }
 
 Tag.propTypes = {
-  ...Button.propTypes,
-  variant: PropTypes.oneOf(['flat', 'outlined']),
+  ...Div.propTypes,
+  variant: PropTypes.oneOf(['flat', 'outlined', 'outlined-bg']),
   shape: PropTypes.oneOf(['circle', 'rounded']),
-  size: PropTypes.oneOf([size])
+  size: PropTypes.oneOf(['m', 'l'])
 }
 
 export default observer(Tag)

--- a/packages/ui/components/Tag/index.js
+++ b/packages/ui/components/Tag/index.js
@@ -4,7 +4,6 @@ import { observer } from 'startupjs'
 import PropTypes from 'prop-types'
 import { colorToRGBA } from '../../helpers'
 import Icon from '../Icon'
-import Row from '../Row'
 import Div from '../Div'
 import Span from '../typography/Span'
 import STYLES from './index.styl'
@@ -12,32 +11,37 @@ import STYLES from './index.styl'
 const { colors } = STYLES
 
 const ICON_SIZES = {
-  m: 's',
-  l: 'm'
+  s: 's',
+  m: 's'
 }
 
 function Tag ({
   style,
-  iconStyle,
-  secondaryIconStyle,
   textStyle,
   children,
   color,
   variant,
   size,
   icon,
+  iconStyle,
   secondaryIcon,
+  secondaryIconStyle,
   disabled,
   hoverStyle,
   activeStyle,
   onPress,
   ...props
 }) {
-  if (!colors[color]) console.error('Tag component: Color for color property is incorrect. Use colors from $UI.colors')
+  if (!colors[color]) {
+    console.error(
+      'Tag component: Color for color property is incorrect. ' +
+      'Use colors from $UI.colors'
+    )
+  }
 
   const isFlat = variant === 'flat'
   const _color = colors[color]
-  const rootStyle = { }
+  const rootStyle = {}
   let extraHoverStyle
   let extraActiveStyle
 
@@ -67,20 +71,18 @@ function Tag ({
       rootStyle.borderColor = _color
       rootStyle.backgroundColor = colorToRGBA(_color, 0.15)
       extraHoverStyle = { backgroundColor: colorToRGBA(_color, 0.05) }
-      extraActiveStyle = { backgroundColor: colorToRGBA(_color, 0.35) }
+      extraActiveStyle = { backgroundColor: colorToRGBA(_color, 0.25) }
       break
   }
 
   return pug`
-    Row.root(
+    Div.root(
       style=[rootStyle, style]
       styleName=[
         variant,
         size,
         { disabled }
       ]
-      align='center'
-      vAlign='center'
       variant='highlight'
       hoverStyle=extraHoverStyle ? [extraHoverStyle, hoverStyle] : hoverStyle
       activeStyle=extraActiveStyle ? [extraActiveStyle, activeStyle] : activeStyle
@@ -89,7 +91,9 @@ function Tag ({
       ...props
     )
       if icon
-        Div.iconWrapper.left
+        Div.iconWrapper.left(
+          styleName=[size]
+        )
           Icon.icon(
             style=iconStyle
             styleName=[variant]
@@ -97,6 +101,9 @@ function Tag ({
             size=ICON_SIZES[size]
           )
 
+      //- workaround when we interpolate variable into component
+      //- const value = 0
+      //- Tag= value
       if children != null
         Span.label(
           style=[textStyle]
@@ -104,10 +111,12 @@ function Tag ({
         )= children
 
       if secondaryIcon
-        Div.iconWrapper.right
+        Div.iconWrapper.right(
+          styleName=[size]
+        )
           Icon.icon(
             style=secondaryIconStyle
-            styleName=[variant]
+            styleName=[variant, size]
             icon=secondaryIcon
             size=ICON_SIZES[size]
           )
@@ -126,7 +135,7 @@ Tag.propTypes = {
   ...Div.propTypes,
   variant: PropTypes.oneOf(['flat', 'outlined', 'outlined-bg']),
   shape: PropTypes.oneOf(['circle', 'rounded']),
-  size: PropTypes.oneOf(['m', 'l'])
+  size: PropTypes.oneOf(['s', 'm'])
 }
 
 export default observer(Tag)

--- a/packages/ui/components/Tag/index.mdx.styl
+++ b/packages/ui/components/Tag/index.mdx.styl
@@ -1,2 +1,5 @@
 .icon
-  color: $UI.colors.primary
+  color: $UI.colors.dark
+
+.secondaryIcon
+  color: $UI.colors.error

--- a/packages/ui/components/Tag/index.styl
+++ b/packages/ui/components/Tag/index.styl
@@ -1,66 +1,81 @@
-_sizes = 'l' 'm'
-
 // ----- CONFIG: $UI.Tag
-$this = merge(
-  {
+
+$this = merge({
   heights: {
-    m: 2u,
-    l: 3u
+    s: 2.5u,
+    m: 3u,
   },
   paddings: {
-    m: 0.75u,
-    l: 1u
+    s: 1u,
+    m: 1.5u
   },
   fontSizes: {
-    m: 's',
-    l: 'm'
+    s: 's',
+    m: 's'
   },
-  lineHeights: {
-    m: 'xs',
-    l: 's'
+  iconMargins: {
+    inside: {
+      s: 0.75u,
+      m: 1u
+    }
+    outside: {
+      s: -0.25u,
+      m: -0.5u
+    }
   }
-  outlinedBorderWidth: 1px
+  outlinedBorderWidth: 1px,
+  disabledOpacity: 0.25
 },
   $UI.Tag,
   true
 )
 
-// ----- COMPONENT
-_disabledOpacity = 0.25
-
 .root
-  max-width 100%
+  flex-direction row
+  align-items center
+  justify-content center
+
+  for size, height in $this.heights
+    &.{size}
+      height height
+
+  for size, padding in $this.paddings
+    &.{size}
+      padding-left padding
+      padding-right padding
 
   &.disabled
-    opacity _disabledOpacity
+    opacity $this.disabledOpacity
 
   &.outlined
   &.outlined-bg
     border-width: $this.outlinedBorderWidth
 
-  for size in _sizes
-    &.{size}
-      padding-left: $this.paddings[size]
-      padding-right @padding-left
-      height: $this.heights[size]
-
-    &.outlined.{size}
-    &.outlined-bg.{size}
-      padding-left: $this.paddings[size] - $this.outlinedBorderWidth
-      padding-right @padding-left
-
 .label
-  for size in _sizes
+  font-weight 500
+
+  for size, fontSize in $this.fontSizes
     &.{size}
-      font-size: $UI.fontSizes[$this.fontSizes[size]]
-      line-height: $UI.lineHeights[$this.lineHeights[size]]
+      font(fontSize)
 
 .iconWrapper
   &.left
-    margin-right 0.5u
+    for size, margin in $this.iconMargins.inside
+      &.{size}
+        margin-right margin
+
+    for size, margin in $this.iconMargins.outside
+      &.{size}
+        margin-left margin
 
   &.right
-    margin-left 0.5u
+    for size, margin in $this.iconMargins.inside
+      &.{size}
+        margin-left margin
+
+    for size, margin in $this.iconMargins.outside
+      &.{size}
+        margin-right margin
 
 .icon
   color: $UI.colors.dark
@@ -69,5 +84,6 @@ _disabledOpacity = 0.25
     color: $UI.colors.white
 
 // ----- JS EXPORTS
+
 :export
   colors: $UI.colors

--- a/packages/ui/components/Tag/index.styl
+++ b/packages/ui/components/Tag/index.styl
@@ -1,0 +1,73 @@
+_sizes = 'l' 'm'
+
+// ----- CONFIG: $UI.Tag
+$this = merge(
+  {
+  heights: {
+    m: 2u,
+    l: 3u
+  },
+  paddings: {
+    m: 0.75u,
+    l: 1u
+  },
+  fontSizes: {
+    m: 's',
+    l: 'm'
+  },
+  lineHeights: {
+    m: 'xs',
+    l: 's'
+  }
+  outlinedBorderWidth: 1px
+},
+  $UI.Tag,
+  true
+)
+
+// ----- COMPONENT
+_disabledOpacity = 0.25
+
+.root
+  max-width 100%
+
+  &.disabled
+    opacity _disabledOpacity
+
+  &.outlined
+  &.outlined-bg
+    border-width: $this.outlinedBorderWidth
+
+  for size in _sizes
+    &.{size}
+      padding-left: $this.paddings[size]
+      padding-right @padding-left
+      height: $this.heights[size]
+
+    &.outlined.{size}
+    &.outlined-bg.{size}
+      padding-left: $this.paddings[size] - $this.outlinedBorderWidth
+      padding-right @padding-left
+
+.label
+  for size in _sizes
+    &.{size}
+      font-size: $UI.fontSizes[$this.fontSizes[size]]
+      line-height: $UI.lineHeights[$this.lineHeights[size]]
+
+.iconWrapper
+  &.left
+    margin-right 0.5u
+
+  &.right
+    margin-left 0.5u
+
+.icon
+  color: $UI.colors.dark
+
+  &.flat
+    color: $UI.colors.white
+
+// ----- JS EXPORTS
+:export
+  colors: $UI.colors

--- a/packages/ui/components/forms/Multiselect/defaultTag.js
+++ b/packages/ui/components/forms/Multiselect/defaultTag.js
@@ -12,6 +12,7 @@ function DefaultTag ({
   return pug`
     Tag.tag(
       styleName={last: isLast}
+      size='s'
       variant='flat'
       color='primary'
     )= record.label


### PR DESCRIPTION
BREKING CHANGE:
- remove `iconPosition` property. For the icon on the left, use the `icon` property and `iconStyle` to style it, for the icon on the right, use the `secondaryIcon` and `secondaryIconStyle` properties, and all these properties to use two icons
- no more support loading indicator for async action
- the default component size has become larger
- add `size` property