### PR TITLE
refactor(babel-plugin-import-to-react-lazy): Refactor and add more tests

### DIFF
--- a/packages/babel-plugin-import-to-react-lazy/__tests__/__snapshots__/index.spec.js.snap
+++ b/packages/babel-plugin-import-to-react-lazy/__tests__/__snapshots__/index.spec.js.snap
@@ -1,11 +1,51 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`@startupjs/babel-plugin-import-to-react-lazy Ignores files with import and export declarations without default specifier: Ignores files with import and export declarations without default specifier 1`] = `
+
+/* @asyncImports */
+import { PHome } from './PHome';
+import { PGames } from './PGames';
+export { PHome, PGames };
+console.log('Hello World');
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { lazy as _lazy } from "react";
+
+/* @asyncImports */
+import { PHome } from "./PHome";
+import { PGames } from "./PGames";
+export { PHome, PGames };
+console.log("Hello World");
+
+
+`;
+
 exports[`@startupjs/babel-plugin-import-to-react-lazy Ignores files without @asyncImports annotation: Ignores files without @asyncImports annotation 1`] = `
 
 console.log('Hello World')
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
+console.log("Hello World");
+
+
+`;
+
+exports[`@startupjs/babel-plugin-import-to-react-lazy Ignores named imports and exports: Ignores named imports and exports 1`] = `
+
+/* @asyncImports */
+import { Home } from './PHome';
+export { Home };
+console.log('Hello World');
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { lazy as _lazy } from "react";
+
+/* @asyncImports */
+import { Home } from "./PHome";
+export { Home };
 console.log("Hello World");
 
 
@@ -63,6 +103,56 @@ console.log('Hello World')
 import { lazy as _lazy } from "react";
 
 /* @asyncImports */
+console.log("Hello World");
+
+
+`;
+
+exports[`@startupjs/babel-plugin-import-to-react-lazy Processes files with multiple exports and a mix of imports and exports: Processes files with multiple exports and a mix of imports and exports 1`] = `
+
+/* @asyncImports */
+import PHome from './PHome';
+import PGames from './PGames';
+export { PHome, PGames };
+export { default as PProfile } from './PProfile';
+console.log('Hello World');
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { lazy as _lazy } from "react";
+
+/* @asyncImports */
+const PHome = _lazy(() => import("./PHome"));
+
+const PGames = _lazy(() => import("./PGames"));
+
+export { PHome, PGames };
+export const PProfile = _lazy(() => import("./PProfile"));
+console.log("Hello World");
+
+
+`;
+
+exports[`@startupjs/babel-plugin-import-to-react-lazy Processes files with multiple import and export declarations: Processes files with multiple import and export declarations 1`] = `
+
+/* @asyncImports */
+import PHome from './PHome';
+import PGames from './PGames';
+export { default as PHome } from './PHome';
+export { default as PGames } from './PGames';
+console.log('Hello World');
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { lazy as _lazy } from "react";
+
+/* @asyncImports */
+const PHome = _lazy(() => import("./PHome"));
+
+const PGames = _lazy(() => import("./PGames"));
+
+export const PHome = _lazy(() => import("./PHome"));
+export const PGames = _lazy(() => import("./PGames"));
 console.log("Hello World");
 
 

--- a/packages/babel-plugin-import-to-react-lazy/__tests__/index.spec.js
+++ b/packages/babel-plugin-import-to-react-lazy/__tests__/index.spec.js
@@ -27,6 +27,35 @@ pluginTester({
       export { default as PHome } from './PHome'
       export { default as PGames } from './PGames'
       console.log('Hello World')
+    `,
+    'Processes files with multiple import and export declarations': /* js */ `
+      /* @asyncImports */
+      import PHome from './PHome';
+      import PGames from './PGames';
+      export { default as PHome } from './PHome';
+      export { default as PGames } from './PGames';
+      console.log('Hello World');
+    `,
+    'Processes files with multiple exports and a mix of imports and exports': /* js */ `
+      /* @asyncImports */
+      import PHome from './PHome';
+      import PGames from './PGames';
+      export { PHome, PGames };
+      export { default as PProfile } from './PProfile';
+      console.log('Hello World');
+    `,
+    'Ignores named imports and exports': /* js */ `
+      /* @asyncImports */
+      import { Home } from './PHome';
+      export { Home };
+      console.log('Hello World');
+    `,
+    'Ignores files with import and export declarations without default specifier': /* js */ `
+      /* @asyncImports */
+      import { PHome } from './PHome';
+      import { PGames } from './PGames';
+      export { PHome, PGames };
+      console.log('Hello World');
     `
   }
 })

--- a/packages/babel-plugin-import-to-react-lazy/index.js
+++ b/packages/babel-plugin-import-to-react-lazy/index.js
@@ -1,110 +1,90 @@
 const { addNamed } = require('@babel/helper-module-imports')
 const template = require('@babel/template').default
