### PR TITLE
feat(react-sharedb-hooks): implement caching system for styles and scoped models

### DIFF
--- a/packages/app/client/helpers/useNeedUpdate.js
+++ b/packages/app/client/helpers/useNeedUpdate.js
@@ -3,19 +3,10 @@ import { useDoc } from 'startupjs'
 
 const OS = Platform.OS
 
-let resolved
-
-const promise = new Promise(resolve => {
-  setTimeout(() => {
-    resolved = true
-    resolve()
-  }, 1000)
-})
-
 export default function useNeedUpdate (criticalVersion) {
-  if (!resolved) throw promise
   const [, $version] = useDoc('service', 'version')
   const newOsVersion = $version.get(`criticalVersion.${OS}`)
   const currentOsVersion = criticalVersion && criticalVersion[OS]
+
   return currentOsVersion < newOsVersion
 }

--- a/packages/app/client/helpers/useNeedUpdate.js
+++ b/packages/app/client/helpers/useNeedUpdate.js
@@ -14,9 +14,7 @@ const promise = new Promise(resolve => {
 
 export default function useNeedUpdate (criticalVersion) {
   if (!resolved) throw promise
-  console.log('>>> useNeedUpdate')
-  const [version, $version] = useDoc('service', 'version')
-  console.log('>>>>>>> GOT DATA', { $version, version })
+  const [, $version] = useDoc('service', 'version')
   const newOsVersion = $version.get(`criticalVersion.${OS}`)
   const currentOsVersion = criticalVersion && criticalVersion[OS]
   return currentOsVersion < newOsVersion

--- a/packages/app/client/helpers/useNeedUpdate.js
+++ b/packages/app/client/helpers/useNeedUpdate.js
@@ -3,10 +3,21 @@ import { useDoc } from 'startupjs'
 
 const OS = Platform.OS
 
+let resolved
+
+const promise = new Promise(resolve => {
+  setTimeout(() => {
+    resolved = true
+    resolve()
+  }, 1000)
+})
+
 export default function useNeedUpdate (criticalVersion) {
-  const [, $version] = useDoc('service', 'version')
+  if (!resolved) throw promise
+  console.log('>>> useNeedUpdate')
+  const [version, $version] = useDoc('service', 'version')
+  console.log('>>>>>>> GOT DATA', { $version, version })
   const newOsVersion = $version.get(`criticalVersion.${OS}`)
   const currentOsVersion = criticalVersion && criticalVersion[OS]
-
   return currentOsVersion < newOsVersion
 }

--- a/packages/app/client/index.js
+++ b/packages/app/client/index.js
@@ -95,7 +95,7 @@ const App = observer(function AppComponent ({
     if user && user.blocked
       if renderBlocked
         = renderBlocked(Blocked)
-      else 
+      else
         Blocked
     else
       Suspense(fallback=null)

--- a/packages/auth-linkedin/package.json
+++ b/packages/auth-linkedin/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "@fortawesome/free-brands-svg-icons": "^5.12.0",
-    "bcrypt": "^4.0.1",
+    "bcrypt": "^5.0.1",
     "passport-linkedin-oauth2": "^2.0.0",
     "qs": "^6.9.3"
   },

--- a/packages/auth-local/package.json
+++ b/packages/auth-local/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@hapi/joi": "^17.1.1",
     "@startupjs/recaptcha": "^0.42.0",
-    "bcrypt": "^4.0.1",
+    "bcrypt": "^5.0.1",
     "passport-local": "^1.0.0"
   },
   "peerDependencies": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -10,7 +10,7 @@
   "scripts": {},
   "license": "MIT",
   "dependencies": {
-    "bcrypt": "^4.0.1",
+    "bcrypt": "^5.0.1",
     "js-cookie": "^2.2.1",
     "lodash": "^4.17.20",
     "passport": "^0.4.1"

--- a/packages/babel-plugin-rn-stylename-to-style/__tests__/__snapshots__/index.spec.js.snap
+++ b/packages/babel-plugin-rn-stylename-to-style/__tests__/__snapshots__/index.spec.js.snap
@@ -364,6 +364,146 @@ function Test({ style, active, submit, disabled, titleStyle }) {
 
 `;
 
+exports[`@startupjs/babel-plugin-rn-stylename-to-style Failed test 1: Failed test 1 1`] = `
+
+import { observer, useBackPress } from 'startupjs'
+
+function Layout ({ style, children }) {
+  return (
+    <SafeAreaView styleName='root' style={style}>
+      <StatusBar
+        backgroundColor={bgColor}
+        barStyle='dark-content'
+      >
+        {children}
+      </StatusBar>
+    </SafeAreaView>
+  )
+}
+
+export default observer(Layout)
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { observer, useBackPress } from "startupjs";
+import { process as _processStyleName } from "@startupjs/babel-plugin-rn-stylename-to-style/process";
+
+function Layout({ style, children }) {
+  return (
+    <SafeAreaView
+      {..._processStyleName(
+        "root",
+        {},
+        typeof __CSS_GLOBAL__ !== "undefined" && __CSS_GLOBAL__,
+        typeof __CSS_LOCAL__ !== "undefined" && __CSS_LOCAL__,
+        {
+          style: style,
+        }
+      )}
+    >
+      <StatusBar backgroundColor={bgColor} barStyle="dark-content">
+        {children}
+      </StatusBar>
+    </SafeAreaView>
+  );
+}
+
+export default observer(Layout);
+
+
+`;
+
+exports[`@startupjs/babel-plugin-rn-stylename-to-style Failed test 2: Failed test 2 1`] = `
+
+import { observer, useBackPress } from 'startupjs'
+
+function Menu ({ style, children, value, variant, activeBorder, iconPosition, activeColor, ...props }) {
+  return (
+    <Context.Provider value={value}>
+      <Div style={style} />
+      <Div
+        style={style}
+        styleName={['root', [variant]]}
+        {...props}
+      >{children}</Div>
+    </Context.Provider>
+  )
+}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { observer, useBackPress } from "startupjs";
+import { process as _processStyleName } from "@startupjs/babel-plugin-rn-stylename-to-style/process";
+
+function Menu({
+  style,
+  children,
+  value,
+  variant,
+  activeBorder,
+  iconPosition,
+  activeColor,
+  ...props
+}) {
+  return (
+    <Context.Provider value={value}>
+      <Div
+        {..._processStyleName(
+          "",
+          {},
+          typeof __CSS_GLOBAL__ !== "undefined" && __CSS_GLOBAL__,
+          typeof __CSS_LOCAL__ !== "undefined" && __CSS_LOCAL__,
+          {
+            style: style,
+          }
+        )}
+      />
+      <Div
+        {...props}
+        {..._processStyleName(
+          ["root", [variant]],
+          {},
+          typeof __CSS_GLOBAL__ !== "undefined" && __CSS_GLOBAL__,
+          typeof __CSS_LOCAL__ !== "undefined" && __CSS_LOCAL__,
+          {
+            style: style,
+          }
+        )}
+      >
+        {children}
+      </Div>
+    </Context.Provider>
+  );
+}
+
+
+`;
+
+exports[`@startupjs/babel-plugin-rn-stylename-to-style No styles file: No styles file 1`] = `
+
+function Test () {
+  return <div styleName='root' />
+}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+function Test() {
+  return (
+    <div
+      {..._processStyleName(
+        "root",
+        {},
+        typeof __CSS_GLOBAL__ !== "undefined" && __CSS_GLOBAL__,
+        typeof __CSS_LOCAL__ !== "undefined" && __CSS_LOCAL__,
+        {}
+      )}
+    />
+  );
+}
+
+
+`;
+
 exports[`@startupjs/babel-plugin-rn-stylename-to-style Puts compiled attribute to the end of attributes list: Puts compiled attribute to the end of attributes list 1`] = `
 
 import './index.styl'
@@ -570,6 +710,128 @@ function Test() {
       >
         Submit
       </button>
+    </div>
+  );
+}
+
+
+`;
+
+exports[`@startupjs/babel-plugin-rn-stylename-to-style Style with observer. Should transform for caching: Style with observer. Should transform for caching 1`] = `
+
+import { observer } from 'startupjs'
+export default observer(function Test () {
+  return (
+    <div style={{ backgroundColor: 'red' }}>
+      <div style={{ color: 'green' }} titleStyle={{ color: 'blue' }} />
+      <div>
+        <span headerStyle={{ color: 'yellow' }}>Hello</span>
+      </div>
+    </div>
+  )
+})
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { observer } from "startupjs";
+import { process as _processStyleName } from "@startupjs/babel-plugin-rn-stylename-to-style/process";
+export default observer(function Test() {
+  return (
+    <div
+      {..._processStyleName(
+        "",
+        {},
+        typeof __CSS_GLOBAL__ !== "undefined" && __CSS_GLOBAL__,
+        typeof __CSS_LOCAL__ !== "undefined" && __CSS_LOCAL__,
+        {
+          style: {
+            backgroundColor: "red",
+          },
+        }
+      )}
+    >
+      <div
+        {..._processStyleName(
+          "",
+          {},
+          typeof __CSS_GLOBAL__ !== "undefined" && __CSS_GLOBAL__,
+          typeof __CSS_LOCAL__ !== "undefined" && __CSS_LOCAL__,
+          {
+            style: {
+              color: "green",
+            },
+            titleStyle: {
+              color: "blue",
+            },
+          }
+        )}
+      />
+      <div>
+        <span
+          {..._processStyleName(
+            "",
+            {},
+            typeof __CSS_GLOBAL__ !== "undefined" && __CSS_GLOBAL__,
+            typeof __CSS_LOCAL__ !== "undefined" && __CSS_LOCAL__,
+            {
+              headerStyle: {
+                color: "yellow",
+              },
+            }
+          )}
+        >
+          Hello
+        </span>
+      </div>
+    </div>
+  );
+});
+
+
+`;
+
+exports[`@startupjs/babel-plugin-rn-stylename-to-style Style without observer. Shouldn't transform: Style without observer. Shouldn't transform 1`] = `
+
+import { useLocal } from 'startupjs'
+function Test () {
+  return (
+    <div style={{ backgroundColor: 'red' }}>
+      <div style={{ color: 'green' }} titleStyle={{ color: 'blue' }} />
+      <div>
+        <span headerStyle={{ color: 'yellow' }}>Hello</span>
+      </div>
+    </div>
+  )
+}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { useLocal } from "startupjs";
+
+function Test() {
+  return (
+    <div
+      style={{
+        backgroundColor: "red",
+      }}
+    >
+      <div
+        style={{
+          color: "green",
+        }}
+        titleStyle={{
+          color: "blue",
+        }}
+      />
+      <div>
+        <span
+          headerStyle={{
+            color: "yellow",
+          }}
+        >
+          Hello
+        </span>
+      </div>
     </div>
   );
 }

--- a/packages/babel-plugin-rn-stylename-to-style/__tests__/index.spec.js
+++ b/packages/babel-plugin-rn-stylename-to-style/__tests__/index.spec.js
@@ -15,6 +15,71 @@ pluginTester({
     plugins: ['@babel/plugin-syntax-jsx']
   },
   tests: {
+    'Failed test 2': /* js */`
+      import { observer, useBackPress } from 'startupjs'
+
+      function Menu ({ style, children, value, variant, activeBorder, iconPosition, activeColor, ...props }) {
+        return (
+          <Context.Provider value={value}>
+            <Div style={style} />
+            <Div
+              style={style}
+              styleName={['root', [variant]]}
+              {...props}
+            >{children}</Div>
+          </Context.Provider>
+        )
+      }
+    `,
+    'Failed test 1': /* js */`
+      import { observer, useBackPress } from 'startupjs'
+
+      function Layout ({ style, children }) {
+        return (
+          <SafeAreaView styleName='root' style={style}>
+            <StatusBar
+              backgroundColor={bgColor}
+              barStyle='dark-content'
+            >
+              {children}
+            </StatusBar>
+          </SafeAreaView>
+        )
+      }
+
+      export default observer(Layout)
+    `,
+    'No styles file': /* js */`
+      function Test () {
+        return <div styleName='root' />
+      }
+    `,
+    'Style without observer. Shouldn\'t transform': /* js */`
+      import { useLocal } from 'startupjs'
+      function Test () {
+        return (
+          <div style={{ backgroundColor: 'red' }}>
+            <div style={{ color: 'green' }} titleStyle={{ color: 'blue' }} />
+            <div>
+              <span headerStyle={{ color: 'yellow' }}>Hello</span>
+            </div>
+          </div>
+        )
+      }
+    `,
+    'Style with observer. Should transform for caching': /* js */`
+      import { observer } from 'startupjs'
+      export default observer(function Test () {
+        return (
+          <div style={{ backgroundColor: 'red' }}>
+            <div style={{ color: 'green' }} titleStyle={{ color: 'blue' }} />
+            <div>
+              <span headerStyle={{ color: 'yellow' }}>Hello</span>
+            </div>
+          </div>
+        )
+      })
+    `,
     'Regular string': /* js */`
       import './index.styl'
       function Test () {

--- a/packages/babel-plugin-rn-stylename-to-style/index.cjs
+++ b/packages/babel-plugin-rn-stylename-to-style/index.cjs
@@ -7,6 +7,9 @@ const STYLE_NAME_REGEX = /(?:^s|S)tyleName$/
 const STYLE_REGEX = /(?:^s|S)tyle$/
 const ROOT_STYLE_PROP_NAME = 'style'
 
+const GLOBAL_OBSERVER_LIBRARY = 'startupjs'
+const GLOBAL_OBSERVER_DEFAULT_NAME = 'observer'
+
 const { GLOBAL_NAME, LOCAL_NAME } = require('./constants.cjs')
 
 const buildSafeVar = template.expression(`
@@ -28,6 +31,7 @@ const buildJsonParse = template(`
 module.exports = function (babel) {
   let styleHash = {}
   let cssIdentifier
+  let hasObserver
   let $program
 
   function getStyleFromExpression (expression, state) {
@@ -115,13 +119,15 @@ module.exports = function (babel) {
   }
 
   function handleStyleNames (jsxOpeningElementPath, state) {
-    if (!styleHash[ROOT_STYLE_PROP_NAME]) return
-    const styleName = styleHash[ROOT_STYLE_PROP_NAME].styleName
-    const partStyle = styleHash[ROOT_STYLE_PROP_NAME].partStyle
+    if (!Object.keys(styleHash).length) return
+    const styleName = styleHash[ROOT_STYLE_PROP_NAME]?.styleName
+    const partStyle = styleHash[ROOT_STYLE_PROP_NAME]?.partStyle
     const inlineStyles = []
 
-    // Don't process this element if neither styleName or part found.
-    if (!styleName && !partStyle) return
+    // Always process if 'observer' import is found in the file
+    // which is needed for styles caching.
+    // Otherwise, if no 'observer' found and no 'styleName' or 'part' found then skip
+    if (!(hasObserver || styleName || partStyle)) return
 
     // Check if styleName exists and if it can be processed
     if (styleName != null) {
@@ -249,6 +255,7 @@ module.exports = function (babel) {
     post () {
       styleHash = {}
       cssIdentifier = undefined
+      hasObserver = undefined
       $program = undefined
     },
     visitor: {
@@ -280,6 +287,8 @@ module.exports = function (babel) {
         }
       },
       ImportDeclaration: ($this, state) => {
+        if (!hasObserver) hasObserver = checkObserverImport($this)
+
         const extensions =
           Array.isArray(state.opts.extensions) &&
           state.opts.extensions
@@ -365,7 +374,9 @@ module.exports = function (babel) {
           const convertedName = convertStyleName(name)
           if (!styleHash[convertedName]) styleHash[convertedName] = {}
           styleHash[convertedName].styleName = $this
-        } else if (STYLE_REGEX.test(name)) {
+        // Some react-native built-in stuff might have props like 'barStyle' which
+        // is a string. We skip those.
+        } else if (STYLE_REGEX.test(name) && !$this.get('value').isStringLiteral()) {
           if (!styleHash[name]) styleHash[name] = {}
           styleHash[name].style = $this
         } else if (name === 'part') {
@@ -468,5 +479,17 @@ function buildDynamicPart (expr, part) {
     )
   } else {
     return expr
+  }
+}
+
+function checkObserverImport ($import, {
+  observerLibrary = GLOBAL_OBSERVER_LIBRARY,
+  observerDefaultName = GLOBAL_OBSERVER_DEFAULT_NAME
+} = {}) {
+  if ($import.node.source.value !== observerLibrary) return
+  for (const $specifier of $import.get('specifiers')) {
+    if (!$specifier.isImportSpecifier()) continue
+    const { imported } = $specifier.node
+    if (imported.name === observerDefaultName) return true
   }
 }

--- a/packages/babel-plugin-rn-stylename-to-style/matcher.js
+++ b/packages/babel-plugin-rn-stylename-to-style/matcher.js
@@ -43,7 +43,7 @@ export default function matcher (
 function appendStyleProps (target, appendProps) {
   for (const propName in appendProps) {
     if (target[propName]) {
-      if (isArray(target[propName])) {
+      if (isArray(appendProps[propName])) {
         target[propName] = target[propName].concat(appendProps[propName])
       } else {
         target[propName].push(appendProps[propName])
@@ -56,9 +56,7 @@ function appendStyleProps (target, appendProps) {
 
 // Process all styles, including the ::part() ones.
 function getStyleProps (htmlClasses, styles, legacyRootOnly) {
-  const res = {
-    [ROOT_STYLE_PROP_NAME]: []
-  }
+  const res = {}
   for (const selector in styles) {
     // Find out which part (or root) this selector is targeting
     const match = selector.match(PART_REGEX)

--- a/packages/babel-plugin-rn-stylename-to-style/package.json
+++ b/packages/babel-plugin-rn-stylename-to-style/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@babel/template": "^7.4.0",
     "@babel/types": "^7.0.0",
+    "@startupjs/cache": "^0.42.6",
     "@nx-js/observer-util": "^4.1.3",
     "react-native-dynamic-style-processor": "^0.21.0"
   },

--- a/packages/babel-plugin-rn-stylename-to-style/process.js
+++ b/packages/babel-plugin-rn-stylename-to-style/process.js
@@ -1,8 +1,12 @@
 import { process as dynamicProcess } from 'react-native-dynamic-style-processor/src/index.js'
+import { singletonMemoize } from '@startupjs/cache'
 import dimensions from './dimensions.js'
 import matcher from './matcher.js'
 
-export function process (
+// IMPORTANT:
+//   The args of this function affect the cache setup in @startupjs/react-sharedb-util/cache/styles.js
+//   So if you change it then you also have to change the cache there.
+export const process = singletonMemoize(function _process (
   styleName,
   fileStyles,
   globalStyles,
@@ -16,7 +20,9 @@ export function process (
   return matcher(
     styleName, fileStyles, globalStyles, localStyles, inlineStyleProps
   )
-}
+}, {
+  cacheName: 'styles'
+})
 
 function hasMedia (styles) {
   for (const selector in styles) {

--- a/packages/babel-plugin-rn-stylename-to-style/process.js
+++ b/packages/babel-plugin-rn-stylename-to-style/process.js
@@ -21,7 +21,14 @@ export const process = singletonMemoize(function _process (
     styleName, fileStyles, globalStyles, localStyles, inlineStyleProps
   )
 }, {
-  cacheName: 'styles'
+  cacheName: 'styles',
+  normalizer: (styleName, fileStyles, globalStyles, localStyles, inlineStyleProps) => simpleNumericHash(JSON.stringify([
+    styleName,
+    fileStyles?.__hash__ || fileStyles,
+    globalStyles?.__hash__ || globalStyles,
+    localStyles?.__hash__ || localStyles,
+    inlineStyleProps
+  ]))
 })
 
 function hasMedia (styles) {
@@ -47,4 +54,10 @@ function transformStyles (styles) {
   } else {
     return {}
   }
+}
+
+// ref: https://gist.github.com/hyamamoto/fd435505d29ebfa3d9716fd2be8d42f0?permalink_comment_id=2694461#gistcomment-2694461
+function simpleNumericHash (s) {
+  for (var i = 0, h = 0; i < s.length; i++) h = Math.imul(31, h) + s.charCodeAt(i) | 0
+  return h
 }

--- a/packages/babel-plugin-rn-stylename-to-style/test/matcher.mjs
+++ b/packages/babel-plugin-rn-stylename-to-style/test/matcher.mjs
@@ -6,7 +6,7 @@ function p ({ styleName, fileStyles, globalStyles, localStyles, inlineStyleProps
   if (!legacy) inlineStyleProps = inlineStyleProps || {}
   return matcher(
     styleName,
-    css2rn.default(fileStyles, { parseMediaQueries: true, parsePartSelectors: true }),
+    fileStyles && css2rn.default(fileStyles, { parseMediaQueries: true, parsePartSelectors: true }),
     globalStyles && css2rn.default(globalStyles, { parseMediaQueries: true, parsePartSelectors: true }),
     localStyles && css2rn.default(localStyles, { parseMediaQueries: true, parsePartSelectors: true }),
     inlineStyleProps
@@ -142,6 +142,32 @@ describe('Root styles only', () => {
       cardStyle: {
         marginRight: 10
       }
+    })
+  })
+  it('empty everything. Pipe inline styles only', () => {
+    assert.deepStrictEqual(p({
+      styleName: '',
+      inlineStyleProps: {
+        style: {
+          marginLeft: 10
+        }
+      }
+    }), {
+      style: {
+        marginLeft: 10
+      }
+    })
+  })
+  it('pass inline styles as is if it\'s a string', () => {
+    assert.deepStrictEqual(p({
+      styleName: '',
+      inlineStyleProps: {
+        style: 'my-magic-style',
+        barStyle: 'magic-bar-style'
+      }
+    }), {
+      style: 'my-magic-style',
+      barStyle: 'magic-bar-style'
     })
   })
   it('multiple classes', () => {

--- a/packages/babel-plugin-startupjs-debug/.gitignore
+++ b/packages/babel-plugin-startupjs-debug/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+yarn-error.log
+.coverage
+.idea
+package-lock.json

--- a/packages/babel-plugin-startupjs-debug/README.md
+++ b/packages/babel-plugin-startupjs-debug/README.md
@@ -1,0 +1,53 @@
+# @startupjs/babel-plugin-startupjs-debug
+
+Additional transformations for development and debugging
+
+## Usage
+
+For internal usage only.
+
+### Options
+
+```js
+// defaults
+{
+  fixObserverHotReloading: true,
+  addFilenamesToObserver: true
+}
+```
+
+## Example
+
+fix hot reloading of observer() and add filename
+
+```jsx
+import { observer } from 'startupjs'
+
+export default observer(function Main ({ title }) {
+  return <span>Hello</span>
+}, { forwardRef: true, suspenseProps: { loader: <span>Loading</span> } })
+```
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+```jsx
+import { observer } from "startupjs";
+export default observer.__wrapObserverMeta(
+  observer.__makeObserver(
+    function Main({ title }) {
+      return <span>Hello</span>;
+    },
+    {
+      forwardRef: true,
+      suspenseProps: {
+        loader: <span>Loading</span>,
+      },
+      filename: "/ws/dummy-project/component.js",
+    }
+  )
+);
+```
+
+## Licence
+
+MIT

--- a/packages/babel-plugin-startupjs-debug/__tests__/__snapshots__/index.spec.js.snap
+++ b/packages/babel-plugin-startupjs-debug/__tests__/__snapshots__/index.spec.js.snap
@@ -1,0 +1,187 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`@startupjs/babel-plugin-startupjs-debug Advanced. Multiple components, with options and with another name: Advanced. Multiple components, with options and with another name 1`] = `
+
+import { observer as myObserver } from 'startupjs'
+
+export default myObserver(function Main ({ title }) {
+  return <span>Hello</span>
+})
+
+const Sub = myObserver(function ({ title }) {
+  return <span>Hello</span>
+})
+
+const Sub2 = myObserver(({ title }) => {
+  console.log(/)/.test(title)) // Test for ) here
+  return <span>Hello</span>
+}, { forwardRef: true, suspenseProps: { loader: <span>Loading</span> } })
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { observer as myObserver } from "startupjs";
+export default myObserver.__wrapObserverMeta(
+  myObserver.__makeObserver(
+    function Main({ title }) {
+      return <span>Hello</span>;
+    },
+    {
+      filename: "/ws/dummy-project/component.js",
+    }
+  )
+);
+
+const Sub = myObserver.__wrapObserverMeta(
+  myObserver.__makeObserver(
+    function ({ title }) {
+      return <span>Hello</span>;
+    },
+    {
+      filename: "/ws/dummy-project/component.js",
+    }
+  )
+);
+
+const Sub2 = myObserver.__wrapObserverMeta(
+  myObserver.__makeObserver(
+    ({ title }) => {
+      console.log(/)/.test(title)); // Test for ) here
+
+      return <span>Hello</span>;
+    },
+    {
+      forwardRef: true,
+      suspenseProps: {
+        loader: <span>Loading</span>,
+      },
+      filename: "/ws/dummy-project/component.js",
+    }
+  )
+);
+
+
+`;
+
+exports[`@startupjs/babel-plugin-startupjs-debug Advanced. With options: Advanced. With options 1`] = `
+
+import { observer } from 'startupjs'
+
+export default observer(function Main ({ title }) {
+  return <span>Hello</span>
+}, { forwardRef: true, suspenseProps: { loader: <span>Loading</span> } })
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { observer } from "startupjs";
+export default observer.__wrapObserverMeta(
+  observer.__makeObserver(
+    function Main({ title }) {
+      return <span>Hello</span>;
+    },
+    {
+      forwardRef: true,
+      suspenseProps: {
+        loader: <span>Loading</span>,
+      },
+      filename: "/ws/dummy-project/component.js",
+    }
+  )
+);
+
+
+`;
+
+exports[`@startupjs/babel-plugin-startupjs-debug Doesn't execute without magic observer import: Doesn't execute without magic observer import 1`] = `
+
+import { observer } from 'foobar'
+
+export default observer(() => {})
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { observer } from "foobar";
+export default observer(() => {});
+
+
+`;
+
+exports[`@startupjs/babel-plugin-startupjs-debug Simple. Default export with extra parens in code: Simple. Default export with extra parens in code 1`] = `
+
+import { observer } from 'startupjs'
+
+export default observer(function Main ({ title }) {
+  console.log(/)/.test(title)) // Test for ) here
+  return <span>Hello</span>
+})
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { observer } from "startupjs";
+export default observer.__wrapObserverMeta(
+  observer.__makeObserver(
+    function Main({ title }) {
+      console.log(/)/.test(title)); // Test for ) here
+
+      return <span>Hello</span>;
+    },
+    {
+      filename: "/ws/dummy-project/component.js",
+    }
+  )
+);
+
+
+`;
+
+exports[`@startupjs/babel-plugin-startupjs-debug Simple. Default export: Simple. Default export 1`] = `
+
+import { observer } from 'startupjs'
+
+export default observer(function Main () {
+  return <span>Hello</span>
+})
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { observer } from "startupjs";
+export default observer.__wrapObserverMeta(
+  observer.__makeObserver(
+    function Main() {
+      return <span>Hello</span>;
+    },
+    {
+      filename: "/ws/dummy-project/component.js",
+    }
+  )
+);
+
+
+`;
+
+exports[`@startupjs/babel-plugin-startupjs-debug Simple. Export named const: Simple. Export named const 1`] = `
+
+import { observer } from 'startupjs'
+
+export const Main = observer(({ title }) => {
+  console.log(/)/.test(title)) // Test for ) here
+  return <span>Hello</span>
+})
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { observer } from "startupjs";
+export const Main = observer.__wrapObserverMeta(
+  observer.__makeObserver(
+    ({ title }) => {
+      console.log(/)/.test(title)); // Test for ) here
+
+      return <span>Hello</span>;
+    },
+    {
+      filename: "/ws/dummy-project/component.js",
+    }
+  )
+);
+
+
+`;

--- a/packages/babel-plugin-startupjs-debug/__tests__/index.spec.js
+++ b/packages/babel-plugin-startupjs-debug/__tests__/index.spec.js
@@ -1,0 +1,70 @@
+const pluginTester = require('babel-plugin-tester').default
+const plugin = require('../index')
+const { name: pluginName } = require('../package.json')
+
+pluginTester({
+  plugin,
+  pluginName,
+  snapshot: true,
+  babelOptions: {
+    plugins: ['@babel/plugin-syntax-jsx']
+  },
+  pluginOptions: {
+    __test__: {
+      filename: '/ws/dummy-project/component.js'
+    }
+  },
+  tests: {
+    'Doesn\'t execute without magic observer import': /* js */`
+      import { observer } from 'foobar'
+
+      export default observer(() => {})
+    `,
+    'Simple. Default export': /* js */`
+      import { observer } from 'startupjs'
+
+      export default observer(function Main () {
+        return <span>Hello</span>
+      })
+    `,
+    'Simple. Default export with extra parens in code': /* js */`
+      import { observer } from 'startupjs'
+
+      export default observer(function Main ({ title }) {
+        console.log(/)/.test(title)) // Test for ) here
+        return <span>Hello</span>
+      })
+    `,
+    'Simple. Export named const': /* js */`
+      import { observer } from 'startupjs'
+
+      export const Main = observer(({ title }) => {
+        console.log(/)/.test(title)) // Test for ) here
+        return <span>Hello</span>
+      })
+    `,
+    'Advanced. With options': /* js */`
+      import { observer } from 'startupjs'
+
+      export default observer(function Main ({ title }) {
+        return <span>Hello</span>
+      }, { forwardRef: true, suspenseProps: { loader: <span>Loading</span> } })
+    `,
+    'Advanced. Multiple components, with options and with another name': /* js */`
+      import { observer as myObserver } from 'startupjs'
+
+      export default myObserver(function Main ({ title }) {
+        return <span>Hello</span>
+      })
+
+      const Sub = myObserver(function ({ title }) {
+        return <span>Hello</span>
+      })
+
+      const Sub2 = myObserver(({ title }) => {
+        console.log(/)/.test(title)) // Test for ) here
+        return <span>Hello</span>
+      }, { forwardRef: true, suspenseProps: { loader: <span>Loading</span> } })
+    `
+  }
+})

--- a/packages/babel-plugin-startupjs-debug/index.js
+++ b/packages/babel-plugin-startupjs-debug/index.js
@@ -7,7 +7,7 @@
 const template = require('@babel/template').default
 const t = require('@babel/types')
 
-const GLOBAL_MAGIC_LIBRARY = 'startupjs'
+const GLOBAL_OBSERVER_LIBRARY = 'startupjs'
 const GLOBAL_OBSERVER_DEFAULT_NAME = 'observer'
 
 const buildFixedObserver = template(`
