### PR TITLE
DateTimePicker component styles #1168

### DIFF
--- a/packages/ui/components/forms/DateTimePicker/index.js
+++ b/packages/ui/components/forms/DateTimePicker/index.js
@@ -25,6 +25,7 @@ import './index.styl'
 // What about rename date property to value property like in other inputs?
 function DateTimePicker ({
   style,
+  inputStyle,
   dateFormat,
   timeInterval,
   is24Hour,
@@ -153,6 +154,7 @@ function DateTimePicker ({
 
   const inputProps = {
     style,
+    inputStyle,
     ref: inputRef,
     disabled,
     readonly,
@@ -258,6 +260,7 @@ DateTimePicker.defaultProps = {
 
 DateTimePicker.propTypes = {
   style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+  inputStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   timeInterval: PropTypes.number,
   is24Hour: PropTypes.bool,
   date: PropTypes.number,


### PR DESCRIPTION
Try to use `style` prop before changes:
- expected: override input style
- [-] actual result: override input's parent div style (wrapper) ![image](https://github.com/startupjs/startupjs/assets/17129937/47c298dd-117d-4d17-8165-51da46ee5644)

Try to use `inputStyle` prop before changes:
- expected: override input style
- [-] actual result: override input's parent div style (wrapper) ![image](https://github.com/startupjs/startupjs/assets/17129937/28a3e2f6-c632-4af2-800d-fee6c0629597)

Try to use `inputStyle` prop after changes:
- expected: override input style
- [x] actual result: override input style ![image](https://github.com/startupjs/startupjs/assets/17129937/05ecee2b-1a91-407e-af6b-27a1f42e7672)