### PR TITLE
fix(server): accept correct arguments in gracefulShutdown fn

### DIFF
--- a/packages/server/server/index.js
+++ b/packages/server/server/index.js
@@ -63,7 +63,7 @@ export default async (options) => {
 
 // Handle graceful shutdown of the server
 
-function gracefulShutdown (code) {
+function gracefulShutdown (signaleName, code) {
   console.log('Exiting...')
   if (server) {
     console.log('Http server closing...')


### PR DESCRIPTION
<img width="1064" alt="Screenshot 2023-11-24 at 14 46 35" src="https://github.com/startupjs/startupjs/assets/50324820/f34347ad-0037-4f4e-ae47-6a7ae3df14d5">
