### PR TITLE
feat(ui): Add ability to override ui styles

### DIFF
--- a/packages/startupjs/templates/ui/Root/index.js
+++ b/packages/startupjs/templates/ui/Root/index.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import { Platform } from 'react-native'
+import init from 'startupjs/init'
+import App from 'startupjs/app'
+import { observer, model } from 'startupjs'
+import { registerPlugins } from 'startupjs/plugin'
+import { uiAppPlugin } from '@startupjs/ui'
+import { BASE_URL } from '@env'
+import orm from '../model'
+
+// Frontend micro-services
+import * as main from '../main'
+
+if (Platform.OS === 'web') window.model = model
+
+// Init startupjs connection to server and the ORM.
+// baseUrl option is required for the native to work - it's used
+// to init the websocket connection and axios.
+// Initialization must start before doing any subscribes to data.
+init({ baseUrl: BASE_URL, orm })
+
+registerPlugins({
+  '@startupjs/app': [
+    [uiAppPlugin, { defaultEnable: true }]
+  ]
+})
+
+export default observer(() => {
+  return pug`
+    App(
+      apps={main}
+    )
+  `
+})

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -81,9 +81,20 @@ import { uiAppPlugin } from '@startupjs/ui'
 
 registerPlugins({
   '@startupjs/app': [
-    [uiAppPlugin, { defaultEnable: true }]
+    [uiAppPlugin, { defaultEnable: true, style: overridesStyle }]
   ]
 })
