### PR TITLE
feat(deploy): Implement universal docker container for CI/CD to deploy to AKS

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,46 @@
+name: Publish Docker images
+
+on:
+  push:
+    branches:
+      - 'deploy-aks'
+    tags:
+      - 'v*.*.*'
+    # branches:
+    #   - "!*"
+    # tags:
+    #   - "v*"
+
+jobs:
+  deploy-aks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            startupjs/deploy-aks
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action
+        with:
+          context: ./docker/deploy-aks
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -18,12 +18,6 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3
@@ -37,6 +31,12 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v2

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -3,13 +3,9 @@ name: deploy-aks
 on:
   push:
     branches:
-      - 'deploy-aks'
+      - "!*"
     tags:
       - 'v*.*.*'
-    # branches:
-    #   - "!*"
-    # tags:
-    #   - "v*"
 
 jobs:
   deploy-aks:
@@ -30,7 +26,6 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=sha
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v1

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -44,3 +44,4 @@ jobs:
           context: ./docker/deploy-aks
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,4 +1,4 @@
-name: Publish Docker images
+name: deploy-aks
 
 on:
   push:
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Log in to Docker Hub
-        uses: docker/login-action
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -39,7 +39,7 @@ jobs:
             type=sha
 
       - name: Build and push Docker image
-        uses: docker/build-push-action
+        uses: docker/build-push-action@v2
         with:
           context: ./docker/deploy-aks
           push: true

--- a/docker/deploy-aks/Dockerfile
+++ b/docker/deploy-aks/Dockerfile
@@ -1,0 +1,41 @@
+# Build and deploy startupjs app into an opinionated AKS cluster
+#
+# REQUIREMENTS:
+#   a) You have to pass the following env vars:
+#      - AZURE_CREDENTIALS
+#      - APP
+#      - COMMIT_SHA
+#   b) Mount the source code of your app as `/project`
+#      You can configure project path in container by passing env var PROJECT_PATH
+
+# Kaniko binaries are used to build the image
+# ref: https://stackoverflow.com/a/69251129
+FROM gcr.io/kaniko-project/executor:v1.7.0 AS kaniko
+
+# Azure CLI is the main binary so it makes sense to just use as the base image
+FROM mcr.microsoft.com/azure-cli
+
+# Add kaniko to this image by re-using binaries and steps from official image
+COPY --from=kaniko /kaniko/executor /kaniko/executor
+COPY --from=kaniko /kaniko/docker-credential-gcr /kaniko/docker-credential-gcr
+COPY --from=kaniko /kaniko/docker-credential-ecr-login /kaniko/docker-credential-ecr-login
+COPY --from=kaniko /kaniko/docker-credential-acr /kaniko/docker-credential-acr
+COPY --from=kaniko /etc/nsswitch.conf /etc/nsswitch.conf
+COPY --from=kaniko /kaniko/.docker /kaniko/.docker
+ENV PATH $PATH:/kaniko
+ENV DOCKER_CONFIG /kaniko/.docker/
+# ref: https://github.com/GoogleContainerTools/kaniko/issues/1542#issuecomment-853929795
+ENV container docker
+
+WORKDIR /
+
+# Copy the main script with all the commands
+COPY entrypoint.sh /
+
+# Run 'init' step
+RUN ["/bin/sh", "/entrypoint.sh", "init"]
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+# Run all other steps as a batch job to perform the actual deployment
+CMD ["batch"]

