### PR TITLE
fix(sandbox): overflow

### DIFF
--- a/packages/docs/client/components/Props/Renderer/GridVisualizer/index.styl
+++ b/packages/docs/client/components/Props/Renderer/GridVisualizer/index.styl
@@ -112,3 +112,6 @@ grid(direction, color, size)
       background-color $darkInvalid
       &.valid
         background-color $darkValidLine
+
+.content
+  overflow hidden


### PR DESCRIPTION
https://trello.com/c/VrbkJKvp/534-bug-sandbox-data-is-displayed-incorrectly-when-select-left-position-in-the-sandbox-on-the-drawersidebar-page-startup