+```
+
+where `overridesStyle` is the styles to override default components' styles and for the override to work the component must be wrapped into `themed()` decorator. The override syntax looks requires that component is referred as a class by its name (starting with a capital letter) in the `.styl` file. For example `Button` is referred as `.Button`:
+
+```styl
+.Button
+  color red
+  &:part(hover)
+    color green
+  &:part(active)
+    color blue
 ```
 
 ## Usage

--- a/packages/ui/StyleContext.js
+++ b/packages/ui/StyleContext.js
@@ -1,0 +1,9 @@
+import React, { useContext } from 'react'
+
+const StyleContext = React.createContext()
+
+export default StyleContext
+
+export function useStyle () {
+  return useContext(StyleContext)
+}

--- a/packages/ui/components/Alert/index.js
+++ b/packages/ui/components/Alert/index.js
@@ -12,6 +12,7 @@ import Div from '../Div'
 import Span from '../typography/Span'
 import Row from '../Row'
 import Icon from '../Icon'
+import themed from '../../theming/themed'
 import './index.styl'
 
 const ICONS = {
@@ -79,4 +80,4 @@ Alert.propTypes = {
   onClose: PropTypes.func
 }
 
-export default observer(Alert)
+export default observer(themed(Alert))

--- a/packages/ui/components/AutoSuggest/index.js
+++ b/packages/ui/components/AutoSuggest/index.js
@@ -8,6 +8,7 @@ import Menu from '../Menu'
 import Popover from '../popups/Popover'
 import Loader from '../Loader'
 import useKeyboard from './useKeyboard'
+import themed from '../../theming/themed'
 import './index.styl'
 
 const SUPPORT_PLACEMENTS = [
@@ -176,4 +177,4 @@ AutoSuggest.propTypes = {
   onScrollEnd: PropTypes.func
 }
 
-export default observer(AutoSuggest)
+export default observer(themed(AutoSuggest))

--- a/packages/ui/components/Avatar/index.js
+++ b/packages/ui/components/Avatar/index.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types'
 import randomcolor from 'randomcolor'
 import Div from './../Div'
 import Span from '../typography/Span'
+import themed from '../../theming/themed'
 import STYLES from './index.styl'
 
 const { config } = STYLES
@@ -97,4 +98,4 @@ Avatar.propTypes = {
   onPress: Div.propTypes.onPress
 }
 
-export default observer(Avatar)
+export default observer(themed(Avatar))

--- a/packages/ui/components/Badge/index.js
+++ b/packages/ui/components/Badge/index.js
@@ -6,6 +6,7 @@ import Div from '../Div'
 import Icon from '../Icon'
 import Row from '../Row'
 import Span from '../typography/Span'
+import themed from '../../theming/themed'
 import STYLES from './index.styl'
 
 const {
@@ -87,4 +88,4 @@ Badge.propTypes = {
   size: PropTypes.oneOf(['s', 'm', 'l'])
 }
 
-export default observer(Badge)
+export default observer(themed(Badge))

--- a/packages/ui/components/Br/index.js
+++ b/packages/ui/components/Br/index.js
@@ -1,7 +1,8 @@
 import React from 'react'
-import { observer, u } from 'startupjs'
 import { Text } from 'react-native'
+import { observer, u } from 'startupjs'
 import PropTypes from 'prop-types'
+import themed from '../../theming/themed'
 import './index.styl'
 const LINE_HEIGHT = u(2)
 
@@ -24,4 +25,4 @@ Br.propTypes = {
 
 }
 
-export default observer(Br)
+export default observer(themed(Br))

--- a/packages/ui/components/Breadcrumbs/index.js
+++ b/packages/ui/components/Breadcrumbs/index.js
@@ -7,6 +7,7 @@ import Row from '../Row'
 import Div from '../Div'
 import Icon from '../Icon'
 import Span from '../typography/Span'
+import themed from '../../theming/themed'
 import STYLES from './index.styl'
 
 const { colors } = STYLES
@@ -79,4 +80,4 @@ Breadcrumbs.propTypes = {
   replace: PropTypes.bool
 }
 
-export default observer(Breadcrumbs)
+export default observer(themed(Breadcrumbs))

--- a/packages/ui/components/Button/index.js
+++ b/packages/ui/components/Button/index.js
@@ -8,6 +8,7 @@ import Row from '../Row'
 import Div from '../Div'
 import Loader from '../Loader'
 import Span from '../typography/Span'
+import themed from '../../theming/themed'
 import STYLES from './index.styl'
 
 const {
@@ -175,4 +176,4 @@ Button.propTypes = {
   iconPosition: PropTypes.oneOf(['left', 'right'])
 }
 
-export default observer(Button)
+export default observer(themed(Button))

--- a/packages/ui/components/Card/index.js
+++ b/packages/ui/components/Card/index.js
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react'
 import { observer } from 'startupjs'
 import PropTypes from 'prop-types'
 import Div from '../Div'
+import themed from '../../theming/themed'
 import STYLES from './index.styl'
 
 const { shadows: SHADOWS } = STYLES
@@ -45,4 +46,4 @@ Card.propTypes = {
   onPress: PropTypes.func
 }
 
-export default observer(Card)
+export default observer(themed(Card))

--- a/packages/ui/components/Collapse/CollapseContent/index.js
+++ b/packages/ui/components/Collapse/CollapseContent/index.js
@@ -1,9 +1,10 @@
 import React from 'react'
-import { observer } from 'startupjs'
-import PropTypes from 'prop-types'
 import { View } from 'react-native'
 import Collapsible from 'react-native-collapsible'
+import { observer } from 'startupjs'
+import PropTypes from 'prop-types'
 import Span from './../../typography/Span'
+import themed from '../../../theming/themed'
 import './index.styl'
 
 function CollapseContent ({
@@ -33,4 +34,4 @@ CollapseContent.propTypes = {
   children: PropTypes.node
 }
 
-export default observer(CollapseContent)
+export default observer(themed(CollapseContent))

--- a/packages/ui/components/Collapse/CollapseHeader/index.js
+++ b/packages/ui/components/Collapse/CollapseHeader/index.js
@@ -1,12 +1,13 @@
 import React, { useRef } from 'react'
+import { Animated } from 'react-native'
 import { observer, useDidUpdate } from 'startupjs'
 import PropTypes from 'prop-types'
-import { Animated } from 'react-native'
+import { faCaretRight } from '@fortawesome/free-solid-svg-icons'
 import Div from './../../Div'
 import Row from './../../Row'
 import Icon from './../../Icon'
 import Span from './../../typography/Span'
-import { faCaretRight } from '@fortawesome/free-solid-svg-icons'
+import themed from '../../../theming/themed'
 import './index.styl'
 
 function CollapseHeader ({
@@ -77,4 +78,4 @@ CollapseHeader.propTypes = {
   children: PropTypes.node
 }
 
-export default observer(CollapseHeader)
+export default observer(themed(CollapseHeader))

--- a/packages/ui/components/Collapse/index.js
+++ b/packages/ui/components/Collapse/index.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import Div from './../Div'
 import CollapseHeader from './CollapseHeader'
 import CollapseContent from './CollapseContent'
+import themed from '../../theming/themed'
 import './index.styl'
 
 // TODO: hover, active states
@@ -82,7 +83,7 @@ Collapse.propTypes = {
   onChange: PropTypes.func
 }
 
-const ObserverCollapse = observer(Collapse)
+const ObserverCollapse = observer(themed(Collapse))
 ObserverCollapse.Header = CollapseHeader
 ObserverCollapse.Content = CollapseContent
 

--- a/packages/ui/components/Content/index.js
+++ b/packages/ui/components/Content/index.js
@@ -1,7 +1,8 @@
 import React from 'react'
+import { View } from 'react-native'
 import { observer } from 'startupjs'
 import PropTypes from 'prop-types'
-import { View } from 'react-native'
+import themed from '../../theming/themed'
 import STYLES from './index.styl'
 
 const {
@@ -41,4 +42,4 @@ Content.propTypes = {
   children: PropTypes.node
 }
 
-export default observer(Content)
+export default observer(themed(Content))

--- a/packages/ui/components/Div/index.js
+++ b/packages/ui/components/Div/index.js
@@ -8,6 +8,7 @@ import {
 import { observer, useDidUpdate } from 'startupjs'
 import PropTypes from 'prop-types'
 import { colorToRGBA } from '../../helpers'
+import themed from '../../theming/themed'
 import STYLES from './index.styl'
 
 const isWeb = Platform.OS === 'web'
@@ -179,7 +180,7 @@ Div.propTypes = {
   _preventEvent: PropTypes.bool
 }
 
-export default observer(Div)
+export default observer(themed(Div))
 
 function getDefaultStyle (style, type, variant) {
   if (variant === 'opacity') {

--- a/packages/ui/components/Divider/index.js
+++ b/packages/ui/components/Divider/index.js
@@ -1,7 +1,8 @@
 import React from 'react'
+import { View } from 'react-native'
 import { observer, u } from 'startupjs'
 import PropTypes from 'prop-types'
-import { View } from 'react-native'
+import themed from '../../theming/themed'
 import STYLES from './index.styl'
 
 const {
@@ -55,4 +56,4 @@ Divider.propTypes = {
   lines: PropTypes.number
 }
 
-export default observer(Divider)
+export default observer(themed(Divider))

--- a/packages/ui/components/DrawerSidebar/index.js
+++ b/packages/ui/components/DrawerSidebar/index.js
@@ -3,6 +3,7 @@ import { ScrollView, StyleSheet } from 'react-native'
 import DrawerLayout from 'react-native-drawer-layout-polyfill'
 import { observer, useComponentId, useBind, useLocal, useDidUpdate } from 'startupjs'
 import PropTypes from 'prop-types'
+import themed from '../../theming/themed'
 import STYLES from './index.styl'
 
 const { colors } = STYLES
@@ -84,4 +85,4 @@ DrawerSidebar.propTypes = {
   renderContent: PropTypes.func
 }
 
-export default observer(DrawerSidebar)
+export default observer(themed(DrawerSidebar))

--- a/packages/ui/components/Hr/index.js
+++ b/packages/ui/components/Hr/index.js
@@ -1,7 +1,8 @@
 import React from 'react'
+import { View } from 'react-native'
 import { observer } from 'startupjs'
 import PropTypes from 'prop-types'
-import { View } from 'react-native'
+import themed from '../../theming/themed'
 import './index.styl'
 
 const LINE_SIZE = 8
@@ -36,4 +37,4 @@ Hr.propTypes = {
   size: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(['m', 'l', 'xl'])])
 }
 
-export default observer(Hr)
+export default observer(themed(Hr))

--- a/packages/ui/components/Icon/index.js
+++ b/packages/ui/components/Icon/index.js
@@ -1,8 +1,9 @@
 import React, { useMemo } from 'react'
-import { observer, u } from 'startupjs'
-import PropTypes from 'prop-types'
 import { StyleSheet } from 'react-native'
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome'
+import { observer, u } from 'startupjs'
+import PropTypes from 'prop-types'
+import themed from '../../theming/themed'
 import STYLES from './index.styl'
 
 const {
@@ -68,4 +69,4 @@ Icon.propTypes = {
   ])
 }
 
-export default observer(Icon)
+export default observer(themed(Icon))

--- a/packages/ui/components/Layout/index.js
+++ b/packages/ui/components/Layout/index.js
@@ -1,8 +1,9 @@
 import React from 'react'
-import { observer, useBackPress } from 'startupjs'
-import PropTypes from 'prop-types'
 import { SafeAreaView, StatusBar } from 'react-native'
 import { useHistory } from 'react-router-native'
+import { observer, useBackPress } from 'startupjs'
+import PropTypes from 'prop-types'
+import themed from '../../theming/themed'
 import STYLES from './index.styl'
 
 const {
@@ -35,4 +36,4 @@ Layout.propTypes = {
   children: PropTypes.node
 }
 
-export default observer(Layout)
+export default observer(themed(Layout))

--- a/packages/ui/components/Link/index.js
+++ b/packages/ui/components/Link/index.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types'
 import Div from './../Div'
 import Button from './../Button'
 import Span from './../typography/Span'
+import themed from '../../theming/themed'
 import './index.styl'
 
 const isWeb = Platform.OS === 'web'
@@ -127,4 +128,4 @@ Link.propTypes = {
   color: PropTypes.oneOf(['default', 'primary'])
 }
 
-export default observer(Link)
+export default observer(themed(Link))

--- a/packages/ui/components/Loader/index.js
+++ b/packages/ui/components/Loader/index.js
@@ -1,7 +1,8 @@
 import React from 'react'
+import { ActivityIndicator } from 'react-native'
 import { observer } from 'startupjs'
 import PropTypes from 'prop-types'
-import { ActivityIndicator } from 'react-native'
+import themed from '../../theming/themed'
 import STYLES from './index.styl'
 
 const { colors } = STYLES
@@ -28,4 +29,4 @@ Loader.propTypes = {
   color: PropTypes.oneOf(Object.keys(colors))
 }
 
-export default observer(Loader)
+export default observer(themed(Loader))

--- a/packages/ui/components/Menu/MenuItem/index.js
+++ b/packages/ui/components/Menu/MenuItem/index.js
@@ -6,6 +6,7 @@ import Link from './../../Link'
 import Icon from './../../Icon'
 import Span from './../../typography/Span'
 import { useMenuContext } from './../menuContext'
+import themed from '../../../theming/themed'
 import STYLES from './index.styl'
 
 const { colors } = STYLES
@@ -82,4 +83,4 @@ MenuItem.propTypes = {
   activeColor: PropTypes.string
 }
 
-export default observer(MenuItem)
+export default observer(themed(MenuItem))

--- a/packages/ui/components/Menu/index.js
+++ b/packages/ui/components/Menu/index.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import Div from './../Div'
 import MenuItem from './MenuItem'
 import { MenuProvider } from './menuContext'
+import themed from '../../theming/themed'
 import './index.styl'
 
 function Menu ({
@@ -43,6 +44,8 @@ Menu.propTypes = {
   activeColor: PropTypes.string
 }
 
-const ObservedMenu = observer(Menu)
+const ObservedMenu = observer(themed(Menu))
+
 ObservedMenu.Item = MenuItem
+
 export default ObservedMenu

--- a/packages/ui/components/Modal/ModalActions/index.js
+++ b/packages/ui/components/Modal/ModalActions/index.js
@@ -3,6 +3,7 @@ import { observer } from 'startupjs'
 import PropTypes from 'prop-types'
 import Row from './../../Row'
 import Button from './../../Button'
+import themed from '../../../theming/themed'
 import './index.styl'
 
 function ModalActions ({
@@ -48,4 +49,4 @@ ModalActions.propTypes = {
   onConfirm: PropTypes.func
 }
 
-export default observer(ModalActions)
+export default observer(themed(ModalActions))

--- a/packages/ui/components/Modal/ModalContent/index.js
+++ b/packages/ui/components/Modal/ModalContent/index.js
@@ -1,8 +1,9 @@
 import React from 'react'
+import { ScrollView } from 'react-native'
 import { observer } from 'startupjs'
 import PropTypes from 'prop-types'
-import { ScrollView } from 'react-native'
 import Span from './../../typography/Span'
+import themed from '../../../theming/themed'
 import './index.styl'
 
 function ModalContent ({
@@ -33,4 +34,4 @@ ModalContent.propTypes = {
   children: PropTypes.node
 }
 
-export default observer(ModalContent)
+export default observer(themed(ModalContent))

--- a/packages/ui/components/Modal/ModalHeader/index.js
+++ b/packages/ui/components/Modal/ModalHeader/index.js
@@ -6,6 +6,7 @@ import Span from './../../typography/Span'
 import Icon from './../../Icon'
 import Row from './../../Row'
 import Div from './../../Div'
+import themed from '../../../theming/themed'
 import './index.styl'
 
 function ModalHeader ({
@@ -31,4 +32,4 @@ ModalHeader.propTypes = {
   onCrossPress: PropTypes.func
 }
 
-export default observer(ModalHeader)
+export default observer(themed(ModalHeader))

--- a/packages/ui/components/Modal/index.js
+++ b/packages/ui/components/Modal/index.js
@@ -8,7 +8,7 @@ import ModalContent from './ModalContent'
 import ModalActions from './ModalActions'
 import Portal from '../Portal'
 
-function Modal ({
+function ModalRoot ({
   style,
   modalStyle,
   $visible,
@@ -73,7 +73,7 @@ function Modal ({
   `
 }
 