--- a/docker/deploy-aks/README.md
+++ b/docker/deploy-aks/README.md
@@ -1,0 +1,75 @@
+# startupjs/deploy-aks
+
+> fully universal docker container to build and deploy the startupjs app to an opinionated AKS cluster.
+
+It uses `kaniko` under the hood to build an image in any `docker` runtime, so you can use docker binary of any CI/CD provider or Kubernetes or your local Docker. It does **NOT** need root or `--privileged` or any other custom configuration, only a regular `docker run` with an ability to pass env vars and mount the source code inside it.
+
+## AKS cluster requirements:
+
+1. You must provide a service principal key `AZURE_CREDENTIALS` which has access to only one resource group which has only one AKS cluster and only one ACR. It doesn't matter how you name them.
+
+2. Deployments which you want to update in this cluster must have the following labels in `metadata.labels`:
+
+    ```
+    managed-by=terraform
+    part-of=${APP}
+    ```
+
+    Replace ${APP} with the name of your app, for example `part-of=myapp`
+
+3. Container name inside the Deployment (`spec.template.spec.containers[0].name`) must be the same as the Deployment name itself (`metadata.name`)
+
+## How to test the build and deploy process:
+
+You can test using your local docker. Just install Docker Desktop if you don't have it yet and then:
+
+1. Save the script below as `test_deploy.sh` in the root of your startupjs project.
+2. Read the source code carefully
+3. Update the required env vars
+4. Make script executable and run it with:
+
+    ```
+    chmod a+x ./test_deploy.sh && ./test_deploy.sh
+    ```
+
+Here is the script:
+
+```sh
+#!/bin/sh
+
+# You must specify the following 3 ENV vars:
+
+# 1. name of your app in kube.
+#     This should match the label `part-of` of the deployment(s)
+APP="myapp"
+
+# 2. service principal json to access the AKS cluster:
+AZURE_CREDENTIALS=$( cat ./keys/cicd_apps_account.json )
+
+# 3. SHA of the git commit:
+COMMIT_SHA="git-commit-sha"
+
+# Run the build and deploy your startupjs app:
+#
+# you have to mount the source code of your app as `/project`
+# OR
+# specify the path to the project source code in container with PROJECT_PATH
+#
+# For example Google Cloud Build mounts code automatically to `/workspace`,
+# so you can pass `PROJECT_PATH=/workspace` to get things working there.
+#
+# When running locally you would just mount your app as a default `/project`
+# and pass all env vars as in the following:
+docker run -ti --rm \
+  -v "${PWD}:/project" \
+  -e "APP=${APP}" \
+  -e "AZURE_CREDENTIALS=${AZURE_CREDENTIALS}" \
+  -e "COMMIT_SHA=${COMMIT_SHA}" \
+  startupjs/deploy-aks
+```
+
+## CI/CD integrations
+
+Since everything is encapsulated into one docker image it's very easy to get this running on any CI/CD provider which supports `docker run` or any other way of running docker containers.
+
+You can find some sample integrations in the `sample-cicd` folder.