@@ -56,10 +56,10 @@ module.exports = function (babel, opts) {
 }
 
 function maybeGetObserverName ($import, {
-  magicLibrary = GLOBAL_MAGIC_LIBRARY,
+  observerLibrary = GLOBAL_OBSERVER_LIBRARY,
   observerDefaultName = GLOBAL_OBSERVER_DEFAULT_NAME
 } = {}) {
-  if ($import.node.source.value !== magicLibrary) return
+  if ($import.node.source.value !== observerLibrary) return
   for (const $specifier of $import.get('specifiers')) {
     if (!$specifier.isImportSpecifier()) continue
     const { local, imported } = $specifier.node

--- a/packages/babel-plugin-startupjs-debug/index.js
+++ b/packages/babel-plugin-startupjs-debug/index.js
@@ -1,0 +1,96 @@
+/**
+ * replace:
+ *   observer(...)
+ * with:
+ *   observer.__wrapObserverMeta(observer.__makeObserver(...))
+ */
+const template = require('@babel/template').default
+const t = require('@babel/types')
+
+const GLOBAL_MAGIC_LIBRARY = 'startupjs'
+const GLOBAL_OBSERVER_DEFAULT_NAME = 'observer'
+
+const buildFixedObserver = template(`
+  %%observer%%.__wrapObserverMeta(%%observer%%.__makeObserver(%%args%%))
+`)
+
+module.exports = function (babel, opts) {
+  opts = {
+    fixObserverHotReloading: true,
+    addFilenamesToObserver: true,
+    ...opts
+  }
+  let OBSERVER_NAME
+  let FILENAME
+
+  const earlyVisitor = {
+    ImportDeclaration ($this) {
+      if ((opts.fixObserverHotReloading || opts.addFilenamesToObserver) && !OBSERVER_NAME) {
+        OBSERVER_NAME = maybeGetObserverName($this)
+      }
+    },
+    CallExpression ($this) {
+      if ((opts.fixObserverHotReloading || opts.addFilenamesToObserver) && OBSERVER_NAME) {
+        maybeReplaceObserver($this, {
+          observerName: OBSERVER_NAME,
+          filename: FILENAME,
+          fixObserverHotReloading: opts.fixObserverHotReloading,
+          addFilenamesToObserver: opts.addFilenamesToObserver
+        })
+      }
+    }
+  }
+
+  return {
+    pre () {
+      OBSERVER_NAME = undefined
+      FILENAME = undefined
+    },
+    visitor: {
+      Program ($this, state) {
+        FILENAME = state.file?.opts?.filename || opts.__test__?.filename
+        $this.traverse(earlyVisitor)
+      }
+    }
+  }
+}
+
+function maybeGetObserverName ($import, {
+  magicLibrary = GLOBAL_MAGIC_LIBRARY,
+  observerDefaultName = GLOBAL_OBSERVER_DEFAULT_NAME
+} = {}) {
+  if ($import.node.source.value !== magicLibrary) return
+  for (const $specifier of $import.get('specifiers')) {
+    if (!$specifier.isImportSpecifier()) continue
+    const { local, imported } = $specifier.node
+    if (imported.name === observerDefaultName) return local.name
+  }
+}
+
+function maybeReplaceObserver ($callExpression, {
+  observerName,
+  filename = 'ERROR_NON_IDENTIFIABLE',
+  fixObserverHotReloading,
+  addFilenamesToObserver
+}) {
+  const $callee = $callExpression.get('callee')
+  if (!($callee.isIdentifier() && $callee.node.name === observerName)) return
+  if (addFilenamesToObserver) {
+    const args = $callExpression.node.arguments
+    let object
+    if (t.isObjectExpression(args[1])) {
+      object = args[1]
+    } else {
+      object = t.objectExpression([])
+      args.push(object)
+    }
+    object.properties.push(t.objectProperty(t.identifier('filename'), t.stringLiteral(filename)))
+  }
+  if (fixObserverHotReloading) {
+    const $newObserver = buildFixedObserver({
+      observer: $callExpression.get('callee').node,
+      args: $callExpression.node.arguments
+    })
+    $callExpression.replaceWith($newObserver)
+  }
+}

--- a/packages/babel-plugin-startupjs-debug/package.json
+++ b/packages/babel-plugin-startupjs-debug/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@startupjs/babel-plugin-startupjs-debug",
+  "version": "0.42.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "description": "Additional transformations for development and debugging",
+  "keywords": [
+    "babel",
+    "babel-plugin",
+    "startupjs",
+    "debug"
+  ],
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "author": "Pavel Zhukov",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/startupjs/startupjs"
+  },
+  "files": [
+    "index.js",
+    "README.md"
+  ],
+  "devDependencies": {
+    "@babel/plugin-syntax-jsx": "^7.0.0",
+    "@babel/template": "^7.4.0",
+    "@babel/types": "^7.4.0",
+    "babel-plugin-tester": "^9.1.0",
+    "jest": "^26.0.1"
+  }
+}

