### PR TITLE
feat(backend): Implement proper flushing of redis db, use prefix for redis keys in sharedb

### DIFF
--- a/packages/backend/index.js
+++ b/packages/backend/index.js
@@ -83,9 +83,7 @@ module.exports = async options => {
           // In production we flush redis db once a day using locking in redis itself.
           const redlock = new Redlock([redisClient], {
             driftFactor: 0.01,
-            retryCount: 1,
-            retryDelay: 10,
-            retryJitter: 10
+            retryCount: 0
           })
           const ONE_DAY = 1000 * 60 * 60 * 24
           const LOCK_FLUSH_DB_KEY = 'startupjs_service_flushdb'

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -15,6 +15,7 @@
     "racer": "1.0.0",
     "redis": "^3.1.1",
     "redis-url": "^1.2.0",
+    "redlock": "^4.2.0",
     "sharedb": "^1.0.0",
     "sharedb-hooks": "~4.0.0",
     "sharedb-mongo": "1.0.0-beta.15",


### PR DESCRIPTION
1. Implement locking in redis itself for flushing Redis DB once a day.

    This should improve stability of production when delpoying.

2. Use prefix for ShareDB PubSub in redis.

    This allows having multiple staging apps to use the same Redis DB.

    **IMPORTANT:** backend function now also returns `redisPrefix`. You should use it as a prefix for your lock names if you use `redlock` in your business logic. And for any other redis keys you have in your app/libraries.

This is a NON-BREAKING change, **BUT** in our next release we **should** let people know that they should use `redisPrefix` returned from the `backend()` function in all their redis locks (`redlock`).

@Yska We should also:

1. Refactor `worker` to use `redisPrefix` in `redlock` lock names.
2. Refactor `online-status-tracker` (from our `core`) to pass a `prefix` option to `tracker.init({ ... })`. 

    `redis-online` supports it already: [REF](https://github.com/dmapper/redis-online/blob/master/index.js#L7).

    We should just pass it as something like `{ prefix: redisPrefix + '_online', ... }`. Well, and we need to figure out how get `redisPrefix` from `backend()` result and pass it to the `online-status-tracker` server-side options.