--- a/docker/deploy-aks/README.md
+++ b/docker/deploy-aks/README.md
@@ -36,6 +36,7 @@ Here is the script:
 
 ```sh
 #!/bin/sh
+# test_deploy.sh
 
 # You must specify the following 3 ENV vars:
 
@@ -73,3 +74,5 @@ docker run -ti --rm \
 Since everything is encapsulated into one docker image it's very easy to get this running on any CI/CD provider which supports `docker run` or any other way of running docker containers.
 
 You can find some sample integrations in the `sample-cicd` folder.
+
+To integrate with a missing CI/CD provider just get familiar with the `test_deploy.sh` script source code from the previous section.

--- a/docker/deploy-aks/entrypoint.sh
+++ b/docker/deploy-aks/entrypoint.sh
@@ -1,0 +1,318 @@
+#!/bin/sh
+# shellcheck disable=SC2059,SC2236
+
+# Fail script on first failed command
+set -e
+
+# MANUAL:
+#
+# This script runs in 4 stages and relies on a custom docker image
+# based on official azure-cli image (alpine) with 'kaniko' binary on top of it.
+#
+# It supports a batch mode execution as well as a step-by-step execution.
+#
+# BATCH mode:
+#
+#   Just run the the script without sepcifying any param. It will execute
+#   all steps one after another.
+#
+#   Requirements:
+#     a) You have to pass the following env vars:
+#        - AZURE_CREDENTIALS
+#        - APP
+#        - COMMIT_SHA
+#      b) Mount the source code of your app as `/project`
+#         You can configure project path in container by passing env var PROJECT_PATH
+#
+# STEP-BY-STEP mode:
+#
+#   For step by step execution it passes ENV vars from step to step using
+#   a generated intermediary 'vars.sh' file which must be mounted when
+#   running each step.
+#
+#   Since 'init' step is baked into the docker image, you have to execute
+#   the following 3 steps in a sequence:
+#   1. prepare
+#   2. build
+#   3. apply
+#
+# STEPS:
+#
+# 0. init
+#
+#    install all binaries. This is the RUN in Dockerfile of the custom image
+#
+# 1. prepare
+#
+#    obtain all dynamic vars and generate the shell script which exports them
+#
+#    Requirements:
+#      a) You have to pass the following env vars:
+#         - AZURE_CREDENTIALS
+#         - APP
+#         - COMMIT_SHA
+#      b) You have to provide the volume mount for the /tmp/vars folder in the container
+#
+#    Artifacts:
+#      Generates /tmp/vars/vars.sh file (path is customizable with $ENV_VARS_FILE)
+#      which will be reused in the later steps.
+#
+# 2. build
+#
+#    build the app image
+#
+#    Requirements:
+#      a) You have to mount the same folder for /tmp/vars as you did in 'prepare' step
+#      b) Mount the source code of your app as `/project`
+#         You can configure project path in container by passing env var PROJECT_PATH
+#
+# 3. apply
+#
+#    deploy to the opinionated kubernetes cluster
+#
+#    Requirements:
+#      You have to mount the same folder for /tmp/vars as you did in 'prepare' step
+
+# CONSTANTS
+ENV_VARS_FILE=${ENV_VARS_FILE:-"/tmp/vars/vars.sh"}
+PROJECT_PATH=${PROJECT_PATH:-"/project"}
+DOCKERFILE_PATH=${DOCKERFILE_PATH:-"$PROJECT_PATH/Dockerfile"}
+
+# if we are in steps mode we need to pass config from step to step using a temp
+# $ENV_VARS_FILE file
+PASS_ENV="1"
+
+main () {
+  _command=$1
+
+  case "$_command" in
+    "init"    ) run_step_init;;
+    "prepare" ) run_step_prepare;;
+    "build"   ) run_step_build;;
+    "apply"   ) run_step_apply;;
+    "batch"   ) run_batch;;
+    *         ) echo "ERROR! Command '${_command}' not found.";;
+  esac
+
+  # integration_test
+}
+
+# -----------------------------------------------------------------------------
+#   BATCH
+# -----------------------------------------------------------------------------
+
+run_batch () {
+  # in batch mode we don't need to pass config through a temp file
+  PASS_ENV=""
+  _log "validate_batch" && validate_batch
+  # NOTE: run_step_init is executed as RUN when building an image from Dockerfile
+  _step "prepare" && run_step_prepare
+  _step "build" && run_step_build
+  _step "apply" && run_step_apply
+}
+
+validate_batch () {
+  validate_step_prepare
+  validate_step_build
+  validate_step_apply
+}
+
+# -----------------------------------------------------------------------------
+#   Step 0: init
+# -----------------------------------------------------------------------------
+
+run_step_init () {
+  _log "install_generic" && install_generic
+  _log "install_kubectl" && install_kubectl
+}
+
+install_generic () {
+  return 0
+}
+
+install_kubectl () {
+  az aks install-cli
+}
+
+# -----------------------------------------------------------------------------
+#   Step 1: prepare
+# -----------------------------------------------------------------------------
+
+run_step_prepare () {
+  _log "validate_step_prepare" && validate_step_prepare
+  _log "init_primary_variables" && init_primary_variables
+  _log "maybe_login_az" && maybe_login_az
+  _log "init_secondary_variables" && init_secondary_variables
+  maybe_export_env
+}
+
+validate_step_prepare () {
+  if [ ! -n "$AZURE_CREDENTIALS" ]; then echo "AZURE_CREDENTIALS env var is required" && exit 1; fi
+  if [ ! -n "$APP" ]; then echo "APP env var is required" && exit 1; fi
+  if [ ! -n "$COMMIT_SHA" ]; then echo "COMMIT_SHA env var is required" && exit 1; fi
+}
+
+init_primary_variables () {
+  CLIENT_ID=$( _get_json_value 'clientId' )
+  CLIENT_SECRET=$( _get_json_value 'clientSecret' )
+  TENANT_ID=$( _get_json_value 'tenantId' )
+}
+
+maybe_login_az () {
+  if [ -n "$DONE_maybe_login_az" ]; then return 0; fi
+  az login \
+    --service-principal \
+    -u "$CLIENT_ID" \
+    -p "$CLIENT_SECRET" \
+    --tenant "$TENANT_ID"
+  DONE_maybe_login_az="1"
+}
+
+init_secondary_variables () {
+  CLUSTER_NAME=$( az aks list --query '[].name' -o tsv | head -1 )
+  RESOURCE_GROUP_NAME=$( az aks list --query '[].resourceGroup' -o tsv | head -1 )
+  REGISTRY_SERVER=$( az acr list --query '[].loginServer' -o tsv | head -1 )
+}
+
+# -----------------------------------------------------------------------------
+#   Step 2: build
+# -----------------------------------------------------------------------------
+
+run_step_build () {
+  maybe_import_env
+  _log "validate_step_build" && validate_step_build
+  _log "copy_source_code" && copy_source_code
+  _log "build_image_kaniko" && build_image_kaniko
+}
+
+validate_step_build () {
+  if ! which executor; then echo "'executor' binary is not found. Your docker image was probably built incorrectly and doesn't have kaniko binaries." && exit 1; fi
+  if [ ! -d "$PROJECT_PATH" ] || [ -z "$(ls -A "$PROJECT_PATH")" ]; then echo "app folder '$PROJECT_PATH' does not exist or is empty. You've probably forgot to mount it as /project or did not pass a custom PROJECT_PATH env var" && exit 1; fi
+  if [ ! -f "$PROJECT_PATH/Dockerfile" ]; then echo "app Dockerfile was not found at '$DOCKERFILE_PATH'" && exit 1; fi
+}
+
+copy_source_code () {
+  cp -r "$PROJECT_PATH" /_project
+}
+
+build_image_kaniko () {
+  mkdir -p /kaniko/.docker
+  # authorize to registry
+  echo "{\"auths\":{\"${REGISTRY_SERVER}\":{\"auth\":\"$(printf "%s:%s" "${CLIENT_ID}" "${CLIENT_SECRET}" | base64 | tr -d '\n')\"}}}" > /kaniko/.docker/config.json
+  executor \
+    --context /_project \
+    --dockerfile "$DOCKERFILE_PATH" \
+    --destination "${REGISTRY_SERVER}/${APP}:${COMMIT_SHA}" \
+    --destination "${REGISTRY_SERVER}/${APP}:latest"
+}
+
+# -----------------------------------------------------------------------------
+#   Step 3: apply
+# -----------------------------------------------------------------------------
+
+run_step_apply () {
+  maybe_import_env
+  _log "validate_step_apply" && validate_step_apply
+  _log "maybe_login_az" && maybe_login_az
+  _log "login_kubectl" && login_kubectl
+  _log "update_secret" && update_secret
+  _log "update_deployments" && update_deployments
+}
+
+validate_step_apply () {
+  return 0 # dummy. no checks here yet
+}
+
+login_kubectl () {
+  az aks get-credentials --resource-group "$RESOURCE_GROUP_NAME" --name "$CLUSTER_NAME"
+}
+
+update_secret () {
+  _secrets_yaml=$(_get_keyvault_secrets_yaml)
+  echo "$_secrets_yaml" | kubectl apply -f -
+}
+
+# TODO: Refactor to POSIX
+_get_keyvault_secrets_yaml () {
+  _cluster_name_hash=$(printf "$CLUSTER_NAME" | md5sum | awk '{print $1}' | grep -o '.....$')
+  _vault_name="${APP}-${_cluster_name_hash}"
+  for _name in $(az keyvault secret list --vault-name "$_vault_name" --query "[].name" -o tsv); do
+    _value=$(az keyvault secret show --vault-name "$_vault_name" -n "$_name" --query "value" -o tsv)
+    _name=$(echo "$_name" | sed 's/-/_/g')
+    echo "${_name}=${_value}" >> ./secrets.env
+  done
+  # Next command will output the yaml to stdout and we'll catch it outside
+  kubectl create secret generic "$APP" --type=Opaque --from-env-file=./secrets.env --dry-run -o yaml
+  rm ./secrets.env
+}
+
+update_deployments () {
+  for _name in $(kubectl get deployments -l "managed-by=terraform,part-of=${APP}" --no-headers -o custom-columns=":metadata.name"); do
+    kubectl set image "deployment/$_name" "$_name=${REGISTRY_SERVER}/${APP}:${COMMIT_SHA}" --record
+  done
+}
+
+# ----- test -----
+
+integration_test () {
+  az aks list -o table
+  az acr list -o table
+  kubectl get pods
+}
+
+# ----- export/import env vars -----
+#
+# NOTE: This is only used when when executing steps manually.
+#       It's not needed in batch mode at all. That's why in batch mode
+#       we unset the global flag PASS_ENV
+
+maybe_export_env () {
+  if [ ! -n "$PASS_ENV" ]; then return 0; fi
+  mkdir -p "$( dirname "$ENV_VARS_FILE" )"
+  {
+    echo "export CLUSTER_NAME=$CLUSTER_NAME"
+    echo "export RESOURCE_GROUP_NAME=$RESOURCE_GROUP_NAME"
+    echo "export REGISTRY_SERVER=$REGISTRY_SERVER"
+    echo "export CLIENT_ID=$CLIENT_ID"
+    echo "export CLIENT_SECRET=$CLIENT_SECRET"
+    echo "export TENANT_ID=$TENANT_ID"
+    echo "export APP=$APP"
+    echo "export COMMIT_SHA=$COMMIT_SHA"
+  } > "$ENV_VARS_FILE"
+}
+
+maybe_import_env () {
+  if [ ! -n "$PASS_ENV" ]; then return 0; fi
+  if [ ! -f "$ENV_VARS_FILE" ]; then echo "env vars file '$ENV_VARS_FILE' not found" && exit 1; fi
+  # shellcheck source=/dev/null
+  . "$ENV_VARS_FILE"
+  if [ ! -n "$CLUSTER_NAME" ]; then echo "CLUSTER_NAME env var is required" && exit 1; fi
+  if [ ! -n "$RESOURCE_GROUP_NAME" ]; then echo "RESOURCE_GROUP_NAME env var is required" && exit 1; fi
+  if [ ! -n "$REGISTRY_SERVER" ]; then echo "REGISTRY_SERVER env var is required" && exit 1; fi
+  if [ ! -n "$CLIENT_ID" ]; then echo "CLIENT_ID env var is required" && exit 1; fi
+  if [ ! -n "$CLIENT_SECRET" ]; then echo "CLIENT_SECRET env var is required" && exit 1; fi
+  if [ ! -n "$TENANT_ID" ]; then echo "TENANT_ID env var is required" && exit 1; fi
+  if [ ! -n "$APP" ]; then echo "APP env var is required" && exit 1; fi
+  if [ ! -n "$COMMIT_SHA" ]; then echo "COMMIT_SHA env var is required" && exit 1; fi
+}
+
+# ----- helpers -----
+
+_get_json_value () {
+  _key=$1
+  echo "$AZURE_CREDENTIALS" | grep -o "\"${_key}\"[^\"]*\"[^\"]*" | sed -n 's/"[^"]*"[^"]*"//p'
+}
+
+_step () {
+  _message=$1
+  _current_step=${_current_step:-1}
+  printf "\n\033[0;36m[STEP ${_current_step}] ${_message}\033[0m\n\n"
+  _current_step=$((_current_step + 1))
+}
+
+_log () {
+  _message=$1
+  printf "\n\033[0;36m- ${_message}\033[0m\n\n"
+}
+
+main "$@"; exit

--- a/docker/deploy-aks/sample-cicd/github-workflow.yml
+++ b/docker/deploy-aks/sample-cicd/github-workflow.yml
@@ -1,0 +1,27 @@
+# You have to provide as GitHub Secrets:
+# 1. APP - name of your application in kube cluster
+# 2. AZURE_CREDENTIALS - copy from keys/cicd_apps_account.json after running terraform
+
+name: Azure Test
+
+on:
+  push:
+    branches:
+      - production
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      # Check out project under github.workspace
+      - uses: actions/checkout@v2
+      # Deploy using the latest startupjs version of major v0.*.*
+      - uses: docker://startupjs/deploy-aks:0
+        env:
+          APP: ${{ secrets.APP }}
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
+          COMMIT_SHA: ${{ github.sha }}
+          PROJECT_PATH: ${{ github.workspace }}

--- a/docker/deploy-aks/sample-cicd/github-workflow.yml
+++ b/docker/deploy-aks/sample-cicd/github-workflow.yml
@@ -2,7 +2,7 @@
 # 1. APP - name of your application in kube cluster
 # 2. AZURE_CREDENTIALS - copy from keys/cicd_apps_account.json after running terraform
 
-name: Azure Test
+name: deploy-production
 
 on:
   push:
@@ -18,8 +18,13 @@ jobs:
     steps:
       # Check out project under github.workspace
       - uses: actions/checkout@v2
-      # Deploy using the latest startupjs version of major v0.*.*
-      - uses: docker://startupjs/deploy-aks:0
+      # Get version of startupjs from source code
+      - id: version
+        run: |
+          VERSION=$( sed -n 's/.*"startupjs"[^"]*"[^0-9]*\([^"]*\).*/\1/p' < ${{ github.workspace }}/package.json )
+          echo "::set-output name=version::$VERSION"
+      # Deploy using the image version matching startupjs version
+      - uses: docker://startupjs/deploy-aks:${{ steps.version.outputs.version }}
         env:
           APP: ${{ secrets.APP }}
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}


### PR DESCRIPTION
implement a fully universal docker container to build and deploy the startupjs app to an opinionated AKS cluster.

It uses `kaniko` under the hood to build an image in any `docker` runtime, so you can use docker binary of any CI/CD provider or Kubernetes or your local Docker.

## AKS cluster requirements:

1. You must provide a service principal key `AZURE_CREDENTIALS` which has access to only one resource group which has only one AKS cluster and only one ACR. It doesn't matter how you name them.

2. Deployments which you want to update in this cluster must have the following labels in `metadata.labels`:

    ```
    managed-by=terraform
    part-of=${APP}
    ```

    Replace ${APP} with the name of your app, for example `part-of=myapp`

3. Container name inside the Deployment (`spec.template.spec.containers[0].name`) must be the same as the Deployment name itself (`metadata.name`)

## How to manually test the build and deploy process:

You can test using your local docker. Just install Docker Desktop if you don't have it yet and then:

1. Save the script below as `test_deploy.sh` in the root of your startupjs project.
2. Read the source code carefully
3. Update the required env vars
4. Make script executable and run it with:
    
    ```
    chmod a+x ./test_deploy.sh && ./test_deploy.sh
    ```

Here is the script:

```sh
#!/bin/sh

# You must specify the following 3 ENV vars:

# 1. name of your app in kube.
#     This should match the label `part-of` of the deployment(s)
APP="myapp"

# 2. service principal json to access the AKS cluster:
AZURE_CREDENTIALS=$( cat ./keys/cicd_apps_account.json )

# 3. SHA of the git commit:
COMMIT_SHA="git-commit-sha"

# Run the build and deploy your startupjs app:
docker run -ti --rm \
  -v "${PWD}:/project" \
  -e "APP=${APP}" \
  -e "AZURE_CREDENTIALS=${AZURE_CREDENTIALS}" \
  -e "COMMIT_SHA=${COMMIT_SHA}" \
  startupjs/deploy-aks
```