--- a/packages/babel-plugin-startupjs-utils/.gitignore
+++ b/packages/babel-plugin-startupjs-utils/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+yarn-error.log
+.coverage
+.idea
+package-lock.json

--- a/packages/babel-plugin-startupjs-utils/README.md
+++ b/packages/babel-plugin-startupjs-utils/README.md
@@ -1,0 +1,15 @@
+# @startupjs/babel-plugin-startupjs-utils
+
+Additional transformations for startupjs configs and other stuff
+
+## Usage
+
+For internal usage only.
+
+## Features
+
+1. Enables observer-level caching of styles and model if `observerCache` is passed in babel options
+
+## Licence
+
+MIT

--- a/packages/babel-plugin-startupjs-utils/__tests__/__snapshots__/index.spec.js.snap
+++ b/packages/babel-plugin-startupjs-utils/__tests__/__snapshots__/index.spec.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`@startupjs/babel-plugin-startupjs-utils Get cache value from options: Get cache value from options 1`] = `
+
+import cacheEnabled from '@startupjs/cache/enabled'
+import { __increment, __decrement } from '@startupjs/debug'
+
+export const CACHE_ACTIVE = { value: cacheEnabled }
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { __increment, __decrement } from "@startupjs/debug";
+const cacheEnabled = true;
+export const CACHE_ACTIVE = {
+  value: cacheEnabled,
+};
+
+
+`;
+
+exports[`@startupjs/babel-plugin-startupjs-utils Use default cache value if nothing is set in options: Use default cache value if nothing is set in options 1`] = `
+
+import cacheEnabled from '@startupjs/cache/enabled'
+import { __increment, __decrement } from '@startupjs/debug'
+
+export const CACHE_ACTIVE = { value: cacheEnabled }
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { __increment, __decrement } from "@startupjs/debug";
+const cacheEnabled = false;
+export const CACHE_ACTIVE = {
+  value: cacheEnabled,
+};
+
+
+`;

--- a/packages/babel-plugin-startupjs-utils/__tests__/index.spec.js
+++ b/packages/babel-plugin-startupjs-utils/__tests__/index.spec.js
@@ -1,0 +1,41 @@
+const pluginTester = require('babel-plugin-tester').default
+const plugin = require('../index')
+const { name: pluginName } = require('../package.json')
+
+pluginTester({
+  plugin,
+  pluginName,
+  snapshot: true,
+  babelOptions: {
+    plugins: ['@babel/plugin-syntax-jsx']
+  },
+  pluginOptions: {},
+  tests: {
+    'Use default cache value if nothing is set in options': /* js */`
+      import cacheEnabled from '@startupjs/cache/enabled'
+      import { __increment, __decrement } from '@startupjs/debug'
+
+      export const CACHE_ACTIVE = { value: cacheEnabled }
+    `
+  }
+})
+
+pluginTester({
+  plugin,
+  pluginName,
+  snapshot: true,
+  babelOptions: {
+    plugins: ['@babel/plugin-syntax-jsx']
+  },
+  pluginOptions: {
+    observerCache: true
+  },
+  tests: {
+    'Get cache value from options': /* js */`
+      import cacheEnabled from '@startupjs/cache/enabled'
+      import { __increment, __decrement } from '@startupjs/debug'
+
+      export const CACHE_ACTIVE = { value: cacheEnabled }
+    `
+  }
+})

--- a/packages/babel-plugin-startupjs-utils/index.js
+++ b/packages/babel-plugin-startupjs-utils/index.js
@@ -1,0 +1,63 @@
+const template = require('@babel/template').default
+const t = require('@babel/types')
+
+const GLOBAL_CACHE_ENABLED_LIBRARY = '@startupjs/cache/enabled'
+
+const buildConst = template(`
+  const %%variable%% = %%value%%
+`)
+
+module.exports = function (babel, opts) {
+  opts.observerCache = (opts.observerCache != null ? opts.observerCache : false)
+  let $program
+  let handledCache
+
+  return {
+    pre () {
+      $program = undefined
+      handledCache = undefined
+    },
+    visitor: {
+      Program ($this) {
+        $program = $this
+      },
+      ImportDeclaration ($this) {
+        if (!handledCache) {
+          const local = maybeGetCacheEnabledIdentifier($this)
+          if (local) {
+            insertAfterImports($program, buildConst({
+              variable: local,
+              value: t.booleanLiteral(opts.observerCache)
+            }))
+            $this.remove()
+            handledCache = true
+          }
+        }
+      }
+    }
+  }
+}
+
+function maybeGetCacheEnabledIdentifier ($import, {
+  cacheEnabledLibrary = GLOBAL_CACHE_ENABLED_LIBRARY
+} = {}) {
+  if ($import.node.source.value !== cacheEnabledLibrary) return
+  for (const $specifier of $import.get('specifiers')) {
+    if (!$specifier.isImportDefaultSpecifier()) continue
+    const { local } = $specifier.node
+    return local
+  }
+}
+
+function insertAfterImports ($program, expressionStatement) {
+  const lastImport = $program
+    .get('body')
+    .filter($i => $i.isImportDeclaration())
+    .pop()
+
+  if (lastImport) {
+    lastImport.insertAfter(expressionStatement)
+  } else {
+    $program.unshift(expressionStatement)
+  }
+}

