### PR TITLE
Sidebar: fix root styles

### DIFF
--- a/packages/ui/components/Sidebar/index.styl
+++ b/packages/ui/components/Sidebar/index.styl
@@ -1,5 +1,6 @@
 .root
   flex-direction row
+  flex-grow 1
   flex-shrink 1
 
   &.right


### PR DESCRIPTION
<img width="1434" alt="Снимок экрана 2022-12-26 в 16 25 49" src="https://user-images.githubusercontent.com/95744828/209553695-3629ed92-a01b-4072-a7aa-ae0408bc110c.png">
<img width="1434" alt="Снимок экрана 2022-12-26 в 16 25 54" src="https://user-images.githubusercontent.com/95744828/209553701-8c54fcf9-6de9-4ba3-9dba-82435971f137.png">