-const t = require('@babel/types')
 
 const ASYNC_IMPORTS_ANNOTATION_REGEX = /@asyncImports/
 
-// import PHome from './PHome'
 const buildLazyImport = template(`
   const %%local%% = %%lazy%%(() => import(%%source%%))
 `)
 
-// export { default as PHome } from './PHome'
 const buildLazyExport = template(`
   export const %%exported%% = %%lazy%%(() => import(%%source%%))
 `)
 
 module.exports = function (babel) {
-  let lazy
-  let skip
-
   return {
-    post () {
-      lazy = undefined
-      skip = undefined
-    },
     visitor: {
       Program: {
-        enter (path, state) {
-          skip = !hasAnnotation(state)
-          if (skip) return
-          lazy = addLazyImport(path)
+        enter ($program, state) {
+          if (!hasAnnotation(state)) {
+            $program.stop()
+            return
+          }
+          state.lazy = addLazyImport($program)
+        },
+        exit (_, state) {
+          delete state.lazy
         }
       },
-      ImportDeclaration: (path) => {
-        if (skip) return
-        if (!validateImport(path)) return
+      ImportDeclaration ($import, state) {
+        if (!validateImport($import)) return
 
         const {
           node: {
             source,
-            specifiers: [{
-              local
-            }]
+            specifiers: [{ local }]
           }
-        } = path
-        const lazyImport = buildLazyImport({ local, source, lazy })
+        } = $import
+        const lazyImport = buildLazyImport({ local, source, lazy: state.lazy })
 
-        path.replaceWith(lazyImport)
+        $import.replaceWith(lazyImport)
       },
-      ExportDeclaration: (path) => {
-        if (skip) return
-        if (!validateExport(path)) return
+      ExportDeclaration ($export, state) {
+        if (!validateExport($export)) return
 
         const {
           node: {
             source,
-            specifiers: [{
-              exported
-            }]
+            specifiers: [{ exported }]
           }
-        } = path
-        const lazyExport = buildLazyExport({ exported, source, lazy })
+        } = $export
+        const lazyExport = buildLazyExport({ exported, source, lazy: state.lazy })
 
-        path.replaceWith(lazyExport)
+        $export.replaceWith(lazyExport)
       }
     }
   }
 }
 
-function addLazyImport (path) {
-  return addNamed(path, 'lazy', 'react', {
+function addLazyImport ($program) {
+  return addNamed($program, 'lazy', 'react', {
     importedInterop: 'uncompiled',
     ensureLiveReference: true
   })
 }
 
-// Handle only imports which import a single 'default'
-function validateImport (path) {
-  const { node } = path
+function validateImport ($import) {
+  const { node } = $import
 
-  if (!(
-    node.specifiers &&
-    node.specifiers.length === 1
-  )) return
+  if (!(node.specifiers && node.specifiers.length === 1)) return
 
-  const specifier = node.specifiers[0]
-  if (!t.isImportDefaultSpecifier(specifier)) return
+  const $specifier = $import.get('specifiers.0')
+  if (!$specifier.isImportDefaultSpecifier()) return
 
   return true
 }
 
-// Handle only exports which reexport a single 'default'
-function validateExport (path) {
-  const { node } = path
+function validateExport ($export) {
+  const { node } = $export
 
-  if (!(
-    node.specifiers &&
-    node.specifiers.length === 1
-  )) return
+  if (!(node.specifiers && node.specifiers.length === 1)) return
 
-  const specifier = node.specifiers[0]
-  const { local, exported } = specifier
-  if (!(
-    t.isIdentifier(local) &&
-    local.name === 'default' &&
-    t.isIdentifier(exported)
-  )) return
+  const $specifier = $export.get('specifiers.0')
+  const $local = $specifier.get('local')
+  const $exported = $specifier.get('exported')
+  if (
+    !($local.isIdentifier() && $local.node.name === 'default' && $exported.isIdentifier())
+  ) { return }
 
   return true
 }

--- a/packages/babel-plugin-import-to-react-lazy/index.js
+++ b/packages/babel-plugin-import-to-react-lazy/index.js
@@ -64,9 +64,7 @@ function addLazyImport ($program) {
 }
 
 function validateImport ($import) {
-  const { node } = $import
-
-  if (!(node.specifiers && node.specifiers.length === 1)) return
+  if ($import.get('specifiers').length !== 1) return
 
   const $specifier = $import.get('specifiers.0')
   if (!$specifier.isImportDefaultSpecifier()) return
@@ -75,9 +73,7 @@ function validateImport ($import) {
 }
 
 function validateExport ($export) {
-  const { node } = $export
-
-  if (!(node.specifiers && node.specifiers.length === 1)) return
+  if ($export.get('specifiers').length !== 1) return
 
   const $specifier = $export.get('specifiers.0')
   const $local = $specifier.get('local')


### PR DESCRIPTION
- use $path names
- get rid of global `lazy` and `skip`
- ...and actually get rid of the `skip` directly
- add more tests