--- a/packages/babel-plugin-startupjs-utils/package.json
+++ b/packages/babel-plugin-startupjs-utils/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@startupjs/babel-plugin-startupjs-utils",
+  "version": "0.42.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "description": "Additional transformations for startupjs configs and other stuff",
+  "keywords": [
+    "babel",
+    "babel-plugin",
+    "startupjs",
+    "utils"
+  ],
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "author": "Pavel Zhukov",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/startupjs/startupjs"
+  },
+  "files": [
+    "index.js",
+    "README.md"
+  ],
+  "devDependencies": {
+    "@babel/plugin-syntax-jsx": "^7.0.0",
+    "@babel/template": "^7.4.0",
+    "@babel/types": "^7.4.0",
+    "babel-plugin-tester": "^9.1.0",
+    "jest": "^26.0.1"
+  }
+}

--- a/packages/babel-preset-startupjs/index.js
+++ b/packages/babel-preset-startupjs/index.js
@@ -86,6 +86,7 @@ const CONFIG_NATIVE_DEVELOPMENT = {
     [require('./metroPresetWithTypescript')]
   ],
   plugins: [
+    [require('@startupjs/babel-plugin-startupjs-debug')],
     dotenvPlugin(),
     nativeReactCssModulesPlatformExtensionsPlugin(),
     ...nativeReactCssModulesPlugins(),
@@ -118,6 +119,7 @@ const CONFIG_WEB_UNIVERSAL_DEVELOPMENT = {
     // [require('./metroPresetWithTypescript')]
   ],
   plugins: [
+    // [require('@startupjs/babel-plugin-startupjs-debug')],
     [require('react-refresh/babel'), { skipEnvCheck: true }],
     dotenvPlugin({ mockBaseUrl: true }),
     ...nativeReactCssModulesPlugins({ platform: 'web' }),
@@ -174,6 +176,7 @@ const CONFIG_WEB_PURE_DEVELOPMENT = {
     // [require('./metroPresetWithTypescript')]
   ],
   plugins: [
+    [require('@startupjs/babel-plugin-startupjs-debug')],
     [require('react-refresh/babel'), { skipEnvCheck: true }],
     dotenvPlugin({ mockBaseUrl: true }),
     webReactCssModulesPlugin(),

--- a/packages/babel-preset-startupjs/index.js
+++ b/packages/babel-preset-startupjs/index.js
@@ -119,7 +119,7 @@ const CONFIG_WEB_UNIVERSAL_DEVELOPMENT = {
     // [require('./metroPresetWithTypescript')]
   ],
   plugins: [
-    // [require('@startupjs/babel-plugin-startupjs-debug')],
+    [require('@startupjs/babel-plugin-startupjs-debug')],
     [require('react-refresh/babel'), { skipEnvCheck: true }],
     dotenvPlugin({ mockBaseUrl: true }),
     ...nativeReactCssModulesPlugins({ platform: 'web' }),

--- a/packages/babel-preset-startupjs/index.js
+++ b/packages/babel-preset-startupjs/index.js
@@ -15,7 +15,10 @@ const DIRECTORY_ALIASES = {
   appConstants: './appConstants'
 }
 
-const basePlugins = ({ alias } = {}) => [
+const basePlugins = ({ alias, observerCache } = {}) => [
+  [require('@startupjs/babel-plugin-startupjs-utils'), {
+    observerCache
+  }],
   [require('babel-plugin-module-resolver'), {
     alias: {
       ...DIRECTORY_ALIASES,

--- a/packages/babel-preset-startupjs/package.json
+++ b/packages/babel-preset-startupjs/package.json
@@ -23,6 +23,7 @@
     "@babel/plugin-transform-runtime": "^7.0.0",
     "@babel/plugin-transform-typescript": "^7.5.0",
     "@babel/runtime": "^7.9.0",
+    "@startupjs/babel-plugin-startupjs-debug": "^0.42.0",
     "@startupjs/babel-plugin-dotenv": "^0.42.0",
     "@startupjs/babel-plugin-i18n-extract": "^0.42.0",
     "@startupjs/babel-plugin-import-to-react-lazy": "^0.42.0",

--- a/packages/babel-preset-startupjs/package.json
+++ b/packages/babel-preset-startupjs/package.json
@@ -24,6 +24,7 @@
     "@babel/plugin-transform-typescript": "^7.5.0",
     "@babel/runtime": "^7.9.0",
     "@startupjs/babel-plugin-startupjs-debug": "^0.42.0",
+    "@startupjs/babel-plugin-startupjs-utils": "^0.42.0",
     "@startupjs/babel-plugin-dotenv": "^0.42.0",
     "@startupjs/babel-plugin-i18n-extract": "^0.42.0",
     "@startupjs/babel-plugin-import-to-react-lazy": "^0.42.0",

--- a/packages/backend/getRedis.js
+++ b/packages/backend/getRedis.js
@@ -64,14 +64,8 @@ module.exports = function getRedis () {
 
   return { client, observer, prefix: PREFIX }
 }
-// ref: https://stackoverflow.com/a/8831937
-function simpleNumericHash (source) {
-  let hash = 0
-  if (source.length === 0) return hash
-  for (let i = 0; i < source.length; i++) {
-    const char = source.charCodeAt(i)
-    hash = ((hash << 5) - hash) + char
-    hash = hash & hash // Convert to 32bit integer
-  }
-  return hash
+// ref: https://gist.github.com/hyamamoto/fd435505d29ebfa3d9716fd2be8d42f0?permalink_comment_id=2694461#gistcomment-2694461
+function simpleNumericHash (s) {
+  for (var i = 0, h = 0; i < s.length; i++) h = Math.imul(31, h) + s.charCodeAt(i) | 0
+  return h
 }

--- a/packages/bundler/lib/cssToReactNativeLoader.js
+++ b/packages/bundler/lib/cssToReactNativeLoader.js
@@ -9,6 +9,8 @@ module.exports = function cssToReactNative (source) {
   for (const key in cssObject.__exportProps || {}) {
     cssObject[key] = parseStylValue(cssObject.__exportProps[key])
   }
+  // save hash to use with the caching system of @startupjs/cache
+  cssObject.__hash__ = simpleNumericHash(JSON.stringify(cssObject))
   return 'module.exports = ' + JSON.stringify(cssObject)
 }
 
@@ -75,4 +77,10 @@ function escapeExport (source) {
   source = source.slice(0, start) + properties + source.slice(end)
 
   return source
+}
+
+// ref: https://gist.github.com/hyamamoto/fd435505d29ebfa3d9716fd2be8d42f0?permalink_comment_id=2694461#gistcomment-2694461
+function simpleNumericHash (s) {
+  for (var i = 0, h = 0; i < s.length; i++) h = Math.imul(31, h) + s.charCodeAt(i) | 0
+  return h
 }

--- a/packages/bundler/lib/rnTransformer.js
+++ b/packages/bundler/lib/rnTransformer.js
@@ -7,7 +7,6 @@ const stylusToCssLoader = require('./stylusToCssLoader')
 const cssToReactNativeLoader = require('./cssToReactNativeLoader')
 const mdxExamplesLoader = require('./mdxExamplesLoader')
 const mdxLoader = require('./mdxLoader')
-const replaceObserverLoader = require('./replaceObserverLoader')
 const callLoader = require('./callLoader')
 
 module.exports.transform = function ({ src, filename, options = {} }) {
@@ -24,10 +23,6 @@ module.exports.transform = function ({ src, filename, options = {} }) {
   } else if (/\.svg$/.test(filename)) {
     return svgTransformer.transform({ src, filename, options })
   } else if (/\.[cm]?jsx?$/.test(filename) && /['"]startupjs['"]/.test(src)) {
-    // Fix Fast Refresh to work with observer() decorator.
-    // For details view ./replaceObserverLoader.js
-    src = src.replace(/(?:\/\*(?:[\s\S]*?)\*\/)|(?:^\s*\/\/(?:.*)$)/gm, '')
-    src = callLoader(replaceObserverLoader, src, filename)
     return upstreamTransformer.transform({ src, filename, options })
   } else if (/\.mdx?$/.test(filename)) {
     src = callLoader(mdxExamplesLoader, src, filename)

--- a/packages/bundler/webpack.web.config.js
+++ b/packages/bundler/webpack.web.config.js
@@ -1,6 +1,6 @@
 const { getPluginConfigs } = require('@startupjs/plugin/manager.cjs')
+const { getLocalIdent } = require('@startupjs/babel-plugin-react-css-modules/utils')
 const pickBy = require('lodash/pickBy')
-const pick = require('lodash/pick')
 const fs = require('fs')
 const path = require('path')
 const AssetsPlugin = require('assets-webpack-plugin')
@@ -10,7 +10,6 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin')
 const { LOCAL_IDENT_NAME } = require('babel-preset-startupjs/constants')
 const autoprefixer = require('autoprefixer')
-const { getLocalIdent } = require('@startupjs/babel-plugin-react-css-modules/utils')
 const DEV_PORT = ~~process.env.DEV_PORT || 3010
 const PROD = !process.env.WEBPACK_DEV
 const STYLES_PATH = path.join(process.cwd(), '/styles/index.styl')
@@ -19,7 +18,6 @@ const BUILD_PATH = path.join(process.cwd(), BUILD_DIR)
 const BUNDLE_NAME = 'main'
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin')
 const webpack = require('webpack')
-const { getJsxRule } = require('./helpers')
 const DEFAULT_MODE = 'react-native'
 const PLUGINS = getPluginConfigs()
 
@@ -187,36 +185,30 @@ module.exports = function getConfig (env, {
     module: {
       rules: [
         {
-          test: getJsxRule().test,
+          test: /\.[mc]?[jt]sx?$/,
           resolve: {
             fullySpecified: false
           },
           exclude: /node_modules/,
           use: [
-            pick(getJsxRule(), ['loader', 'options']),
-            {
-              loader: require.resolve('./lib/replaceObserverLoader.js')
-            }
+            { loader: 'babel-loader' }
           ]
         },
         {
-          test: getJsxRule().test,
+          test: /\.[mc]?[jt]sx?$/,
           resolve: {
             fullySpecified: false
           },
           include: new RegExp(`node_modules/(?:react-native-(?!web)|${forceCompileModules.join('|')})`),
           use: [
-            pick(getJsxRule(), ['loader', 'options']),
-            {
-              loader: require.resolve('./lib/replaceObserverLoader.js')
-            }
+            { loader: 'babel-loader' }
           ]
         },
         {
           test: /\.mdx?$/,
           exclude: /node_modules/,
           use: [
-            pick(getJsxRule(), ['loader', 'options']),
+            { loader: 'babel-loader' },
             {
               loader: '@mdx-js/loader'
             },
@@ -279,7 +271,7 @@ module.exports = function getConfig (env, {
               }
             }
           ] : [
-            pick(getJsxRule(), ['loader', 'options']),
+            { loader: 'babel-loader' },
             {
               loader: require.resolve('./lib/cssToReactNativeLoader.js')
             },
@@ -308,7 +300,7 @@ module.exports = function getConfig (env, {
               }
             }
           ] : [
-            pick(getJsxRule(), ['loader', 'options']),
+            { loader: 'babel-loader' },
             {
               loader: require.resolve('./lib/cssToReactNativeLoader.js')
             }

--- a/packages/cache/.eslintrc.json
+++ b/packages/cache/.eslintrc.json
@@ -1,0 +1,26 @@
+{
+  "root": true,
+  "env": {
+    "browser": true,
+    "es6": true,
+    "node": true,
+    "mocha": true
+  },
+  "extends": [
+    "standard"
+  ],
+  "globals": {
+    "Atomics": "readonly",
+    "SharedArrayBuffer": "readonly"
+  },
+  "parserOptions": {
+    "ecmaFeatures": {
+      "legacyDecorators": false,
+      "jsx": false
+    },
+    "ecmaVersion": 6,
+    "sourceType": "module"
+  },
+  "plugins": [],
+  "rules": {}
+}

--- a/packages/cache/.gitignore
+++ b/packages/cache/.gitignore
@@ -1,0 +1,23 @@
+.DS_Store
+*.swp
+*.log
+.idea
+.history
+.vscode
+npm-*
+coverage
+
+# Deps
+/node_modules/
+/bower_components/
+
+# App
+/build/
+/public/js/minified/
+/public/img/sprites/
+
+# Temp
+/tmp/
+
+# Tests
+test/shots/*

--- a/packages/cache/.npmignore
+++ b/packages/cache/.npmignore
@@ -1,0 +1,31 @@
+# Some packagers (like React Native) try to use .babelrc from node_modules.
+# So we need to ignore it to prevent unnecessary compilation and errors.
+.babelrc
+
+# ###########################################
+# Everything from .gitignore (except of compiled /lib/) below:
+# ###########################################
+
+.DS_Store
+*.swp
+*.log
+.idea
+.history
+.vscode
+npm-*
+coverage
+
+# Deps
+/node_modules/
+/bower_components/
+
+# App
+/build/
+/public/js/minified/
+/public/img/sprites/
+
+# Temp
+/tmp/
+
+# Tests
+test/shots/*

--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -8,6 +8,14 @@ This is used to establish auto-caching (memoization) of styles and `model.at()`,
 
 For internal use only.
 
+By default the cache is enabled. To disable it everywhere do this:
+
+```js
+import { CACHE_ACTIVE } from '@startupjs/cache'
+
+CACHE_ACTIVE.value = false
+```
+
 ## Licence
 
 MIT

--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -1,0 +1,15 @@
+# startupjs cache
+
+> Helpers for caching.
+
+This is used to establish auto-caching (memoization) of styles and `model.at()`, `model.scope()` in React components context
+
+## Usage
+
+For internal use only.
+
+## Licence
+
+MIT
+
+(c) Decision Mapper - http://decisionmapper.com

--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -8,13 +8,7 @@ This is used to establish auto-caching (memoization) of styles and `model.at()`,
 
 For internal use only.
 
-By default the cache is enabled. To disable it everywhere do this:
-
-```js
-import { CACHE_ACTIVE } from '@startupjs/cache'
-
-CACHE_ACTIVE.value = false
-```
+To enable cache in a startupjs project, pass `cache: true` option to the `startupjs` preset in babel config.
 
 ## Licence
 

--- a/packages/cache/enabled.js
+++ b/packages/cache/enabled.js
@@ -1,0 +1,3 @@
+// this is a dummy file. The value here gets replaced by babel with
+// the value of `cache` option of the `babel-preset-startupjs`
+export default false

--- a/packages/cache/index.js
+++ b/packages/cache/index.js
@@ -12,12 +12,12 @@
  */
 import { __increment, __decrement } from '@startupjs/debug'
 
-export const DEBUG_CACHE_ACTIVE = true
+export const CACHE_ACTIVE = { value: true }
 
 const activeCaches = {}
 
 export function createCaches (cacheNames) {
-  if (!DEBUG_CACHE_ACTIVE) return { activate: () => {}, deactivate: () => {}, clear: () => {} }
+  if (!CACHE_ACTIVE.value) return { activate: () => {}, deactivate: () => {}, clear: () => {} }
   if (!cacheNames) throw Error(ERROR_NO_CACHE_NAMES)
   if (typeof cacheNames === 'string') cacheNames = [cacheNames]
   let caches = {}
@@ -63,7 +63,7 @@ export function singletonMemoize (
     nestedThis = false
   } = {}
 ) {
-  if (!(DEBUG_CACHE_ACTIVE && active)) return fn
+  if (!(CACHE_ACTIVE.value && active)) return fn
   if (!cacheName) throw Error(ERROR_NO_CACHE_NAME)
 
   function getFromCache (cache, args) {

--- a/packages/cache/index.js
+++ b/packages/cache/index.js
@@ -10,10 +10,13 @@
  *
  * IMPORTANT: You must do cache.clear() when you don't need it anymore otherwise you'll have HUGE memory leaks
  */
-import { __increment, __decrement } from '@startupjs/debug'
+import cacheEnabled from '@startupjs/cache/enabled'
+import { __increment, __decrement, setDebugVar } from '@startupjs/debug'
 
 // global setting to disable cache
-export const CACHE_ACTIVE = { value: true }
+export const CACHE_ACTIVE = { value: cacheEnabled }
+
+setDebugVar('cacheEnabled', cacheEnabled)
 
 // a global semaphore used to temporarily block cache
 const BLOCK_CACHE = { value: false }

--- a/packages/cache/index.js
+++ b/packages/cache/index.js
@@ -12,9 +12,12 @@
  */
 import { __increment, __decrement } from '@startupjs/debug'
 
+export const DEBUG_CACHE_ACTIVE = true
+
 const activeCaches = {}
 
 export function createCaches (cacheNames) {
+  if (!DEBUG_CACHE_ACTIVE) return { activate: () => {}, clear: () => {} }
   if (!cacheNames) throw Error(ERROR_NO_CACHE_NAMES)
   if (typeof cacheNames === 'string') cacheNames = [cacheNames]
   let caches = {}
@@ -40,7 +43,8 @@ export function createCaches (cacheNames) {
   }
 }
 
-export function singletonMemoize (fn, { cacheName, normalizer = defaultNormalizer } = {}) {
+export function singletonMemoize (fn, { cacheName, active = true, normalizer = defaultNormalizer } = {}) {
+  if (!(DEBUG_CACHE_ACTIVE && active)) return fn
   if (!cacheName) throw Error(ERROR_NO_CACHE_NAME)
   return (...args) => {
     if (!activeCaches[cacheName]) return fn(...args)

--- a/packages/cache/index.js
+++ b/packages/cache/index.js
@@ -1,0 +1,60 @@
+/**
+ * Caching system for memoized functions which keeps track of which cache is currently active
+ * (singleton cache) and uses the active cache in the memoized function
+ *
+ * Algorithm works the following way:
+ *   1. initially observer() wrapper creates a new cache for the 'styles' singletonName just for the current component
+ *   2. this will replace the previous active 'styles' cache with the new one
+ *   3. memoized function has to specify which singleton cache it uses
+ *   4. whenever observer() re-renders the component next time it will re-activate its cache
+ *
+ * IMPORTANT: You must do cache.clear() when you don't need it anymore otherwise you'll have HUGE memory leaks
+ */
+import { __increment, __decrement } from '@startupjs/debug'
+
+const activeCaches = {}
+
+export function createCaches (cacheNames) {
+  if (!cacheNames) throw Error(ERROR_NO_CACHE_NAMES)
+  if (typeof cacheNames === 'string') cacheNames = [cacheNames]
+  let caches = {}
+  for (const cacheName of cacheNames) {
+    caches[cacheName] = {}
+    __increment(`cache.${cacheName}`)
+  }
+  return {
+    activate () {
+      if (!caches) return console.error(ERROR_CACHE_CLEARED)
+      for (const cacheName of cacheNames) activeCaches[cacheName] = caches[cacheName]
+    },
+    clear () {
+      if (!caches) return console.error(ERROR_CACHE_CLEARED)
+      for (const cacheName of cacheNames) {
+        for (const i in caches[cacheName]) delete caches[cacheName][i]
+        if (activeCaches[cacheName] === caches[cacheName]) activeCaches[cacheName] = undefined
+        delete caches[cacheName]
+        __decrement(`cache.${cacheName}`)
+      }
+      caches = undefined
+    }
+  }
+}
+
+export function singletonMemoize (fn, { cacheName, normalizer = defaultNormalizer } = {}) {
+  if (!cacheName) throw Error(ERROR_NO_CACHE_NAME)
+  return (...args) => {
+    if (!activeCaches[cacheName]) return fn(...args)
+    const id = normalizer(...args)
+    // eslint-disable-next-line no-prototype-builtins
+    if (activeCaches[cacheName].hasOwnProperty(id)) return activeCaches[cacheName][id]
+    return (activeCaches[cacheName][id] = fn(...args))
+  }
+}
+
+function defaultNormalizer (...args) {
+  return JSON.stringify(args)
+}
+
+const ERROR_CACHE_CLEARED = 'WARNING! Cache was already cleared. This should never happen'
+const ERROR_NO_CACHE_NAME = '[react-sharedb-util/cache/createCaches] You must specify the cache singleton names'
+const ERROR_NO_CACHE_NAMES = '[react-sharedb-util/cache/memoize] You must specify the cache singleton name'

--- a/packages/cache/index.js
+++ b/packages/cache/index.js
@@ -17,7 +17,7 @@ export const DEBUG_CACHE_ACTIVE = true
 const activeCaches = {}
 
 export function createCaches (cacheNames) {
-  if (!DEBUG_CACHE_ACTIVE) return { activate: () => {}, clear: () => {} }
+  if (!DEBUG_CACHE_ACTIVE) return { activate: () => {}, deactivate: () => {}, clear: () => {} }
   if (!cacheNames) throw Error(ERROR_NO_CACHE_NAMES)
   if (typeof cacheNames === 'string') cacheNames = [cacheNames]
   let caches = {}
@@ -29,6 +29,12 @@ export function createCaches (cacheNames) {
     activate () {
       if (!caches) return console.error(ERROR_CACHE_CLEARED)
       for (const cacheName of cacheNames) activeCaches[cacheName] = caches[cacheName]
+    },
+    deactivate () {
+      if (!caches) return console.error(ERROR_CACHE_CLEARED)
+      for (const cacheName of cacheNames) {
+        if (activeCaches[cacheName] === caches[cacheName]) activeCaches[cacheName] = undefined
+      }
     },
     clear () {
       if (!caches) return console.error(ERROR_CACHE_CLEARED)

--- a/packages/cache/index.js
+++ b/packages/cache/index.js
@@ -28,8 +28,20 @@ export function unblockCache () {
   if (BLOCK_CACHE.value) BLOCK_CACHE.value = false
 }
 
+export function getDummyCache () {
+  return {
+    activate () {
+      for (const cacheName in activeCaches) activeCaches[cacheName] = undefined
+    },
+    deactivate () {
+      for (const cacheName in activeCaches) activeCaches[cacheName] = undefined
+    },
+    clear () {}
+  }
+}
+
 export function createCaches (cacheNames) {
-  if (!CACHE_ACTIVE.value) return { activate: () => {}, deactivate: () => {}, clear: () => {} }
+  if (!CACHE_ACTIVE.value) return getDummyCache()
   if (!cacheNames) throw Error(ERROR_NO_CACHE_NAMES)
   if (typeof cacheNames === 'string') cacheNames = [cacheNames]
   let caches = {}

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@startupjs/cache",
+  "type": "module",
+  "version": "0.42.6",
+  "engines": {
+    "node": ">= 14"
+  },
+  "description": "Helpers for doing auto-caching and memoization",
+  "main": "index.js",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {},
+  "license": "MIT",
+  "dependencies": {
+    "@startupjs/debug": "^0.42.6"
+  }
+}

--- a/packages/cache/startupjs.config.cjs
+++ b/packages/cache/startupjs.config.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  type: 'plugin',
+  bundler: {
+    forceCompile: {
+      web: true,
+      server: true
+    }
+  }
+}

--- a/packages/debug/.eslintrc.json
+++ b/packages/debug/.eslintrc.json
@@ -1,0 +1,26 @@
+{
+  "root": true,
+  "env": {
+    "browser": true,
+    "es6": true,
+    "node": true,
+    "mocha": true
+  },
+  "extends": [
+    "standard"
+  ],
+  "globals": {
+    "Atomics": "readonly",
+    "SharedArrayBuffer": "readonly"
+  },
+  "parserOptions": {
+    "ecmaFeatures": {
+      "legacyDecorators": false,
+      "jsx": false
+    },
+    "ecmaVersion": 6,
+    "sourceType": "module"
+  },
+  "plugins": [],
+  "rules": {}
+}

--- a/packages/debug/.gitignore
+++ b/packages/debug/.gitignore
@@ -1,0 +1,23 @@
+.DS_Store
+*.swp
+*.log
+.idea
+.history
+.vscode
+npm-*
+coverage
+
+# Deps
+/node_modules/
+/bower_components/
+
+# App
+/build/
+/public/js/minified/
+/public/img/sprites/
+
+# Temp
+/tmp/
+
+# Tests
+test/shots/*

--- a/packages/debug/.npmignore
+++ b/packages/debug/.npmignore
@@ -1,0 +1,31 @@
+# Some packagers (like React Native) try to use .babelrc from node_modules.
+# So we need to ignore it to prevent unnecessary compilation and errors.
+.babelrc
+
+# ###########################################
+# Everything from .gitignore (except of compiled /lib/) below:
+# ###########################################
+
+.DS_Store
+*.swp
+*.log
+.idea
+.history
+.vscode
+npm-*
+coverage
+
+# Deps
+/node_modules/
+/bower_components/
+
+# App
+/build/
+/public/js/minified/
+/public/img/sprites/
+
+# Temp
+/tmp/
+
+# Tests
+test/shots/*

--- a/packages/debug/README.md
+++ b/packages/debug/README.md
@@ -1,0 +1,13 @@
+# startupjs debug
+
+> Debugging helpers
+
+## Usage
+
+For internal use only.
+
+## Licence
+
+MIT
+
+(c) Decision Mapper - http://decisionmapper.com

--- a/packages/debug/index.js
+++ b/packages/debug/index.js
@@ -1,0 +1,16 @@
+export const DEBUG = {}
+
+if (typeof window !== 'undefined') {
+  if (!window.__startupjs__) window.__startupjs__ = {}
+  window.__startupjs__.DEBUG = DEBUG
+}
+
+export function __increment (name) {
+  if (!DEBUG[name]) DEBUG[name] = 0
+  DEBUG[name] += 1
+}
+
+export function __decrement (name) {
+  if (!DEBUG[name]) DEBUG[name] = 0
+  DEBUG[name] -= 1
+}

--- a/packages/debug/index.js
+++ b/packages/debug/index.js
@@ -14,3 +14,7 @@ export function __decrement (name) {
   if (!DEBUG[name]) DEBUG[name] = 0
   DEBUG[name] -= 1
 }
+
+export function setDebugVar (key, value) {
+  DEBUG[key] = value
+}

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@startupjs/debug",
+  "type": "module",
+  "version": "0.42.6",
+  "engines": {
+    "node": ">= 14"
+  },
+  "description": "Debugging helpers",
+  "main": "index.js",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {},
+  "license": "MIT",
+  "dependencies": {}
+}

--- a/packages/debug/startupjs.config.cjs
+++ b/packages/debug/startupjs.config.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  type: 'plugin',
+  bundler: {
+    forceCompile: {
+      web: true,
+      server: true
+    }
+  }
+}

--- a/packages/orm/lib/index.js
+++ b/packages/orm/lib/index.js
@@ -1,5 +1,6 @@
 import racer from 'racer'
 import promisifyRacer from './promisifyRacer'
+import { singletonMemoize } from '@startupjs/cache'
 
 const Model = racer.Model
 
@@ -37,7 +38,9 @@ export default function (racer) {
     return model
   }
 
-  Model.prototype.scope = function (path, alias) {
+  // TODO: do NOT cache within built-in use* hooks from react-sharedb
+  //       because they already handle caching internally
+  Model.prototype.scope = singletonMemoize(function (path, alias) {
     if (alias) {
       if (global.STARTUP_JS_ORM[alias]) {
         return this.__createScopedModel(path, global.STARTUP_JS_ORM[alias].OrmEntity)
@@ -69,7 +72,10 @@ export default function (racer) {
     }
 
     return this._scope(path)
-  }
+  }, {
+    cacheName: 'model',
+    nestedThis: true
+  })
 
   Model.prototype.__createScopedModel = function (path, OrmEntity) {
     var model

--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -11,6 +11,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
+    "@startupjs/cache": "^0.42.6",
     "pluralize": "^8.0.0",
     "racer": "1.0.1"
   },

--- a/packages/react-sharedb-hooks/lib/hooks/meta.js
+++ b/packages/react-sharedb-hooks/lib/hooks/meta.js
@@ -1,4 +1,5 @@
-import React, { useContext } from 'react'
+import React, { useContext, useMemo } from 'react'
+import { DEBUG_CACHE_ACTIVE } from '@startupjs/cache'
 
 export const ComponentMetaContext = React.createContext({})
 
@@ -13,6 +14,7 @@ export function useComponentId () {
 }
 
 export function useCache () {
+  if (!DEBUG_CACHE_ACTIVE) return useMemo(() => ({ activate: () => {}, clear: () => {} }), [])
   const { cache } = useContext(ComponentMetaContext)
   return cache
 }

--- a/packages/react-sharedb-hooks/lib/hooks/meta.js
+++ b/packages/react-sharedb-hooks/lib/hooks/meta.js
@@ -11,3 +11,8 @@ export function useComponentId () {
   const { componentId } = useContext(ComponentMetaContext)
   return componentId
 }
+
+export function useCache () {
+  const { cache } = useContext(ComponentMetaContext)
+  return cache
+}

--- a/packages/react-sharedb-hooks/lib/hooks/meta.js
+++ b/packages/react-sharedb-hooks/lib/hooks/meta.js
@@ -1,5 +1,5 @@
 import React, { useContext, useMemo } from 'react'
-import { CACHE_ACTIVE } from '@startupjs/cache'
+import { CACHE_ACTIVE, getDummyCache } from '@startupjs/cache'
 
 export const ComponentMetaContext = React.createContext({})
 
@@ -13,8 +13,8 @@ export function useComponentId () {
   return componentId
 }
 
-export function useCache () {
-  if (!CACHE_ACTIVE.value) return useMemo(() => ({ activate: () => {}, deactivate: () => {}, clear: () => {} }), [])
+export function useCache (active) {
+  if (!CACHE_ACTIVE.value || !active) return useMemo(getDummyCache, [])
   const { cache } = useContext(ComponentMetaContext)
   return cache
 }

--- a/packages/react-sharedb-hooks/lib/hooks/meta.js
+++ b/packages/react-sharedb-hooks/lib/hooks/meta.js
@@ -1,5 +1,5 @@
 import React, { useContext, useMemo } from 'react'
-import { DEBUG_CACHE_ACTIVE } from '@startupjs/cache'
+import { CACHE_ACTIVE } from '@startupjs/cache'
 
 export const ComponentMetaContext = React.createContext({})
 
@@ -14,7 +14,7 @@ export function useComponentId () {
 }
 
 export function useCache () {
-  if (!DEBUG_CACHE_ACTIVE) return useMemo(() => ({ activate: () => {}, deactivate: () => {}, clear: () => {} }), [])
+  if (!CACHE_ACTIVE.value) return useMemo(() => ({ activate: () => {}, deactivate: () => {}, clear: () => {} }), [])
   const { cache } = useContext(ComponentMetaContext)
   return cache
 }

--- a/packages/react-sharedb-hooks/lib/hooks/meta.js
+++ b/packages/react-sharedb-hooks/lib/hooks/meta.js
@@ -14,7 +14,7 @@ export function useComponentId () {
 }
 
 export function useCache () {
-  if (!DEBUG_CACHE_ACTIVE) return useMemo(() => ({ activate: () => {}, clear: () => {} }), [])
+  if (!DEBUG_CACHE_ACTIVE) return useMemo(() => ({ activate: () => {}, deactivate: () => {}, clear: () => {} }), [])
   const { cache } = useContext(ComponentMetaContext)
   return cache
 }

--- a/packages/react-sharedb-hooks/lib/hooks/observer.js
+++ b/packages/react-sharedb-hooks/lib/hooks/observer.js
@@ -115,7 +115,7 @@ function wrapObserverMeta (
   function ObserverWrapper (props, ref) {
     const cache = React.useMemo(() => {
       __increment('ObserverWrapper.cache')
-      return createCaches(['styles'])
+      return createCaches(['styles', 'model'])
     }, [])
     // TODO: using useState instead of useMemo will keep this intact during Fast Refresh
     //       Research if we can change it to use it.

--- a/packages/react-sharedb-hooks/lib/hooks/observer.js
+++ b/packages/react-sharedb-hooks/lib/hooks/observer.js
@@ -2,10 +2,12 @@
 import * as React from 'react'
 import { observe, unobserve } from '@nx-js/observer-util'
 import { batching } from '@startupjs/react-sharedb-util'
+import { createCaches } from '@startupjs/cache'
+import { __increment, __decrement } from '@startupjs/debug'
 import destroyer from './destroyer.js'
 import promiseBatcher from './promiseBatcher.js'
 import $root from '@startupjs/model'
-import { ComponentMetaContext } from './meta.js'
+import { ComponentMetaContext, useCache } from './meta.js'
 
 const DEFAULT_OPTIONS = {
   forwardRef: false,
@@ -17,8 +19,7 @@ const DEFAULT_OPTIONS = {
 // TODO: Fix passing options argument in react-native Fast Refresh patch.
 //       It has to properly put the closing bracket.
 function observer (Component, options) {
-  const _options = Object.assign({}, DEFAULT_OPTIONS, options)
-  return wrapObserverMeta(makeObserver(Component, _options), _options)
+  return wrapObserverMeta(makeObserver(Component, options))
 }
 
 observer.__wrapObserverMeta = wrapObserverMeta
@@ -47,7 +48,8 @@ function pipeComponentMeta (SourceComponent, TargetComponent, suffix = '', defau
 }
 
 function makeObserver (baseComponent, options = {}) {
-  const { forwardRef } = Object.assign({}, DEFAULT_OPTIONS, options)
+  options = Object.assign({}, DEFAULT_OPTIONS, options)
+  const { forwardRef } = options
   // MAGIC. This fixes hot-reloading. TODO: figure out WHY it fixes it
   const random = Math.random()
 
@@ -57,6 +59,7 @@ function makeObserver (baseComponent, options = {}) {
   const WrappedComponent = (...args) => {
     // forceUpdate 2.0
     const forceUpdate = useForceUpdate()
+    const cache = useCache()
 
     // wrap the baseComponent into an observe decorator once.
     // This way it will track any observable changes and will trigger rerender
@@ -70,14 +73,16 @@ function makeObserver (baseComponent, options = {}) {
         if (!blockUpdate.value) forceUpdate()
       }
       const batchedUpdate = () => batching.add(update)
-      return observe(wrapBaseComponent(baseComponent, blockUpdate), {
+      return observe(wrapBaseComponent(baseComponent, blockUpdate, cache), {
         scheduler: batchedUpdate,
         lazy: true
       })
     }, [random])
 
     // clean up observer on unmount
-    useUnmount(() => unobserve(observedComponent))
+    useUnmount(() => {
+      unobserve(observedComponent)
+    })
 
     return observedComponent(...args)
   }
@@ -88,14 +93,15 @@ function makeObserver (baseComponent, options = {}) {
 
   pipeComponentMeta(baseComponent, Component)
 
+  Component.__observerOptions = options
+
   return Component
 }
 
 function wrapObserverMeta (
-  Component,
-  options = {}
+  Component
 ) {
-  const { forwardRef, suspenseProps } = Object.assign({}, DEFAULT_OPTIONS, options)
+  const { forwardRef, suspenseProps } = Component.__observerOptions
   if (!(suspenseProps && suspenseProps.fallback)) {
     throw Error(
       '[observer()] You must pass at least ' +
@@ -104,12 +110,30 @@ function wrapObserverMeta (
   }
 
   function ObserverWrapper (props, ref) {
+    const cache = React.useMemo(() => {
+      __increment('ObserverWrapper.cache')
+      return createCaches(['styles'])
+    }, [])
+    // TODO: using useState instead of useMemo will keep this intact during Fast Refresh
+    //       Research if we can change it to use it.
+    // const [componentMeta] = React.useState({
+    //   componentId: $root.id(),
+    //   createdAt: Date.now(),
+    //   cache
+    // })
     var componentMeta = React.useMemo(function () {
       return {
         componentId: $root.id(),
-        createdAt: Date.now()
+        createdAt: Date.now(),
+        cache: cache
       }
     }, [])
+
+    useUnmount(() => {
+      __decrement('ObserverWrapper.cache')
+      cache.clear()
+    })
+
     return React.createElement(
       ComponentMetaContext.Provider,
       { value: componentMeta },
@@ -138,9 +162,10 @@ function wrapObserverMeta (
   return memoComponent
 }
 
-function wrapBaseComponent (baseComponent, blockUpdate) {
+function wrapBaseComponent (baseComponent, blockUpdate, cache) {
   return (...args) => {
     blockUpdate.value = true
+    cache.activate()
     let res
     try {
       destroyer.reset()

--- a/packages/react-sharedb-hooks/lib/hooks/observer.js
+++ b/packages/react-sharedb-hooks/lib/hooks/observer.js
@@ -175,6 +175,7 @@ function wrapBaseComponent (baseComponent, blockUpdate, cache) {
       promiseBatcher.reset()
       res = baseComponent(...args)
     } catch (err) {
+      cache.deactivate()
       if (!err.then) throw err
       // If the Promise was thrown, we catch it before Suspense does.
       // And we run destructors for each hook previous to the one
@@ -185,6 +186,7 @@ function wrapBaseComponent (baseComponent, blockUpdate, cache) {
       const destroy = destroyer.getDestructor()
       throw err.then(destroy)
     }
+    cache.deactivate()
     blockUpdate.value = false
     if (promiseBatcher.isActive()) {
       throw Error('[react-sharedb] useBatch* hooks were used without a closing useBatch() call.')

--- a/packages/react-sharedb-hooks/lib/hooks/observer.js
+++ b/packages/react-sharedb-hooks/lib/hooks/observer.js
@@ -59,7 +59,7 @@ function makeObserver (baseComponent, options = {}) {
   const WrappedComponent = (...args) => {
     // forceUpdate 2.0
     const forceUpdate = useForceUpdate()
-    const cache = useCache()
+    const cache = useCache(options.cache != null ? options.cache : true)
 
     // wrap the baseComponent into an observe decorator once.
     // This way it will track any observable changes and will trigger rerender

--- a/packages/react-sharedb-hooks/lib/hooks/observer.js
+++ b/packages/react-sharedb-hooks/lib/hooks/observer.js
@@ -81,6 +81,9 @@ function makeObserver (baseComponent, options = {}) {
 
     // clean up observer on unmount
     useUnmount(() => {
+      // TODO: this does not execute the same amount of times as observe() does,
+      //       probably because of throw's of the async hooks.
+      //       So there probably are memory leaks here. Research this.
       unobserve(observedComponent)
     })
 

--- a/packages/react-sharedb-hooks/lib/hooks/types.js
+++ b/packages/react-sharedb-hooks/lib/hooks/types.js
@@ -11,6 +11,7 @@ import Local from '../types/Local.js'
 import Value from '../types/Value.js'
 import Api from '../types/Api.js'
 import { batching } from '@startupjs/react-sharedb-util'
+import { blockCache, unblockCache } from '@startupjs/cache'
 
 import {
   subDoc,
@@ -60,6 +61,10 @@ function generateUseItemOfType (typeFn, { optional, batch, modelOnly } = {}) {
   const takeOriginalModel = typeFn === subDoc || typeFn === subLocal
   const isSync = typeFn === subLocal || typeFn === subValue
   return (...args) => {
+    // block caching of 'model.at' and 'model.scope' since the caching of model
+    // is handled on its own by these hooks
+    blockCache()
+
     const hookId = useMemo(() => $root.id(), [])
     const hashedArgs = useMemo(() => JSON.stringify(args), args)
 
@@ -205,6 +210,9 @@ function generateUseItemOfType (typeFn, { optional, batch, modelOnly } = {}) {
       },
       [initsCountRef.current]
     )
+
+    // unblock caching 'model.at' and 'model.scope'
+    unblockCache()
 
     // if modelOnly was passed, we return just the model.
     // Using model-only hooks when you don't need data is important for optimization

--- a/packages/react-sharedb-hooks/package.json
+++ b/packages/react-sharedb-hooks/package.json
@@ -14,7 +14,9 @@
   "license": "MIT",
   "dependencies": {
     "@nx-js/observer-util": "^4.1.3",
+    "@startupjs/cache": "^0.42.6",
     "@startupjs/model": "^0.42.6",
+    "@startupjs/debug": "^0.42.6",
     "@startupjs/react-sharedb-util": "^0.42.6",
     "co": "~4.6.0",
     "lodash": "^4.17.20"

--- a/packages/ui/components/draggable/Draggable.js
+++ b/packages/ui/components/draggable/Draggable.js
@@ -166,16 +166,15 @@ export default observer(function Draggable ({
     dndContext.drops[_dropId].items.length - 1 === _index &&
     dndContext.dragHoverIndex === _index + 1
 
-  const placeholder = (
-    <View
-      styleName='placeholder'
-      style={{
-        height: dndContext.activeData?.dragStyle?.height,
-        marginTop: dndContext.activeData?.dragStyle?.marginTop,
-        marginBottom: dndContext.activeData?.dragStyle?.marginBottom
-      }}
-    />
-  )
+  const placeholder = pug`
+    View.placeholder(
+      style={
+        height: dndContext.activeData && dndContext.activeData.dragStyle && dndContext.activeData.dragStyle.height,
+        marginTop: dndContext.activeData && dndContext.activeData.dragStyle && dndContext.activeData.dragStyle.marginTop,
+        marginBottom: dndContext.activeData && dndContext.activeData.dragStyle && dndContext.activeData.dragStyle.marginBottom
+      }
+    )
+  `
 
   return pug`
     if isShowPlaceholder
@@ -200,4 +199,4 @@ export default observer(function Draggable ({
     if isShowLastPlaceholder
       = placeholder
   `
-})
+}, { cache: false })

--- a/styleguide/babel.config.js
+++ b/styleguide/babel.config.js
@@ -1,7 +1,8 @@
 module.exports = {
   presets: [
     ['startupjs/babel.cjs', {
-      alias: {}
+      alias: {},
+      observerCache: true
     }]
   ]
 }

--- a/styleguide/main/pages/PPlayground1.jsx
+++ b/styleguide/main/pages/PPlayground1.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useRef } from 'react'
 import { pug, styl, observer, useValue, useComponentId } from 'startupjs'
-import { Content, Button, Link, Row, Span } from '@startupjs/ui'
+import { Content, Button, Link, Row, Span, Card, H5 } from '@startupjs/ui'
 
 export default observer(function PPlayground () {
   const [count, setCount] = useState(0)
@@ -16,7 +16,8 @@ export default observer(function PPlayground () {
 
   return pug`
     Content(width='mobile')
-      Sub.sub($value=$magicCounter.at('value'))
+      Sub($value=$magicCounter.at('value') style={ backgroundColor: 'red', height: 100 } title='Sub inline styles')
+      Sub.sub($value=$magicCounter.at('value') title='Sub class styles')
       Button(onPress=onPress) Button 1 - #{count} - #{magicCounter.value}
       Link(to='/playground2') Go to Playground 2
       Span
@@ -33,22 +34,24 @@ export default observer(function PPlayground () {
   `
 })
 
-const Sub = observer(({ $value }) => {
+const Sub = observer(({ $value, title }) => {
   const renderRef = useRef(0)
   const [, setForceRerender] = useState()
   ++renderRef.current
   return pug`
-    Button(onPress=() => $value.set($value.get() + 1)) Increase magicCounter.value from Sub
-    Sub2($value=$value)
-    Row(
-      part='root'
-      align='center'
-      vAlign='center'
-      onPress=() => {
-        setForceRerender(Math.random())
-      }
-    )
-      Span Renders: #{renderRef.current}.
+    Card
+      H5= title
+      Button(onPress=() => $value.set($value.get() + 1)) Increase magicCounter.value from Sub
+      Sub2($value=$value)
+      Row(
+        part='root'
+        align='center'
+        vAlign='center'
+        onPress=() => {
+          setForceRerender(Math.random())
+        }
+      )
+        Span Renders: #{renderRef.current}.
   `
   /* eslint-disable-line */styl``
 })

--- a/styleguide/main/pages/PPlayground1.jsx
+++ b/styleguide/main/pages/PPlayground1.jsx
@@ -1,6 +1,6 @@
-import React, { useState, useMemo } from 'react'
+import React, { useState, useMemo, useRef } from 'react'
 import { pug, styl, observer, useValue, useComponentId } from 'startupjs'
-import { Content, Button, Link, Div, Span } from '@startupjs/ui'
+import { Content, Button, Link, Row, Span } from '@startupjs/ui'
 
 export default observer(function PPlayground () {
   const [count, setCount] = useState(0)
@@ -10,7 +10,7 @@ export default observer(function PPlayground () {
   const magic = useMemo(() => Math.random(), [])
   return pug`
     Content(width='mobile')
-      Div(onPress=() => console.log('div 1') style={ height: 100, backgroundColor: 'red' })
+      Sub.sub
       Button(onPress=() => (setCount(count + 1), $lCount.set(lCount + 1))) Button 1 - #{count} - #{lCount}
       Link(to='/playground2') Go to Playground 2
       Span
@@ -18,6 +18,27 @@ export default observer(function PPlayground () {
         | ID: #{componentId}
         | Magic: #{magic}
         | Date: #{date}
+  `
+  /* eslint-disable-line */styl`
+    .sub {
+      backgroundColor red
+      height 100px
+    }
+  `
+})
+
+const Sub = observer(() => {
+  const renderRef = useRef(0)
+  const [, setForceRerender] = useState()
+  ++renderRef.current
+  return pug`
+    Row(
+      part='root'
+      align='center'
+      vAlign='center'
+      onPress=() => setForceRerender(Math.random())
+    )
+      Span Renders: #{renderRef.current}
   `
   /* eslint-disable-line */styl``
 })

--- a/styleguide/main/pages/PPlayground1.jsx
+++ b/styleguide/main/pages/PPlayground1.jsx
@@ -5,13 +5,19 @@ import { Content, Button, Link, Row, Span } from '@startupjs/ui'
 export default observer(function PPlayground () {
   const [count, setCount] = useState(0)
   const [date] = useState(Date.now())
-  const [lCount, $lCount] = useValue(100)
+  const [magicCounter, $magicCounter] = useValue({ value: 100 })
   const componentId = useComponentId()
   const magic = useMemo(() => Math.random(), [])
+
+  function onPress () {
+    setCount(count + 1)
+    $magicCounter.set('value', magicCounter.value + 1)
+  }
+
   return pug`
     Content(width='mobile')
-      Sub.sub
-      Button(onPress=() => (setCount(count + 1), $lCount.set(lCount + 1))) Button 1 - #{count} - #{lCount}
+      Sub.sub($value=$magicCounter.at('value'))
+      Button(onPress=onPress) Button 1 - #{count} - #{magicCounter.value}
       Link(to='/playground2') Go to Playground 2
       Span
         | Hello world here again here ping 28.
@@ -27,18 +33,21 @@ export default observer(function PPlayground () {
   `
 })
 
-const Sub = observer(() => {
+const Sub = observer(({ $value }) => {
   const renderRef = useRef(0)
   const [, setForceRerender] = useState()
   ++renderRef.current
   return pug`
+    Button(onPress=() => $value.set($value.get() + 1)) Increase magicCounter.value from Sub
     Row(
       part='root'
       align='center'
       vAlign='center'
-      onPress=() => setForceRerender(Math.random())
+      onPress=() => {
+        setForceRerender(Math.random())
+      }
     )
-      Span Renders: #{renderRef.current}
+      Span Renders: #{renderRef.current}.
   `
   /* eslint-disable-line */styl``
 })

--- a/styleguide/main/pages/PPlayground1.jsx
+++ b/styleguide/main/pages/PPlayground1.jsx
@@ -1,0 +1,23 @@
+import React, { useState, useMemo } from 'react'
+import { pug, styl, observer, useValue, useComponentId } from 'startupjs'
+import { Content, Button, Link, Div, Span } from '@startupjs/ui'
+
+export default observer(function PPlayground () {
+  const [count, setCount] = useState(0)
+  const [date] = useState(Date.now())
+  const [lCount, $lCount] = useValue(100)
+  const componentId = useComponentId()
+  const magic = useMemo(() => Math.random(), [])
+  return pug`
+    Content(width='mobile')
+      Div(onPress=() => console.log('div 1') style={ height: 100, backgroundColor: 'red' })
+      Button(onPress=() => (setCount(count + 1), $lCount.set(lCount + 1))) Button 1 - #{count} - #{lCount}
+      Link(to='/playground2') Go to Playground 2
+      Span
+        | Hello world here again here ping 28.
+        | ID: #{componentId}
+        | Magic: #{magic}
+        | Date: #{date}
+  `
+  /* eslint-disable-line */styl``
+})

--- a/styleguide/main/pages/PPlayground1.jsx
+++ b/styleguide/main/pages/PPlayground1.jsx
@@ -39,6 +39,7 @@ const Sub = observer(({ $value }) => {
   ++renderRef.current
   return pug`
     Button(onPress=() => $value.set($value.get() + 1)) Increase magicCounter.value from Sub
+    Sub2($value=$value)
     Row(
       part='root'
       align='center'
@@ -48,6 +49,13 @@ const Sub = observer(({ $value }) => {
       }
     )
       Span Renders: #{renderRef.current}.
+  `
+  /* eslint-disable-line */styl``
+})
+
+const Sub2 = observer(({ $value }) => {
+  return pug`
+    Span Sub2 magicCounter.value: #{ $value.get() }
   `
   /* eslint-disable-line */styl``
 })

--- a/styleguide/main/pages/PPlayground2.jsx
+++ b/styleguide/main/pages/PPlayground2.jsx
@@ -1,0 +1,14 @@
+import React, { useState } from 'react'
+import { pug, styl, observer } from 'startupjs'
+import { Content, Button, Link, Div } from '@startupjs/ui'
+
+export default observer(function PPlayground () {
+  const [count, setCount] = useState(0)
+  return pug`
+    Content(width='mobile')
+      Div(onPress=() => console.log('div 2') style={ height: 100, backgroundColor: 'red' })
+      Button(onPress=() => setCount(count + 1)) Button 2 - #{count}
+      Link(to='/playground1') Go to Playground 1
+  `
+  /* eslint-disable-line */styl``
+})

--- a/styleguide/main/pages/index.js
+++ b/styleguide/main/pages/index.js
@@ -1,3 +1,5 @@
+export { default as PPlayground1 } from './PPlayground1'
+export { default as PPlayground2 } from './PPlayground2'
 export { default as PProfile } from './PProfile'
 export { default as PAnchorsExample } from '@startupjs/scrollable-anchors/client/example'
 export { default as PTestComponent } from './PTestComponent'

--- a/styleguide/main/routes.js
+++ b/styleguide/main/routes.js
@@ -18,5 +18,15 @@ export default (components = {}) => [
     path: '/test/:componentName',
     exact: true,
     component: components.PTestComponent
+  },
+  {
+    path: '/playground1',
+    exact: true,
+    component: components.PPlayground1
+  },
+  {
+    path: '/playground2',
+    exact: true,
+    component: components.PPlayground2
   }
 ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1157,6 +1157,14 @@
     "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
 
+"@babel/types@^7.4.0":
+  version "7.17.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.17.0.tgz#a826e368bccb6b3d84acd76acad5c0d87342390b"
+  integrity sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.16.7"
+    to-fast-properties "^2.0.0"
+
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2589,6 +2589,21 @@
     npmlog "^4.1.2"
     write-file-atomic "^2.3.0"
 
+"@mapbox/node-pre-gyp@^1.0.0":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.8.tgz#32abc8a5c624bc4e46c43d84dfb8b26d33a96f58"
+  integrity sha512-CMGKi28CF+qlbXh26hDe6NxCd7amqeAzEqnS6IHeO6LoaKyM/n+Xw3HT1COdq8cuioOdlKdqn/hCmqPUOMOywg==
+  dependencies:
+    detect-libc "^1.0.3"
+    https-proxy-agent "^5.0.0"
+    make-dir "^3.1.0"
+    node-fetch "^2.6.5"
+    nopt "^5.0.0"
+    npmlog "^5.0.1"
+    rimraf "^3.0.2"
+    semver "^7.3.5"
+    tar "^6.1.11"
+
 "@mdx-js/loader@^1.6.22":
   version "1.6.22"
   resolved "https://registry.yarnpkg.com/@mdx-js/loader/-/loader-1.6.22.tgz#d9e8fe7f8185ff13c9c8639c048b123e30d322c4"
@@ -4291,7 +4306,7 @@ aproba@^1.0.3, aproba@^1.1.1, aproba@^1.1.2:
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
 
-"aproba@^1.1.2 || 2", aproba@^2.0.0:
+"aproba@^1.0.3 || ^2.0.0", "aproba@^1.1.2 || 2", aproba@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-2.0.0.tgz#52520b8ae5b569215b354efc0caa3fe1e45a8adc"
   integrity sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==
@@ -4300,6 +4315,14 @@ archy@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
   integrity sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=
+
+are-we-there-yet@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz#372e0e7bd279d8e94c653aaa1f67200884bf3e1c"
+  integrity sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==
+  dependencies:
+    delegates "^1.0.0"
+    readable-stream "^3.6.0"
 
 are-we-there-yet@~1.1.2:
   version "1.1.7"
@@ -5738,13 +5761,13 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bcrypt@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/bcrypt/-/bcrypt-4.0.1.tgz#06e21e749a061020e4ff1283c1faa93187ac57fe"
-  integrity sha512-hSIZHkUxIDS5zA2o00Kf2O5RfVbQ888n54xQoF/eIaquU4uaLxK8vhhBdktd0B3n2MjkcAWzv4mnhogykBKOUQ==
+bcrypt@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/bcrypt/-/bcrypt-5.0.1.tgz#f1a2c20f208e2ccdceea4433df0c8b2c54ecdf71"
+  integrity sha512-9BTgmrhZM2t1bNuDtrtIMVSmmxZBrJ71n8Wg+YgdjHuIWYF7SjjmCPZFB+/5i/o/PIeRpwVJR3P+NrpIItUjqw==
   dependencies:
-    node-addon-api "^2.0.0"
-    node-pre-gyp "0.14.0"
+    "@mapbox/node-pre-gyp" "^1.0.0"
+    node-addon-api "^3.1.0"
 
 before-after-hook@^2.0.0:
   version "2.2.2"
@@ -6432,6 +6455,11 @@ chownr@^1.1.1, chownr@^1.1.2, chownr@^1.1.4:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
+chownr@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
+  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
+
 chrome-trace-event@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"
@@ -6696,7 +6724,7 @@ color-string@^1.6.0:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
 
-color-support@^1.1.3:
+color-support@^1.1.2, color-support@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
   integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
@@ -7906,7 +7934,7 @@ detect-indent@^5.0.0, detect-indent@~5.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
 
-detect-libc@^1.0.2:
+detect-libc@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
@@ -9544,6 +9572,13 @@ fs-minipass@^1.2.7:
   dependencies:
     minipass "^2.6.0"
 
+fs-minipass@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
+  integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
+  dependencies:
+    minipass "^3.0.0"
+
 fs-monkey@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-1.0.3.tgz#ae3ac92d53bb328efe0e9a1d9541f6ad8d48e2d3"
@@ -9620,6 +9655,21 @@ funpermaproxy@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/funpermaproxy/-/funpermaproxy-1.0.1.tgz#4650e69b7c334d9717c06beba9b339cc08ac3335"
   integrity sha512-9pEzs5vnNtR7ZGihly98w/mQ7blsvl68Wj30ZCDAXy7qDN4CWLLjdfjtH/P2m6whsnaJkw15hysCNHMXue+wdA==
+
+gauge@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/gauge/-/gauge-3.0.2.tgz#03bf4441c044383908bcfa0656ad91803259b395"
+  integrity sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==
+  dependencies:
+    aproba "^1.0.3 || ^2.0.0"
+    color-support "^1.1.2"
+    console-control-strings "^1.0.0"
+    has-unicode "^2.0.1"
+    object-assign "^4.1.1"
+    signal-exit "^3.0.0"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
+    wide-align "^1.1.2"
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -10666,7 +10716,7 @@ hyphenate-style-name@^1.0.2, hyphenate-style-name@^1.0.3:
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz#691879af8e220aea5750e8827db4ef62a54e361d"
   integrity sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==
 
-iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
+iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -14327,12 +14377,27 @@ minipass@^2.3.5, minipass@^2.6.0, minipass@^2.9.0:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
+minipass@^3.0.0:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.6.tgz#3b8150aa688a711a1521af5e8779c1d3bb4f45ee"
+  integrity sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==
+  dependencies:
+    yallist "^4.0.0"
+
 minizlib@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
   integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
   dependencies:
     minipass "^2.9.0"
+
+minizlib@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
+  integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
+  dependencies:
+    minipass "^3.0.0"
+    yallist "^4.0.0"
 
 mississippi@^3.0.0:
   version "3.0.0"
@@ -14373,7 +14438,7 @@ mkdirp-promise@^5.0.1:
   dependencies:
     mkdirp "*"
 
-mkdirp@*:
+mkdirp@*, mkdirp@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -14630,15 +14695,6 @@ nearley@^2.7.10:
     railroad-diagrams "^1.0.0"
     randexp "0.4.6"
 
-needle@^2.2.1:
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.9.1.tgz#22d1dffbe3490c2b83e301f7709b6736cd8f2684"
-  integrity sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -14664,10 +14720,10 @@ nocache@^2.1.0:
   resolved "https://registry.yarnpkg.com/nocache/-/nocache-2.1.0.tgz#120c9ffec43b5729b1d5de88cd71aa75a0ba491f"
   integrity sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q==
 
-node-addon-api@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
-  integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
+node-addon-api@^3.1.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
+  integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
 
 node-fetch-npm@^2.0.2:
   version "2.0.4"
@@ -14678,7 +14734,7 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-fetch@2.6.7, node-fetch@^2.2.0, node-fetch@^2.5.0, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
+node-fetch@2.6.7, node-fetch@^2.2.0, node-fetch@^2.5.0, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.5, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
@@ -14752,22 +14808,6 @@ node-notifier@^8.0.0:
     uuid "^8.3.0"
     which "^2.0.2"
 
-node-pre-gyp@0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-releases@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.1.tgz#3d1d395f204f1f2f29a54358b9fb678765ad2fc5"
@@ -14813,6 +14853,13 @@ nopt@^4.0.1, nopt@^4.0.3:
   dependencies:
     abbrev "1"
     osenv "^0.1.4"
+
+nopt@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-5.0.0.tgz#530942bb58a512fccafe53fe210f13a25355dc88"
+  integrity sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==
+  dependencies:
+    abbrev "1"
 
 nopt@~1.0.10:
   version "1.0.10"
@@ -14929,7 +14976,7 @@ npm-normalize-package-bin@^1.0.0, npm-normalize-package-bin@^1.0.1:
     semver "^5.6.0"
     validate-npm-package-name "^3.0.0"
 
-npm-packlist@^1.1.12, npm-packlist@^1.1.6, npm-packlist@^1.4.4, npm-packlist@^1.4.8:
+npm-packlist@^1.1.12, npm-packlist@^1.4.4, npm-packlist@^1.4.8:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
   integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
@@ -15116,7 +15163,7 @@ npm@^6.9.0:
     worker-farm "^1.7.0"
     write-file-atomic "^2.4.3"
 
-npmlog@^4.0.2, npmlog@^4.1.2, npmlog@~4.1.2:
+npmlog@^4.1.2, npmlog@~4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -15125,6 +15172,16 @@ npmlog@^4.0.2, npmlog@^4.1.2, npmlog@~4.1.2:
     console-control-strings "~1.1.0"
     gauge "~2.7.3"
     set-blocking "~2.0.0"
+
+npmlog@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-5.0.1.tgz#f06678e80e29419ad67ab964e0fa69959c1eb8b0"
+  integrity sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==
+  dependencies:
+    are-we-there-yet "^2.0.0"
+    console-control-strings "^1.1.0"
+    gauge "^3.0.0"
+    set-blocking "^2.0.0"
 
 nth-check@^1.0.2:
   version "1.0.2"
@@ -16920,7 +16977,7 @@ raw-body@2.4.2:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
+rc@^1.0.1, rc@^1.1.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -17900,7 +17957,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3, rimraf@^2.7.1:
+rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3, rimraf@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -18115,7 +18172,7 @@ semver-diff@^2.0.0:
   dependencies:
     semver "^5.0.3"
 
-"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", "semver@^2.3.0 || 3.x || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", "semver@^2.3.0 || 3.x || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -19227,7 +19284,7 @@ tapable@^2.1.1, tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
-tar@^4.4.10, tar@^4.4.12, tar@^4.4.19, tar@^4.4.2, tar@^4.4.8:
+tar@^4.4.10, tar@^4.4.12, tar@^4.4.19, tar@^4.4.8:
   version "4.4.19"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.19.tgz#2e4d7263df26f2b914dee10c825ab132123742f3"
   integrity sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==
@@ -19239,6 +19296,18 @@ tar@^4.4.10, tar@^4.4.12, tar@^4.4.19, tar@^4.4.2, tar@^4.4.8:
     mkdirp "^0.5.5"
     safe-buffer "^5.2.1"
     yallist "^3.1.1"
+
+tar@^6.1.11:
+  version "6.1.11"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
+  integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^3.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
 
 teeny-request@^7.0.0:
   version "7.1.3"
@@ -20558,7 +20627,7 @@ wide-align@1.1.3:
   dependencies:
     string-width "^1.0.2 || 2"
 
-wide-align@^1.1.0:
+wide-align@^1.1.0, wide-align@^1.1.2:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.5.tgz#df1d4c206854369ecf3c9a4898f1b23fbd9d15d3"
   integrity sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==


### PR DESCRIPTION
## IMPORTANT

**There are NO breaking changes, BUT we should still release this as a breaking version because we need to see how it works on a large project before we can be sure that there are really no bugs. By default caching is turned OFF because of this.**

## Overview

Added automatic caching for styles and creation of scoped models during react render.

This is considered to be an experimental feature. By default it's turned `OFF` so nothing should break whatsoever.

To turn in `ON`, pass `observerCache: true` to the `startupjs` preset in `babel.config.js`:

```js
    ['startupjs/babel.cjs', {
      ...,
      observerCache: true
    }]
```

To make sure caching is enabled, check the value of `window.__startupjs__.DEBUG.cacheEnabled` in browser console.

Examples:

1. cache pure `style`. This will only work if you have `observer` imported in the current file, this way we don't screw up the 3rd-party libraries which don't use startupjs.
    ```js
    export default observer(function Test () {
      return pug`
        Div(style={ backgroundColor: 'red' })
      `
    })
    ```

1. cache pure `styleName` or any combination of `part`, `style`, `*Style`, `*StyleName`
    ```js
    export default observer(function Test () {
      return pug`
        Div.div
      `
      styl`
        .div
          background-color red
      `
    })
    ```

1. cache scoped model created with `.at()` and `.scope()`
    ```js
    export default observer(function Games () {
      const [games, $games] = useQuery('games', { active: true })
      return pug`
        each game in games
          Game($game=$games.at(game.id))
      `
    })
    const Game = observer(({ $game }) => {
      const game = $game.get()
      return pug`
        Span= game.title
      `
    })
    ```

The last example is especially important since writing code in this way simplifies code a lot in many places. Now you can (and should) pass models whenever possible to child components as arguments, instead of passing an `id` and using `useDoc` or `useLocalDoc`.

Earlier in situations when you run `useQuery` in the parent component and then render each item as a separate component the only way to do it easily and properly was to pass an item id and then do a `useLocalDoc`. And you had to use `useLocalDoc`, otherwise `useDoc` will create an additional doc-only subscription and wait for it. Now this usecase is handled for you automatically, you just create a scoped model the item inline using `$items.at(item.id)` and pass it as `$item` into the child component.

So this change alone will save you from making extra queries in many situations and will make the code easier to follow and more performant overall.

## Changes

1. implement caching system for styles and model.

    - it's implemented in a new package `@startupjs/cache`

    - it relies on the fact that rendering of functional components is fully synchronous. So we start caching all styles within boundaries of the `observer()` wrapper component.

    - memoization by default is done by `JSON.stringify`'ing all arguments, but you can pass a custom normalization function to generate a custom ID for the cache item

    - add support for caching `model.at()` and `model.scope()` within synchronous component renders

    - add `__hash__` on the compiler level to `fileStyles`, `localStyles`, `globalStyles` and provide a custom normalization function for styles memoization

    - cache `style` if `observer()` is present in the file even when `styleName`/`part` are not used

    - add global setting to easily turn caching ON. Described in `@startupjs/cache` readme.

    - disable model cache during execution of react-sharedb `use*` hooks, because these hooks already handle model caching properly themselves

    - you can manually disable caching for a specific component by passing `cache: false` to its `observer()`:

        ```js
        observer(() => pug`Span.title hello world`, { cache: false })
        ````

1. rewrite `replaceObserverLoader` into a new babel plugin `@startupjs/babel-plugin-startupjs-debug`

    - this fixes bugs with non-balanced parenthesis within `observer()` and allows us to easily modify code to pass additional params to it

    - transform `observer()` to add an extra `filename` param to it for debugging

1. Notes:

    - http://localhost:3000/docs/components/draggable - draggable is not updating correctly when cache is enabled, probably because it was relying on extra rerenderings. Using cache in it is disabled.

## Notes

Cache is DISABLED by default because during testing `draggable` was not showing updates correctly with enabled cache, so there might be other components which are broken when cache is enabled. Until we do a bunch of testing on large projects we can't enable it by default.