### PR TITLE
feat(react-sharedb-hooks): Add model-only hooks alternatives for each hook which returns scoped model as a second param. See react-sharedb-hooks readme for documentation.

### DIFF
--- a/packages/react-sharedb-hooks/README.md
+++ b/packages/react-sharedb-hooks/README.md
@@ -320,7 +320,106 @@ const Sidebar = observer(() => {
 render(<Main />, document.body.appendChild(document.createElement('div')))
 ```
 
-### Batching
+### Batching queries
+
+Some hooks are returning data synchronously (like `useLocal`, `useValue`), others will asynchronously query your DB to fetch data (`useDoc`, `useQuery`, `useApi`, etc.).
+
+Sometimes, when the second query depends on the results of the first one, there is no other option but to query them in a chain.
+
+Let's imagine you have a `Game` which stores `playerIds` with an array of `Players` playing it:
+
+```js
+// Lets imagine each query takes 1 seconds to execute.
+observer(function PlayersInGame (gameId) {
+  const [game] = useDoc('games', gameId)
+  // waits until game is fetched from DB (1 second)
+  const [players] = useQueryIds('players', game.playerIds)
+  // waits until players are fetched from DB (1 second)
+  return game.name + ' players: ' + players.map(i => i.name).join(', ')
+})
+```
+
+In the example above we had to:
+
+1. Query the game by id
+2. Wait for it to be fetched from DB and all the way to client - 1 second.
+3. Get `playerIds` from the game and query players
+4. Wait for players to be fetched from DB and all the way to client - 1 second.
+5. Render
+
+Because we did it in a chain we had to wait for 2 seconds total.
+
+Now lets say we change our DB relationship structure between Game and Players from `has-many` to `belongs-to`.
+
+Player documents will now have the `gameId` they belong to which we can use to optimize our querying logic and execute both queries in parallel:
+
+```js
+observer(function PlayersInGame (gameId) {
+  const [game] = useBatchDoc('games', gameId) // remember query but don't execute it yet
+  const [players] = useBatchQueryIds('players', game.playerIds) // remember query but don't execute it yet
+  useBatch() // execute all *Batch queries in parallel
+  // waits until all batched queries fetch their data from DB (1 second)
+  return game.name + ' players: ' + players.map(i => i.name).join(', ')
+})
+```
+
+Hooray! We cut the time to fetch data and render it twice, from 2 seconds to 1 second!
+
+Batching queries can sometimes save time dramatically, especially when you serve users from all around the world and data roundtrip (ping time) from them to your server can be hundreds of milliseconds. Without batching queries wherever possible you might end up with your application taking several seconds until it finally fetches all data in a chain and can render the page.
+
+So please batch queries wherever possible.
+
+### Optimizing rerenders with `$`-hooks
+
+When using 2-way bindings (`@startupjs/ui` provides a lot of such components) you frequently face situations when you need to put something in the model but you don't need to get the data itself. Sometimes you are only interested in passing the model further down to some other component.
+
+Lets say you want to render a simple `Modal` dialog from `@startupjs/ui`. It provides a 2-way binding API for this -- you just need to pass `$value` to it:
+
+```jsx
+import { Modal, Button } from '@startupjs/ui'
+import { observer, useValue } from 'startupjs'
+observer(function SaveChanges () {
+  const [, $visible] = useValue(false)
+  return (
+    <>
+      <Button onPress={() => $visible.set(true)}>Open</Button>
+      <Modal $visible={$visible} title='Confirm'>
+        Are you sure you want to save?
+      </Modal>
+    </>
+  )
+})
+```
+
+In example above we need to make a temporary value and pass it as a 2-way binding to `Modal`. We don't have use for the actual value itself, we only need a scoped model which targets it.
+
+But, even though we just skipped getting the value in the array destructuring, under the hood `react-sharedb` Observable engine still tracks it as being accessed. And whenever the value changes it will trigger rerendering of the whole component.
+
+To optimize such usecases and prevent extra rerenders from happening you should use the same hook with the `$` at the end of its name. It will do exactly the same thing, but will only return the model as a result and it won't trigger access to data through observables.
+
+So to optimize the example above we just need to replace `useValue` with `useValue$` and don't do array destructuring anymore:
+
+```jsx
+import { Modal, Button } from '@startupjs/ui'
+import { observer, useValue$ } from 'startupjs'
+observer(function SaveChanges () {
+  const $visible = useValue$(false)
+  return (
+    <>
+      <Button onPress={() => $visible.set(true)}>Open</Button>
+      <Modal $visible={$visible} title='Confirm'>
+        Are you sure you want to save?
+      </Modal>
+    </>
+  )
+})
+```
+
+`$`-variants of hooks are available for all hooks where they make sense (`useDoc$`, `useBatchDoc$`, `useAsyncDoc$`, `useSession$`, etc.).
+
+Please use `$`-hooks wherever you don't need the actual data but only interested in getting the scoped model. Which happens frequently when you only want to execute some ORM methods or pass this scoped model on to a child component.
+
+### Batching rerenders
 
 By default, React batches updates made in a known method like the lifecycle methods or event handlers, but doesn’t do the same when the updates are within callbacks like in SetTimeout, Promises, etc. This means that if you have multiple calls to update the state, React re-renders the component each time the call is made.
 

--- a/packages/react-sharedb-hooks/lib/hooks/helpers.js
+++ b/packages/react-sharedb-hooks/lib/hooks/helpers.js
@@ -1,6 +1,6 @@
 import { useMemo, useLayoutEffect } from 'react'
 import $root from '@startupjs/model'
-import { useQuery, useLocal, useBatchQuery, useAsyncQuery } from './types.js'
+import { useQuery, useLocal, useBatchQuery, useAsyncQuery, useLocal$ } from './types.js'
 
 export const emit = $root.emit.bind($root)
 
@@ -37,11 +37,16 @@ export function generateUseQueryIds ({ batch, optional } = {}) {
   }
 }
 
+// NOTE: useQueryIds$ doesn't make sense because the returned model simply targets collection,
+//       so instead just a simple useModel(collection) should be used.
 export const useQueryIds = generateUseQueryIds()
 export const useBatchQueryIds = generateUseQueryIds({ batch: true })
 export const useAsyncQueryIds = generateUseQueryIds({ optional: true })
 
-export function generateUseQueryDoc ({ batch, optional } = {}) {
+// NOTE: `useQueryDoc$` does not provide any performance optimizations because it needs to
+//       access data in order to create scoped model.
+//       But it still makes sense to provide it for the sake of keeping the feature parity with `useDoc$`
+export function generateUseQueryDoc ({ batch, optional, modelOnly } = {}) {
   const useFn = batch
     ? useBatchQuery
     : optional
@@ -59,14 +64,22 @@ export function generateUseQueryDoc ({ batch, optional } = {}) {
       },
       [itemId]
     )
-    if (!ready || !itemId) return [undefined, undefined, ready]
-    return [$root.get(`${collection}.${itemId}`), $item, ready]
+    if (!ready || !itemId) {
+      if (modelOnly) return undefined
+      return [undefined, undefined, ready]
+    } else {
+      if (modelOnly) return $item
+      return [$root.get(`${collection}.${itemId}`), $item, ready]
+    }
   }
 }
 
 export const useQueryDoc = generateUseQueryDoc()
+export const useQueryDoc$ = generateUseQueryDoc({ modelOnly: true })
 export const useBatchQueryDoc = generateUseQueryDoc({ batch: true })
+export const useBatchQueryDoc$ = generateUseQueryDoc({ batch: true, modelOnly: true })
 export const useAsyncQueryDoc = generateUseQueryDoc({ optional: true })
+export const useAsyncQueryDoc$ = generateUseQueryDoc({ optional: true, modelOnly: true })
 
 export function useLocalDoc (collection, docId) {
   console.warn(`
@@ -90,20 +103,36 @@ export function useLocalDoc (collection, docId) {
   return useLocal(collection + '.' + docId)
 }
 
-export function useSession (path) {
-  if (typeof path !== 'string') {
-    throw new Error(
-      `[react-sharedb] useSession(): \`path\` must be a String. Got: ${path}`
-    )
+export function generateUseSession ({ modelOnly } = {}) {
+  const useFn = modelOnly
+    ? useLocal$
+    : useLocal
+  return (path) => {
+    if (typeof path !== 'string') {
+      throw new Error(
+        `[react-sharedb] useSession(): \`path\` must be a String. Got: ${path}`
+      )
+    }
+    return useFn('_session' + '.' + path)
   }
-  return useLocal('_session' + '.' + path)
 }
 
-export function usePage (path) {
-  if (typeof path !== 'string') {
-    throw new Error(
-      `[react-sharedb] usePage(): \`path\` must be a String. Got: ${path}`
-    )
+export const useSession = generateUseSession()
+export const useSession$ = generateUseSession({ modelOnly: true })
+
+export function generateUsePage ({ modelOnly } = {}) {
+  const useFn = modelOnly
+    ? useLocal$
+    : useLocal
+  return (path) => {
+    if (typeof path !== 'string') {
+      throw new Error(
+        `[react-sharedb] usePage(): \`path\` must be a String. Got: ${path}`
+      )
+    }
+    return useFn('_page' + '.' + path)
   }
-  return useLocal('_page' + '.' + path)
 }
+
+export const usePage = generateUsePage()
+export const usePage$ = generateUsePage({ modelOnly: true })

--- a/packages/react-sharedb-hooks/lib/hooks/types.js
+++ b/packages/react-sharedb-hooks/lib/hooks/types.js
@@ -31,21 +31,31 @@ const WARNING_MESSAGE = "[react-sharedb] Warning. Item couldn't initialize. " +
   'quickly one after another. Error:'
 
 export const useDoc = generateUseItemOfType(subDoc)
+export const useDoc$ = generateUseItemOfType(subDoc, { modelOnly: true })
 export const useBatchDoc = generateUseItemOfType(subDoc, { batch: true })
+export const useBatchDoc$ = generateUseItemOfType(subDoc, { batch: true, modelOnly: true })
 export const useAsyncDoc = generateUseItemOfType(subDoc, { optional: true })
+export const useAsyncDoc$ = generateUseItemOfType(subDoc, { optional: true, modelOnly: true })
 
+// NOTE: useQuery$ doesn't make sense because the returned model simply targets collection,
+//       so instead just a simple useModel(collection) should be used.
 export const useQuery = generateUseItemOfType(subQuery)
 export const useBatchQuery = generateUseItemOfType(subQuery, { batch: true })
 export const useAsyncQuery = generateUseItemOfType(subQuery, { optional: true })
 
 export const useApi = generateUseItemOfType(subApi)
+export const useApi$ = generateUseItemOfType(subApi, { modelOnly: true })
 export const useBatchApi = generateUseItemOfType(subApi, { batch: true })
+export const useBatchApi$ = generateUseItemOfType(subApi, { batch: true, modelOnly: true })
 export const useAsyncApi = generateUseItemOfType(subApi, { optional: true })
+export const useAsyncApi$ = generateUseItemOfType(subApi, { optional: true, modelOnly: true })
 
 export const useLocal = generateUseItemOfType(subLocal)
+export const useLocal$ = generateUseItemOfType(subLocal, { modelOnly: true })
 export const useValue = generateUseItemOfType(subValue)
+export const useValue$ = generateUseItemOfType(subValue, { modelOnly: true })
 
-function generateUseItemOfType (typeFn, { optional, batch } = {}) {
+function generateUseItemOfType (typeFn, { optional, batch, modelOnly } = {}) {
   const isQuery = typeFn === subQuery
   const takeOriginalModel = typeFn === subDoc || typeFn === subLocal
   const isSync = typeFn === subLocal || typeFn === subValue
@@ -196,25 +206,36 @@ function generateUseItemOfType (typeFn, { optional, batch } = {}) {
       [initsCountRef.current]
     )
 
-    // ----- data -----
+    // if modelOnly was passed, we return just the model.
+    // Using model-only hooks when you don't need data is important for optimization
+    // because it won't trigger extra rerenders when the data itself changes.
+    // And in many situations we don't need the data itself because of 2-way bindings
+    // (when component itself accepts a writable model for one of its attributes)
 
-    // In any situation force access data through the object key to let observer know that the data was accessed
-    const data = $hooks.get()[hookId]
+    if (modelOnly) {
+      return $queryCollection || $model
+    } else {
+      // ----- data -----
 
-    // ----- return -----
+      // In any situation force access data through the object key to let observer know that the data was accessed
+      const data = $hooks.get()[hookId]
 
-    return [
-      initsCountRef.current
-        ? (typeFn === subQuery && isArray(data) ? data.filter(Boolean) : data)
-        : undefined,
+      // ----- return -----
 
-      // Query, QueryExtra: return scoped model to collection path.
-      // Everything else: return the 'hooks.<randomHookId>' scoped model.
-      $queryCollection || $model,
+      return [
+        initsCountRef.current
+          ? (typeFn === subQuery && isArray(data) ? data.filter(Boolean) : data)
+          : undefined,
 
-      // explicit ready flag
-      initsCountRef.current
-    ]
+        // Query, QueryExtra: return scoped model to collection path.
+        // Everything else: return the 'hooks.<randomHookId>' scoped model.
+        // TODO: don't create hooks.* for hooks where we can return an original reference (useDoc, useLocal, etc.)
+        $queryCollection || $model,
+
+        // explicit ready flag, has a second meaning as the inits counter (for each time query params change)
+        initsCountRef.current
+      ]
+    }
   }
 }
 

--- a/packages/react-sharedb-hooks/lib/index.d.ts
+++ b/packages/react-sharedb-hooks/lib/index.d.ts
@@ -42,12 +42,17 @@ export const useBatchQueryIds: <V = any>(collection: string, ids: string[], opti
 export const useAsyncQueryIds: <V = any>(collection: string, ids: string[], options?: {}) => ResultHook<V>;
 
 export const useQueryDoc: <V = any>(collection: string, query: {}) => ResultHook<V>;
+export const useQueryDoc$: (collection: string, query: {}) => any;
 export const useBatchQueryDoc: <V = any>(collection: string, query: {}) => ResultHook<V>;
+export const useBatchQueryDoc$: (collection: string, query: {}) => any;
 export const useAsyncQueryDoc: <V = any>(collection: string, query: {}) => ResultHook<V>;
+export const useAsyncQueryDoc$: (collection: string, query: {}) => any;
 
 export function useLocalDoc<V = any>(collection: string, docId: string): ResultHook<V>;
-export function useSession<V = any>(path: string): ResultHook<V>;
-export function usePage<V = any>(path: string): ResultHook<V>;
+export const useSession: <V = any>(path: string) => ResultHook<V>;
+export const useSession$: (path: string) => any;
+export const usePage: <V = any>(path: string) => ResultHook<V>;
+export const usePage$: (path: string) => any;
 
 export function generateUseQueryDoc<V = any>({ batch, optional }?: {
   batch: boolean;
@@ -74,23 +79,34 @@ export function observer(Component: React.FC<any>, options?: {
 
 // types
 export const useDoc: <V = any>(collection: string, docId: string) => ResultHook<V>;
-export const useBatchDoc: <V = any>(collection: string, docId: string)=> ResultHook<V>;
+export const useDoc$: (collection: string, docId: string) => any;
+export const useBatchDoc: <V = any>(collection: string, docId: string) => ResultHook<V>;
+export const useBatchDoc$: (collection: string, docId: string) => any;
 export const useAsyncDoc: <V = any>(collection: string, docId: string) => ResultHook<V>;
+export const useAsyncDoc$: (collection: string, docId: string) => any;
 
 export const useQuery: <V = any>(collection: string, query: {}) => ResultHook<V>;
 export const useBatchQuery: <V = any>(collection: string, query: {}) => ResultHook<V>;
 export const useAsyncQuery: <V = any>(collection: string, query: {}) => ResultHook<V>;
 
 export function useApi<V = any> (path: string, fn: Function, inputs?: any[], options?: {}): ResultHook<V>;
+export function useApi$ (path: string, fn: Function, inputs?: any[], options?: {}): any;
 export function useApi<V = any> (fn: Function, inputs?: any[], options?: {}): ResultHook<V>;
+export function useApi$ (fn: Function, inputs?: any[], options?: {}): any;
 
 export function useBatchApi<V = any> (path: string, fn: Function, inputs?: any[], options?: {}): ResultHook<V>;
+export function useBatchApi$ (path: string, fn: Function, inputs?: any[], options?: {}): any;
 export function useBatchApi<V = any> (fn: Function, inputs?: any[], options?: {}): ResultHook<V>;
+export function useBatchApi$ (fn: Function, inputs?: any[], options?: {}): any;
 
 export function useAsyncApi<V = any> (path: string, fn: Function, inputs?: any[], options?: {}): ResultHook<V>;
+export function useAsyncApi$ (path: string, fn: Function, inputs?: any[], options?: {}): any;
 export function useAsyncApi<V = any> (fn: Function, inputs?: any[], options?: {}): ResultHook<V>;
+export function useAsyncApi$ (fn: Function, inputs?: any[], options?: {}): any;
 
 export const useLocal: <V = any>(path: string) => ResultHook<V>;
+export const useLocal$: (path: string) => any;
 export const useValue: <V = any>(value?: V) => ResultHook<V>;
+export const useValue$: <V = any>(value?: V) => any;
 
 export function useBatch (): void;


### PR DESCRIPTION
`$`-hooks are the same as regular hooks, but they return only the model and nothing else. They also DON'T trigger Observables engine which prevents react components from re-rendering whenever the actual data changes.

## Example

### Before (we skip `visible` value but it will still rerender the component when it changes):

```jsx
import { Modal, Button } from '@startupjs/ui'
import { observer, useValue } from 'startupjs'
observer(function SaveChanges () {
  const [, $visible] = useValue(false) // this leads to extra re-renderings
  return (
    <>
      <Button onPress={() => $visible.set(true)}>Open</Button>
      <Modal $visible={$visible} title='Confirm'>
        Are you sure you want to save?
      </Modal>
    </>
  )
})
```

### After (get only the model, no extra rerenderings):

```jsx
import { Modal, Button } from '@startupjs/ui'
import { observer, useValue$ } from 'startupjs'
observer(function SaveChanges () {
  const $visible = useValue$(false) // no re-rendering here anymore
  return (
    <>
      <Button onPress={() => $visible.set(true)}>Open</Button>
      <Modal $visible={$visible} title='Confirm'>
        Are you sure you want to save?
      </Modal>
    </>
  )
})
```

`$`-hooks are available for all hooks where it makes sense. Including `*Batch` and `*Async` hooks.