### PR TITLE
fix(cli): Added eslint-plugin-react-hooks to devDeps template

### DIFF
--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -65,6 +65,7 @@ const DEV_DEPENDENCIES = [
   'eslint-plugin-promise',
   'eslint-plugin-react',
   'eslint-plugin-react-pug',
+  'eslint-plugin-react-hooks',
   'eslint-plugin-standard',
   'husky@^4.3.0',
   'lint-staged'


### PR DESCRIPTION
This commit fixes the problem:
Oops! Something went wrong! :(

ESLint: 8.32.0

ESLint couldn't find the plugin "eslint-plugin-react-hooks".

(The package "eslint-plugin-react-hooks" was not found when loaded as a Node module from the directory "/Users/alex/Work/DM/gilleslist".)

It's likely that the plugin isn't installed correctly. Try reinstalling by running the following:

    npm install eslint-plugin-react-hooks@latest --save-dev

The plugin "eslint-plugin-react-hooks" was referenced from the config file in ".eslintrc.json » eslint-config-standard-react".
