### PR TITLE
feat(backend): support development without mongo or redis installed

### DIFF
--- a/packages/backend/index.js
+++ b/packages/backend/index.js
@@ -11,6 +11,7 @@ const racer = require('racer')
 const redis = require('redis')
 const Redlock = require('redlock')
 const shareDbHooks = require('sharedb-hooks')
+const ShareDBMingo = require('sharedb-mingo-memory')
 const getShareMongo = require('./getShareMongo')
 
 global.__clients = {}
@@ -47,7 +48,7 @@ module.exports = async options => {
   if (options.ee != null) options.ee.emit('storeUse', racer)
 
   // ShareDB Setup
-  const shareMongo = await getShareMongo()
+  const shareMongo = (conf.get('MONGO_URL') && !conf.get('NO_MONGO')) ? await getShareMongo() : new ShareDBMingo()
 
   if (options.pollDebounce) shareMongo.pollDebounce = options.pollDebounce
 

--- a/packages/backend/index.js
+++ b/packages/backend/index.js
@@ -11,7 +11,6 @@ const racer = require('racer')
 const redis = require('redis')
 const Redlock = require('redlock')
 const shareDbHooks = require('sharedb-hooks')
-const ShareDBMingo = require('sharedb-mingo-memory')
 const getShareMongo = require('./getShareMongo')
 
 global.__clients = {}
@@ -48,7 +47,7 @@ module.exports = async options => {
   if (options.ee != null) options.ee.emit('storeUse', racer)
 
   // ShareDB Setup
-  const shareMongo = (conf.get('MONGO_URL') && !conf.get('NO_MONGO')) ? await getShareMongo() : new ShareDBMingo()
+  const shareMongo = (conf.get('MONGO_URL') && !conf.get('NO_MONGO')) ? await getShareMongo() : getMingo()
 
   if (options.pollDebounce) shareMongo.pollDebounce = options.pollDebounce
 
@@ -307,4 +306,9 @@ function simpleNumericHash (source) {
     hash = hash & hash // Convert to 32bit integer
   }
   return hash
+}
+
+function getMingo () {
+  const ShareDBMingo = require('sharedb-mingo-memory')
+  return new ShareDBMingo()
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -17,6 +17,7 @@
     "redlock": "^4.2.0",
     "sharedb": "^1.0.0",
     "sharedb-hooks": "~4.0.0",
+    "sharedb-mingo-memory": "^1.2.0",
     "sharedb-mongo": "1.0.0-beta.15",
     "sharedb-redis-pubsub": "^2.0.1"
   },

--- a/packages/server/server/express.js
+++ b/packages/server/server/express.js
@@ -47,7 +47,7 @@ module.exports = (backend, appRoutes, error, options, done) => {
     }
   }
 
-  const sessionStore = MongoStore.create(connectMongoOptions)
+  const sessionStore = (mongoUrl && !conf.get('NO_MONGO')) ? MongoStore.create(connectMongoOptions) : undefined
 
   const session = expressSession({
     secret: conf.get('SESSION_SECRET'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -14185,6 +14185,11 @@ mingo@^0.2.5:
   dependencies:
     underscore ">=1.5.2"
 
+mingo@^4.1.5:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/mingo/-/mingo-4.4.1.tgz#76ce40f9b7a909d704320cdb0ad2444155a74c12"
+  integrity sha512-aig/3anjeJ8VcXLqDQmB/iO8Z8BVzln2BeWcyeI5NtOiLMAQ5xX00QHX9piy8OBAC9pSDYWErY8MHoh8nlCHig==
+
 mini-create-react-context@^0.4.0:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz#072171561bfdc922da08a60c2197a497cc2d1d5e"
@@ -18318,6 +18323,14 @@ sharedb-hooks@~4.0.0:
   integrity sha512-aEMntx3cB0l/rxxzXvBHa6yPzW/nIKym3TDDY8bZBpX9oB1L/zPYrfCqt3tWgqMCYs8Jin2vIWHRzBRnzbVcmA==
   dependencies:
     lodash "^4.17.10"
+
+sharedb-mingo-memory@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/sharedb-mingo-memory/-/sharedb-mingo-memory-1.2.0.tgz#5b7a14e55e829c2d1881ecda5c0156e78aa9e677"
+  integrity sha512-KXGiSQbhfu+s/q7slBBjQrRaNJ85D4qdK+fOj89TE989A3E3dG4RUEmDpYXQRQmLOeE0ZvfAjmkIH11z344WrQ==
+  dependencies:
+    lodash.clonedeep "^4.5.0"
+    mingo "^4.1.5"
 
 sharedb-mingo@^3.0.7:
   version "3.0.7"


### PR DESCRIPTION
Use mingo if NO_MONGO is passed.

Can now run the app without redis or mongo being installed on the machine by passing `NO_REDIS` and `NO_MONGO` env vars:

```
NO_REDIS=1 NO_MONGO=1 yarn start
```

Note that this is only feasible for development since DB won't persist between server restarts and also without redis you can't horizontally scale server processes.