-const ObservedModal = observer(Modal, { forwardRef: true })
+const ObservedModal = observer(ModalRoot, { forwardRef: true })
 
 ObservedModal.defaultProps = {
   variant: 'window',

--- a/packages/ui/components/Modal/layout.js
+++ b/packages/ui/components/Modal/layout.js
@@ -4,6 +4,7 @@ import { observer } from 'startupjs'
 import ModalHeader from './ModalHeader'
 import ModalContent from './ModalContent'
 import ModalActions from './ModalActions'
+import themed from '../../theming/themed'
 import './index.styl'
 
 function Modal ({
@@ -150,4 +151,4 @@ function Modal ({
   `
 }
 
-export default observer(Modal)
+export default observer(themed(Modal))

--- a/packages/ui/components/Pagination/index.js
+++ b/packages/ui/components/Pagination/index.js
@@ -1,17 +1,18 @@
 import React from 'react'
-import usePagination from './usePagination'
 import { observer } from 'startupjs'
 import PropTypes from 'prop-types'
-import Span from './../typography/Span'
-import Row from './../Row'
-import Div from './../Div'
-import Icon from './../Icon'
 import {
   faAngleLeft,
   faAngleDoubleLeft,
   faAngleRight,
   faAngleDoubleRight
 } from '@fortawesome/free-solid-svg-icons'
+import usePagination from './usePagination'
+import Span from './../typography/Span'
+import Row from './../Row'
+import Div from './../Div'
+import Icon from './../Icon'
+import themed from '../../theming/themed'
 import './index.styl'
 
 const ICONS = {
@@ -91,4 +92,4 @@ Pagination.propTypes = {
   // onChangeLimit: propTypes.func TODO: Add selectbox to component to change limit
 }
 
-export default observer(Pagination)
+export default observer(themed(Pagination))

--- a/packages/ui/components/Progress/filler.js
+++ b/packages/ui/components/Progress/filler.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
-import { observer, useDidUpdate } from 'startupjs'
 import { Animated, Easing } from 'react-native'
+import { observer, useDidUpdate } from 'startupjs'
+import themed from '../../theming/themed'
 import STYLES from './index.styl'
 
 const {
@@ -11,7 +12,7 @@ const {
 
 const AnimatedView = Animated.View
 
-export default observer(function ProgressFiller ({ style, value }) {
+function ProgressFiller ({ style, value }) {
   const [progress] = useState(new Animated.Value(value))
   const [width, setWidth] = useState(0)
 
@@ -43,4 +44,6 @@ export default observer(function ProgressFiller ({ style, value }) {
       onLayout=(event) => setWidth(event.nativeEvent.layout.width)
     )
   `
-})
+}
+
+export default observer(themed('Progress', ProgressFiller))

--- a/packages/ui/components/Progress/filler.web.js
+++ b/packages/ui/components/Progress/filler.web.js
@@ -1,10 +1,12 @@
 import React from 'react'
-import { observer } from 'startupjs'
 import { View } from 'react-native'
+import { observer } from 'startupjs'
+import themed from '../../theming/themed'
 import './index.styl'
 
-export default observer(function ProgressFiller ({ style, value }) {
+function ProgressFiller ({ style, value }) {
   return pug`
     View.filler(style=[{width: value + '%'}, style])
   `
-})
+}
+export default observer(themed('Progress', ProgressFiller))

--- a/packages/ui/components/Progress/index.js
+++ b/packages/ui/components/Progress/index.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types'
 import Span from '../typography/Span'
 import Div from '../Div'
 import Filler from './filler'
+import themed from '../../theming/themed'
 import './index.styl'
 
 function Progress ({
@@ -45,4 +46,4 @@ Progress.propTypes = {
   variant: PropTypes.oneOf(['linear', 'circular']) // TODO: Add circular progress
 }
 
-export default observer(Progress)
+export default observer(themed(Progress))

--- a/packages/ui/components/Rating/Star/index.js
+++ b/packages/ui/components/Rating/Star/index.js
@@ -1,14 +1,15 @@
 import React from 'react'
 import { observer } from 'startupjs'
-import Icon from './../../Icon'
 import { faStar } from '@fortawesome/free-solid-svg-icons'
+import Icon from './../../Icon'
+import themed from '../../../theming/themed'
 import './index.styl'
 
 // We can create this component using react-native-svg in future
 // for partial filling (icon + linear gradient) or using star-half
 // icon for 0.5 step
 
-export default observer(function Star ({
+function Star ({
   style,
   active
 }) {
@@ -19,4 +20,6 @@ export default observer(function Star ({
       icon=faStar
     )
   `
-})
+}
+
+export default observer(themed('Rating', Star))

--- a/packages/ui/components/Rating/index.js
+++ b/packages/ui/components/Rating/index.js
@@ -5,7 +5,9 @@ import Div from './../Div'
 import Row from './../Row'
 import { H6 } from './../typography'
 import Star from './Star'
+import themed from '../../theming/themed'
 import './index.styl'
+
 const AMOUNT = 5
 const ITEMS = Array(AMOUNT).fill(null)
 
@@ -43,4 +45,4 @@ Rating.propTypes = {
   onChange: PropTypes.func
 }
 
-export default observer(Rating)
+export default observer(themed(Rating))

--- a/packages/ui/components/Row/index.js
+++ b/packages/ui/components/Row/index.js
@@ -1,8 +1,9 @@
 import React from 'react'
+import { Platform, StyleSheet } from 'react-native'
 import { observer } from 'startupjs'
 import PropTypes from 'prop-types'
-import { Platform, StyleSheet } from 'react-native'
 import Div from './../Div'
+import themed from '../../theming/themed'
 import './index.styl'
 
 const isNative = Platform.OS !== 'web'
@@ -50,7 +51,6 @@ Row.propTypes = {
   reverse: PropTypes.bool,
   align: PropTypes.oneOf(['left', 'center', 'right', 'around', 'between']),
   vAlign: PropTypes.oneOf(['stretch', 'start', 'center', 'end'])
-  // TODO: may be we need add align-content
 }
 
-export default observer(Row)
+export default observer(themed(Row))

--- a/packages/ui/components/Sidebar/index.js
+++ b/packages/ui/components/Sidebar/index.js
@@ -8,6 +8,7 @@ import {
 } from 'startupjs'
 import PropTypes from 'prop-types'
 import Div from '../Div'
+import themed from '../../theming/themed'
 import STYLES from './index.styl'
 
 const { colors } = STYLES
@@ -69,4 +70,4 @@ Sidebar.propTypes = {
   renderContent: PropTypes.func
 }
 
-export default observer(Sidebar)
+export default observer(themed(Sidebar))

--- a/packages/ui/components/SmartSidebar/index.js
+++ b/packages/ui/components/SmartSidebar/index.js
@@ -9,6 +9,7 @@ import {
 } from 'startupjs'
 import PropTypes from 'prop-types'
 import Sidebar from '../Sidebar'
+import themed from '../../theming/themed'
 import DrawerSidebar from '../DrawerSidebar'
 
 const FIXED_LAYOUT_BREAKPOINT = 1024
@@ -118,7 +119,7 @@ SmartSidebar.propTypes = {
   renderContent: PropTypes.func
 }
 
-export default observer(SmartSidebar)
+export default observer(themed(SmartSidebar))
 
 function isFixedLayout (fixedLayoutBreakpoint) {
   let dim = Dimensions.get('window')

--- a/packages/ui/components/Tabs/index.js
+++ b/packages/ui/components/Tabs/index.js
@@ -7,6 +7,7 @@ import findIndex from 'lodash/findIndex'
 import pick from 'lodash/pick'
 import Span from './../typography/Span'
 import Bar from './Bar'
+import themed from '../../theming/themed'
 import './index.styl'
 
 function Tabs ({
@@ -75,7 +76,7 @@ function Tabs ({
   `
 }
 
-const ObservedTabs = observer(Tabs)
+const ObservedTabs = observer(themed(Tabs))
 
 ObservedTabs.defaultProps = {}
 

--- a/packages/ui/components/Tag/index.js
+++ b/packages/ui/components/Tag/index.js
@@ -6,6 +6,7 @@ import { colorToRGBA } from '../../helpers'
 import Icon from '../Icon'
 import Div from '../Div'
 import Span from '../typography/Span'
+import themed from '../../theming/themed'
 import STYLES from './index.styl'
 
 const { colors } = STYLES
@@ -138,4 +139,4 @@ Tag.propTypes = {
   size: PropTypes.oneOf(['s', 'm'])
 }
 
-export default observer(Tag)
+export default observer(themed(Tag))

--- a/packages/ui/components/User/index.js
+++ b/packages/ui/components/User/index.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types'
 import Avatar from '../Avatar'
 import Div from '../Div'
 import Span from '../typography/Span'
+import themed from '../../theming/themed'
 import './index.styl'
 
 function User ({
@@ -67,4 +68,4 @@ User.propTypes = {
   onPress: PropTypes.func
 }
 
-export default observer(User)
+export default observer(themed(User))

--- a/packages/ui/components/forms/ArrayInput/index.js
+++ b/packages/ui/components/forms/ArrayInput/index.js
@@ -7,9 +7,10 @@ import Div from '../../Div'
 import Card from '../../Card'
 import Button from '../../Button'
 import Span from '../../typography/Span'
+import themed from '../../../theming/themed'
 import './index.styl'
 
-export default observer(function ObjectInput ({
+function ArrayInput ({
   style,
   inputStyle,
   $value,
@@ -85,4 +86,6 @@ export default observer(function ObjectInput ({
       onPress=() => $value.push(undefined)
     )
   `)
-})
+}
+
+export default observer(themed(ArrayInput))

--- a/packages/ui/components/forms/Checkbox/checkbox.js
+++ b/packages/ui/components/forms/Checkbox/checkbox.js
@@ -4,11 +4,12 @@ import { observer, useDidUpdate } from 'startupjs'
 import { faCheck } from '@fortawesome/free-solid-svg-icons'
 import Icon from './../../Icon'
 import Div from './../../Div'
+import themed from '../../../theming/themed'
 import './index.styl'
 
 const AnimatedView = Animated.View
 
-export default observer(function Checkbox ({
+function CheckboxInput ({
   style,
   className,
   value,
@@ -67,4 +68,6 @@ export default observer(function Checkbox ({
         }
       )
   `
-})
+}
+
+export default observer(themed('Checkbox', CheckboxInput))

--- a/packages/ui/components/forms/Checkbox/index.js
+++ b/packages/ui/components/forms/Checkbox/index.js
@@ -5,13 +5,14 @@ import { useLayout } from './../../../hooks'
 import Row from './../../Row'
 import Div from './../../Div'
 import Span from './../../typography/Span'
-import Checkbox from './checkbox'
-import Switch from './switch'
+import CheckboxInput from './checkbox'
+import SwitchInput from './switch'
+import themed from '../../../theming/themed'
 import './index.styl'
 
 const INPUT_COMPONENTS = {
-  checkbox: Checkbox,
-  switch: Switch
+  checkbox: CheckboxInput,
+  switch: SwitchInput
 }
 
 const READONLY_ICONS = {
@@ -19,7 +20,7 @@ const READONLY_ICONS = {
   FALSE: '✗'
 }
 
-function CheckboxInput ({
+function Checkbox ({
   style,
   className,
   variant,
@@ -91,14 +92,14 @@ function CheckboxInput ({
   `
 }
 
-CheckboxInput.defaultProps = {
+Checkbox.defaultProps = {
   variant: 'checkbox',
   value: false,
   disabled: false,
   readonly: false
 }
 
-CheckboxInput.propTypes = {
+Checkbox.propTypes = {
   style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   variant: PropTypes.oneOf(['checkbox', 'switch']),
   label: PropTypes.node,
@@ -110,4 +111,4 @@ CheckboxInput.propTypes = {
   onChange: PropTypes.func
 }
 
-export default observer(CheckboxInput)
+export default observer(themed(Checkbox))

--- a/packages/ui/components/forms/Checkbox/switch.js
+++ b/packages/ui/components/forms/Checkbox/switch.js
@@ -1,12 +1,13 @@
 import React, { useRef } from 'react'
-import { observer, useDidUpdate } from 'startupjs'
 import { Animated, Easing } from 'react-native'
+import { observer, useDidUpdate } from 'startupjs'
 import Div from './../../Div'
+import themed from '../../../theming/themed'
 import './index.styl'
 
 const AnimatedView = Animated.View
 
-export default observer(function Switch ({
+function SwitchInput ({
   style,
   className,
   value,
@@ -59,4 +60,5 @@ export default observer(function Switch ({
         }
       )
   `
-})
+}
+export default observer(themed('Checkbox', SwitchInput))

--- a/packages/ui/components/forms/DateTimePicker/index.js
+++ b/packages/ui/components/forms/DateTimePicker/index.js
@@ -11,6 +11,7 @@ import Div from '../../Div'
 import Drawer from '../../popups/Drawer'
 import Row from '../../Row'
 import Span from '../../typography/Span'
+import themed from '../../../theming/themed'
 import STYLES from './index.styl'
 
 const { colors: { mainText, secondaryText } } = STYLES
@@ -256,4 +257,4 @@ DateTimePicker.propTypes = {
   onDateChange: PropTypes.func
 }
 
-export default observer(DateTimePicker)
+export default observer(themed(DateTimePicker))

--- a/packages/ui/components/forms/DateTimePicker/index.web.js
+++ b/packages/ui/components/forms/DateTimePicker/index.web.js
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types'
 import * as locale from 'date-fns/locale'
 import Div from '../../Div'
 import Span from './../../typography/Span'
+import themed from '../../../theming/themed'
 import './index.styl'
 
 const localLanguage = window.navigator.language
@@ -126,4 +127,4 @@ DateTimePicker.propTypes = {
   onDateChange: PropTypes.func
 }
 
-export default observer(DateTimePicker)
+export default observer(themed(DateTimePicker))

--- a/packages/ui/components/forms/ErrorWrapper/index.js
+++ b/packages/ui/components/forms/ErrorWrapper/index.js
@@ -1,15 +1,17 @@
 import React from 'react'
 import { Text } from 'react-native'
+import { observer } from 'startupjs'
 import { Div } from '@startupjs/ui'
+import themed from '../../../theming/themed'
 import './index.styl'
 
-export default ({
+function InputErrorWrapper ({
   style,
   children,
   err,
   position = 'bottom',
   ...otherProps
-}) => {
+}) {
   return pug`
     Div(style=style ...otherProps)
       if err && position === 'top'
@@ -19,3 +21,5 @@ export default ({
         Text.text= err
   `
 }
+
+export default observer(themed(InputErrorWrapper))

--- a/packages/ui/components/forms/Input/index.js
+++ b/packages/ui/components/forms/Input/index.js
@@ -10,6 +10,7 @@ import ObjectInput from '../ObjectInput'
 import PasswordInput from '../PasswordInput'
 import Select from '../Select'
 import TextInput from '../TextInput'
+import themed from '../../../theming/themed'
 
 const INPUTS = {
   text: {
@@ -144,4 +145,4 @@ Input.propTypes = {
   $value: PropTypes.any
 }
 
-export default observer(Input)
+export default observer(themed(Input))

--- a/packages/ui/components/forms/NumberInput/index.js
+++ b/packages/ui/components/forms/NumberInput/index.js
@@ -7,6 +7,7 @@ import { faAngleDown, faAngleUp, faMinus, faPlus } from '@fortawesome/free-solid
 import PropTypes from 'prop-types'
 import TextInput from '../TextInput'
 import Button from '../../Button'
+import themed from '../../../theming/themed'
 import './index.styl'
 
 const IS_WEB = Platform.OS === 'web'
@@ -214,4 +215,4 @@ NumberInput.propTypes = {
   onFocus: PropTypes.func
 }
 
-export default observer(NumberInput)
+export default observer(themed(NumberInput))

--- a/packages/ui/components/forms/ObjectInput/index.js
+++ b/packages/ui/components/forms/ObjectInput/index.js
@@ -5,9 +5,10 @@ import Input from '../Input'
 import Div from '../../Div'
 import Card from '../../Card'
 import Span from '../../typography/Span'
+import themed from '../../../theming/themed'
 import './index.styl'
 
-export default observer(function ObjectInput ({
+function ObjectInput ({
   style,
   inputStyle,
   $value,
@@ -74,7 +75,9 @@ export default observer(function ObjectInput ({
         error=errors[key]
       )
   `)
-})
+}
+
+export default observer(themed(ObjectInput))
 
 function getOrder (order, properties) {
   return order != null ? order : Object.keys(properties)

--- a/packages/ui/components/forms/PasswordInput/index.js
+++ b/packages/ui/components/forms/PasswordInput/index.js
@@ -3,6 +3,7 @@ import { observer } from 'startupjs'
 import omit from 'lodash/omit'
 import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons'
 import TextInput from '../TextInput'
+import themed from '../../../theming/themed'
 
 function PasswordInput ({ ...props }) {
   const [textHidden, setTextHidden] = useState(true)
@@ -30,4 +31,4 @@ PasswordInput.propTypes = {
   ...omit(TextInput.propTypes, ['icon', 'iconPosition', 'numberOfLines', 'resize', 'readonly', 'onIconPress'])
 }
 
-export default observer(PasswordInput)
+export default observer(themed(PasswordInput))

--- a/packages/ui/components/forms/Radio/index.js
+++ b/packages/ui/components/forms/Radio/index.js
@@ -3,9 +3,10 @@ import { observer } from 'startupjs'
 import PropTypes from 'prop-types'
 import Input from './input'
 import Div from './../../Div'
+import themed from '../../../theming/themed'
 import './index.styl'
 
-const Radio = function ({
+function Radio ({
   style,
   children,
   value,
@@ -48,7 +49,7 @@ const Radio = function ({
     })
 
   return pug`
-    Div(style=style)
+    Div.root(style=style)
       = _children
   `
 }
@@ -73,6 +74,8 @@ Radio.propTypes = {
   onChange: PropTypes.func
 }
 
-const ObservedRadio = observer(Radio)
+const ObservedRadio = observer(themed(Radio))
+
 ObservedRadio.Item = Input
+
 export default ObservedRadio

--- a/packages/ui/components/forms/Radio/index.styl
+++ b/packages/ui/components/forms/Radio/index.styl
@@ -4,7 +4,7 @@ $size = 2u
 
 _size = 2u
 
-.root
+.input
   padding 0.5u
 
 .radio

--- a/packages/ui/components/forms/Radio/input.js
+++ b/packages/ui/components/forms/Radio/input.js
@@ -4,6 +4,7 @@ import { observer, useDidUpdate } from 'startupjs'
 import Row from '../../Row'
 import Div from '../../Div'
 import Span from '../../typography/Span'
+import themed from '../../../theming/themed'
 import './index.styl'
 
 const IS_ANDROID = Platform.OS === 'android'
@@ -13,7 +14,7 @@ const ANIMATION_TIMING = 100
 const MIN_SCALE_RATIO = IS_ANDROID ? 0.1 : 0
 const MAX_SCALE_RATIO = 1
 
-const Input = function ({
+const RadioInput = function ({
   style,
   value,
   children,
@@ -67,7 +68,7 @@ const Input = function ({
   }
 
   return pug`
-    Row.root(
+    Row.input(
       style=style
       vAlign='center'
       disabled=disabled
@@ -87,4 +88,4 @@ const Input = function ({
   `
 }
 
-export default observer(Input)
+export default observer(themed('Radio', RadioInput))

--- a/packages/ui/components/forms/Select/Wrapper/index.android.js
+++ b/packages/ui/components/forms/Select/Wrapper/index.android.js
@@ -9,9 +9,10 @@ import {
   NULL_OPTION
 } from './helpers'
 import Div from '../../../Div'
+import themed from '../../../../theming/themed'
 import './index.styl'
 
-export default observer(function SelectWrapper ({
+function SelectWrapper ({
   children,
   style,
   disabled,
@@ -45,4 +46,6 @@ export default observer(function SelectWrapper ({
               label=getLabel(item)
             )
   `
-})
+}
+
+export default observer(themed('Select', SelectWrapper))

--- a/packages/ui/components/forms/Select/Wrapper/index.ios.js
+++ b/packages/ui/components/forms/Select/Wrapper/index.ios.js
@@ -10,9 +10,10 @@ import {
   NULL_OPTION
 } from './helpers'
 import Div from '../../../Div'
+import themed from '../../../../theming/themed'
 import './index.styl'
 
-export default observer(function SelectWrapper ({
+function SelectWrapper ({
   options = [],
   value,
   onChange,
@@ -67,4 +68,5 @@ export default observer(function SelectWrapper ({
                   label=getLabel(item)
                 )
   `
-})
+}
+export default observer(themed('Select', SelectWrapper))

--- a/packages/ui/components/forms/Select/Wrapper/index.web.js
+++ b/packages/ui/components/forms/Select/Wrapper/index.web.js
@@ -3,16 +3,17 @@ import React from 'react'
 // eslint-disable-next-line
 import { unstable_createElement } from 'react-native'
 import { observer } from 'startupjs'
-import Div from '../../../Div'
-import './index.styl'
 import {
   stringifyValue,
   getLabel,
   parseValue,
   NULL_OPTION
 } from './helpers'
+import Div from '../../../Div'
+import themed from '../../../../theming/themed'
+import './index.styl'
 
-export default observer(function SelectWrapper ({
+function SelectWrapper ({
   options = [],
   value,
   onChange,
@@ -38,4 +39,5 @@ export default observer(function SelectWrapper ({
             option(key=index value=stringifyValue(item))
               = getLabel(item)
   `
-})
+}
+export default observer(themed('Select', SelectWrapper))

--- a/packages/ui/components/forms/TextInput/index.js
+++ b/packages/ui/components/forms/TextInput/index.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types'
 import { useLayout } from './../../../hooks'
 import Input from './input'
 import Span from './../../typography/Span'
+import themed from '../../../theming/themed'
 import './index.styl'
 
 function TextInput ({
@@ -42,7 +43,7 @@ function TextInput ({
   function renderInput (standalone) {
     if (readonly) {
       return pug`
-        Span.readonlySpan(
+        Span.readonly(
           styleName=[size]
         )= value
       `
@@ -87,7 +88,7 @@ function TextInput ({
   `
 }
 
-const ObservedTextInput = observer(TextInput, { forwardRef: true })
+const ObservedTextInput = observer(themed(TextInput), { forwardRef: true })
 
 ObservedTextInput.defaultProps = {
   size: 'm',

--- a/packages/ui/components/forms/TextInput/index.styl
+++ b/packages/ui/components/forms/TextInput/index.styl
@@ -34,7 +34,7 @@ _inputFontSizeS = 1.75u
   &.focused
     color _focusedColor
 
-.readonlySpan
+.readonly
   &.s
     font(s)
   &.m

--- a/packages/ui/components/forms/TextInput/input.js
+++ b/packages/ui/components/forms/TextInput/input.js
@@ -11,6 +11,7 @@ import PropTypes from 'prop-types'
 import { colorToRGBA } from '../../../helpers'
 import Div from './../../Div'
 import Icon from './../../Icon'
+import themed from '../../../theming/themed'
 import STYLES from './index.styl'
 
 const {
@@ -202,7 +203,7 @@ function getOppositePosition (position) {
   return position === 'left' ? 'right' : 'left'
 }
 
-const ObservedInput = observer(Input, { forwardRef: true })
+const ObservedInput = observer(themed('TextInput', Input), { forwardRef: true })
 
 ObservedInput.defaultProps = {
   editable: true,

--- a/packages/ui/components/table/Table/index.js
+++ b/packages/ui/components/table/Table/index.js
@@ -1,7 +1,8 @@
 import React from 'react'
+import { View } from 'react-native'
 import { observer } from 'startupjs'
 import PropTypes from 'prop-types'
-import { View } from 'react-native'
+import themed from '../../../theming/themed'
 import './index.styl'
 
 function Table ({ style, children }) {
@@ -15,4 +16,4 @@ Table.propTypes = {
   children: PropTypes.node
 }
 
-export default observer(Table)
+export default observer(themed(Table))

--- a/packages/ui/components/table/Tbody/index.js
+++ b/packages/ui/components/table/Tbody/index.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { observer } from 'startupjs'
 import PropTypes from 'prop-types'
 import Div from '../../Div'
+import themed from '../../../theming/themed'
 
 function Tbody ({ style, children, ...props }) {
   return pug`
@@ -17,4 +18,4 @@ Tbody.propTypes = {
   children: PropTypes.node
 }
 
-export default observer(Tbody)
+export default observer(themed(Tbody))

--- a/packages/ui/components/table/Td/index.js
+++ b/packages/ui/components/table/Td/index.js
@@ -3,6 +3,7 @@ import { observer, useValue } from 'startupjs'
 import PropTypes from 'prop-types'
 import Div from '../../Div'
 import Span from './../../typography/Span'
+import themed from '../../../theming/themed'
 import './index.styl'
 
 function Td ({ style, children, ellipsis, ...props }) {
@@ -45,4 +46,4 @@ Td.propTypes = {
   ellipsis: PropTypes.bool
 }
 
-export default observer(Td)
+export default observer(themed(Td))

--- a/packages/ui/components/table/Th/index.js
+++ b/packages/ui/components/table/Th/index.js
@@ -1,8 +1,9 @@
 import React, { useEffect } from 'react'
-import PropTypes from 'prop-types'
 import { observer, useValue } from 'startupjs'
+import PropTypes from 'prop-types'
 import Div from '../../Div'
 import Span from './../../typography/Span'
+import themed from '../../../theming/themed'
 import './index.styl'
 
 function Th ({ style, children, ellipsis, ...props }) {
@@ -46,4 +47,4 @@ Th.propTypes = {
   ellipsis: PropTypes.bool
 }
 
-export default observer(Th)
+export default observer(themed(Th))

--- a/packages/ui/components/table/Thead/index.js
+++ b/packages/ui/components/table/Thead/index.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { observer } from 'startupjs'
 import PropTypes from 'prop-types'
 import Div from '../../Div'
+import themed from '../../../theming/themed'
 import './index.styl'
 
 function Thead ({ style, children, bordered, ...props }) {
@@ -24,4 +25,4 @@ Thead.propTypes = {
   bordered: PropTypes.bool
 }
 
-export default observer(Thead)
+export default observer(themed(Thead))

--- a/packages/ui/components/table/Tr/index.js
+++ b/packages/ui/components/table/Tr/index.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { observer } from 'startupjs'
 import PropTypes from 'prop-types'
 import Row from '../../Row'
+import themed from '../../../theming/themed'
 
 function Tr ({ style, children, ...props }) {
   return pug`
@@ -17,4 +18,4 @@ Tr.propTypes = {
   children: PropTypes.node
 }
 
-export default observer(Tr)
+export default observer(themed(Tr))

--- a/packages/ui/components/typography/headers/generateHeader.js
+++ b/packages/ui/components/typography/headers/generateHeader.js
@@ -2,10 +2,11 @@ import React from 'react'
 import { Platform, Text } from 'react-native'
 import { observer, styl } from 'startupjs'
 import PropTypes from 'prop-types'
+import themed from '../../../theming/themed'
 
 export default function generateHeader (tag) {
-  const header = observer(
-    ({ children, style, bold, italic, ...props }) => {
+  const header = observer(themed(
+    function Header ({ children, style, bold, italic, ...props }) {
       const isWeb = Platform.OS === 'web'
       const role = isWeb
         ? { accessibilityRole: 'heading', 'aria-level': tag.replace(/^h/, '') }
@@ -20,7 +21,7 @@ export default function generateHeader (tag) {
         )= children
       `
     }
-  )
+  ))
 
   header.defaultProps = {
     bold: false,

--- a/packages/ui/helpers/uiAppPlugin.js
+++ b/packages/ui/helpers/uiAppPlugin.js
@@ -1,12 +1,14 @@
 import React from 'react'
 import { observer } from 'startupjs'
 import Portal from '../components/Portal'
+import StyleContext from '../StyleContext'
 
 export default {
   name: 'ui',
-  LayoutWrapper: observer(({ children }) => {
+  LayoutWrapper: observer(({ children, options = {} }) => {
     return pug`
-      Portal.Provider= children
+      StyleContext.Provider(value=options.style)
+        Portal.Provider= children
     `
   })
 }

--- a/packages/ui/theming/themed.js
+++ b/packages/ui/theming/themed.js
@@ -1,9 +1,36 @@
 import React, { useContext } from 'react'
+import matcher from '@startupjs/babel-plugin-rn-stylename-to-style/matcher'
 import ThemeContext from './ThemeContext'
+import { useStyle } from '../StyleContext'
 
 // TODO: Move themed inside react-sharedb's observer()
-export default function themed (Component) {
+export default function themed (name, Component) {
+  if (typeof name !== 'string') {
+    Component = name
+    name = Component.displayName || Component.name
+  }
   function ThemeWrapper (props) {
+    // Setup global component style overrides
+    const uiStyle = useStyle()
+    if (uiStyle) {
+      const styleProps = matcher(name, uiStyle, '', '', {}) || {}
+      const keysLength = Object.keys(styleProps).length
+      if (
+        keysLength > 0 &&
+        // Handle special case when we have an empty style array
+        // TODO: Fix returning an empty style array
+        !(keysLength === 1 && Array.isArray(styleProps.style) && styleProps.style.length === 0)
+      ) {
+        for (const key in styleProps) {
+          if (props[key]) {
+            styleProps[key] = [styleProps[key], props[key]]
+          }
+        }
+        props = { ...props, ...styleProps }
+      }
+    }
+
+    // Setup theme context
     let contextTheme = useContext(ThemeContext)
     let theme = props.theme || contextTheme
     let res

--- a/packages/ui/theming/themed.js
+++ b/packages/ui/theming/themed.js
@@ -1,7 +1,10 @@
 import React, { useContext } from 'react'
 import matcher from '@startupjs/babel-plugin-rn-stylename-to-style/matcher'
+import memoize from 'lodash/memoize'
 import ThemeContext from './ThemeContext'
 import { useStyle } from '../StyleContext'
+
+const memoizedMatcher = memoize(matcher, name => name)
 
 // TODO: Move themed inside react-sharedb's observer()
 export default function themed (name, Component) {
@@ -12,8 +15,9 @@ export default function themed (name, Component) {
   function ThemeWrapper (props) {
     // Setup global component style overrides
     const uiStyle = useStyle()
+
     if (uiStyle) {
-      const styleProps = matcher(name, uiStyle, '', '', {}) || {}
+      const styleProps = memoizedMatcher(name, uiStyle, '', '', {}) || {}
       const keysLength = Object.keys(styleProps).length
       if (
         keysLength > 0 &&

--- a/styleguide/Root/index.js
+++ b/styleguide/Root/index.js
@@ -38,7 +38,10 @@ init({ baseUrl: BASE_URL, orm })
 
 registerPlugins({
   '@startupjs/app': [
-    [uiAppPlugin, { defaultEnable: true, defaultOptions: { style: UI_STYLE_OVERRIDES } }]
+    [
+      uiAppPlugin,
+      { defaultEnable: true, defaultOptions: { style: UI_STYLE_OVERRIDES } }
+    ]
   ]
 })
 

--- a/styleguide/Root/index.js
+++ b/styleguide/Root/index.js
@@ -7,7 +7,7 @@ import { Platform } from 'react-native'
 import init from 'startupjs/init'
 import App from 'startupjs/app'
 import { observer, model } from 'startupjs'
-import { registerPlugins } from '@startupjs/plugin'
+import { registerPlugins } from 'startupjs/plugin'
 import { uiAppPlugin } from '@startupjs/ui'
 import {
   BASE_URL,
@@ -25,6 +25,9 @@ import * as main from '../main'
 import docs from '../docs'
 import auth from '../auth'
 
+// Override default styles
+import UI_STYLE_OVERRIDES from './uiOverrides.styl'
+
 if (Platform.OS === 'web') window.model = model
 
 // Init startupjs connection to server and the ORM.
@@ -35,7 +38,7 @@ init({ baseUrl: BASE_URL, orm })
 
 registerPlugins({
   '@startupjs/app': [
-    [uiAppPlugin, { defaultEnable: true }]
+    [uiAppPlugin, { defaultEnable: true, defaultOptions: { style: UI_STYLE_OVERRIDES } }]
   ]
 })
 

--- a/styleguide/Root/uiOverrides.styl
+++ b/styleguide/Root/uiOverrides.styl
@@ -1,0 +1,14 @@
+// This in an example file to just demonstrate the ability to override
+// default styles of components.
+// Inspect Button component in browser to see the outline-color and see how it changes on hover and click.
+
+// In order to support the override, each @startupjs/ui component must be wrapped into a
+// `themed()` decorator, same as in Button/index.js
+
+.Button
+  +web()
+    outline-color rgba(255, 0, 0, 0)
+    &:part(hover)
+      outline-color rgba(0, 255, 0, 0)
+    &:part(active)
+      outline-color rgba(0, 0, 255, 0)


### PR DESCRIPTION
We can now pass `style` option to the `uiAppPlugin` to be able to override default components' styles.

1. For the override to work the component must be wrapped into `themed()` decorator.
2. Component is referred as a class by its name (starting with a capital letter) in the `.styl` file. For example `Button` is referred as `.Button`:
    
    ```styl
    .Button
      color red
      &:part(hover)
        color green
      &:part(active)
        color blue
    ```

See `styleguide/Root/index.js` and `styleguide/Root/uiOverrides.styl` for the example of overriding the styles.

Also fix the `startupjs/templates/ui` to use the `uiAppPlugin` (which is required for the tooltips and some other components to work).

**TODO:** wrap each @startupjs/ui component into `themed()` decorator, right now only `Button` and `Span` are wrapped. The change is trivial though -- need to just go and wrap everything into `observer(themed(MyComponent))`. Order matters here -- it has to be specifically `observer(themed(...))`

**NO** breaking changes.