### PR TITLE
feat(registry): support delayed initialization of plugins. feat(server): add 'clientSession' plugin.

### DIFF
--- a/expoapp/app/(tabs)/index.tsx
+++ b/expoapp/app/(tabs)/index.tsx
@@ -2,13 +2,11 @@ import { useState } from 'react'
 import { StyleSheet } from 'react-native'
 
 import { axios, useValue$, observer, $ } from 'startupjs'
-import { Br, Button, Div } from '@startupjs/ui'
-import EditScreenInfo from '@/components/EditScreenInfo'
+import { Br, Button, Div, Span } from '@startupjs/ui'
 import { Text, View } from '@/components/Themed'
 
-const $banner = $.session.banner
-
 export default observer(function TabOneScreen () {
+  const { $banner, $userId } = $.session
   const $count = useValue$(0)
   const [text, setText] = useState('')
   const [error, setError] = useState('')
@@ -41,10 +39,10 @@ export default observer(function TabOneScreen () {
         </Button>
       </Div>
       <Br />
+      <Span>userId: {$userId.get()}</Span>
+      <Br />
       {text ? <Text>Text: {text}</Text> : undefined}
       {error ? <Text>Error: {error}</Text> : undefined}
-      <View style={styles.separator} lightColor="#eee" darkColor="rgba(255,255,255,0.1)" />
-      <EditScreenInfo path="app/(tabs)/index.tsx" />
     </View>
   )
 })

--- a/expoapp/app/(tabs)/three.js
+++ b/expoapp/app/(tabs)/three.js
@@ -1,6 +1,5 @@
 import { pug, styl, observer } from 'startupjs'
 
-import EditScreenInfo from '@/components/EditScreenInfo'
 import { Text, View } from '@/components/Themed'
 
 export default observer(function TabThreeScreen () {
@@ -26,8 +25,6 @@ export default observer(function TabThreeScreen () {
           Text address 2 is flat
         else
           Text address 2 is NOT flat
-      View.separator(lightColor='#eee' darkColor='rgba(255,255,255,0.1)')
-      EditScreenInfo(path='app/(tabs)/three.js')
   `
 })
 

--- a/expoapp/app/(tabs)/two.tsx
+++ b/expoapp/app/(tabs)/two.tsx
@@ -7,7 +7,6 @@ import {
 } from 'startupjs'
 
 import { H1, Button, Div, Br, alert } from '@startupjs/ui'
-import EditScreenInfo from '@/components/EditScreenInfo'
 import { Text, View } from '@/components/Themed'
 
 export default observer(function TabTwoScreen () {
@@ -27,8 +26,6 @@ export default observer(function TabTwoScreen () {
   return pug`
     View.container
       Text.title Tab Two or yes? no? what's 84
-      View.separator(lightColor="#eee" darkColor="rgba(255,255,255,0.1)")
-      EditScreenInfo(path="app/(tabs)/two.tsx")
       View.separator(lightColor="#eee" darkColor="rgba(255,255,255,0.1)")
       Div(row)
         Button(color='error' onPress=() => $count.increment(-1)) -

--- a/packages/babel-plugin-startupjs-plugins/loader.js
+++ b/packages/babel-plugin-startupjs-plugins/loader.js
@@ -92,6 +92,7 @@ function parsePackage (root, packagePath, _pluginImports = new Set(), _handledPa
 }
 
 function isPartOfFramework (packageJson) {
+  if (/^(?:startupjs|@startupjs\/)/.test(packageJson.name)) return true
   for (const deps of ['peerDependencies', 'dependencies', 'devDependencies']) {
     if (packageJson[deps]?.[MAGIC_DEPENDENCY]) return true
   }

--- a/packages/init/lib/native/index.js
+++ b/packages/init/lib/native/index.js
@@ -12,7 +12,6 @@ import isWeb from '@startupjs/utils/isWeb'
 import axios from '@startupjs/utils/axios'
 import { ROOT_MODULE as MODULE } from '@startupjs/registry'
 import ShareDB from 'sharedb/lib/client'
-import projectAxios from 'axios'
 import commonInit from '../util/common'
 import connectModel from '../util/connectModel'
 
@@ -37,14 +36,6 @@ export default (options = {}) => {
   }
 
   axios.defaults.baseURL = options.baseUrl
-
-  // Patch project-level axios.
-  // People might be using it directly in their project already.
-  // This also works fine if there is no axios on the project level.
-  // We specify it in this package as a peerDependency,
-  // while @startupjs/utils/axios specifies it as a dependency,
-  // so it's guaranteed to be installed in the project.
-  projectAxios.defaults.baseURL = options.baseUrl
 
   globalThis.__startupjsChannelOptions = {
     baseUrl: options.baseUrl,

--- a/packages/registry/createRegistry.js
+++ b/packages/registry/createRegistry.js
@@ -25,7 +25,7 @@ export default function createRegistry ({ RegistryClass = Registry, rootModuleNa
      * we can just write <MODULE.RenderHook /> and not have React
      * complain that component name can't start with the lowercase
      */
-    ROOT_MODULE: registry.getModule(rootModuleName),
+    ROOT_MODULE: registry.rootModule,
 
     /**
      * Get module by name
@@ -43,10 +43,10 @@ export default function createRegistry ({ RegistryClass = Registry, rootModuleNa
      * @param {string} pluginName - name of the plugin
      * @returns {Plugin} plugin instance
      */
-    getPlugin (moduleName = rootModuleName, pluginName) {
+    getPlugin (moduleName, pluginName) {
       if (!pluginName) {
         pluginName = moduleName
-        moduleName = rootModuleName
+        moduleName = registry.rootModule.name
       }
       return registry.getModule(moduleName).getPlugin(pluginName)
     },
@@ -67,7 +67,7 @@ export default function createRegistry ({ RegistryClass = Registry, rootModuleNa
      */
     createPlugin ({ name, for: _for, ...props }) {
       if (!name) throw Error('[@startupjs/registry] Plugin "name" is required')
-      if (!_for) _for = rootModuleName
+      if (!_for) _for = registry.rootModule.name
       const plugin = registry.getModule(_for).getPlugin(name)
       plugin.create(props) // this ensures that the plugin of this name is created only once
       return plugin

--- a/packages/registry/lib/sortPlugins.js
+++ b/packages/registry/lib/sortPlugins.js
@@ -6,6 +6,7 @@ export const ORDER_GROUPS = [
   'first',
   'root',
   'session',
+  'auth',
   'api',
   'pure', // for pure startupjs plugins which don't depend on 'ui' or 'router' being present
   'ui', // for plugins which depend on 'ui' being present and initialized

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -7,6 +7,12 @@
   "version": "0.56.0-alpha.3",
   "type": "module",
   "main": "index.js",
+  "exports": {
+    ".": "./index.js",
+    "./nconf": "./nconf.js",
+    "./nconf.js": "./nconf.js",
+    "./plugins/clientSession.plugin": "./plugins/clientSession.plugin.js"
+  },
   "dependencies": {
     "@startupjs/backend": "^0.56.0-alpha.3",
     "@startupjs/channel": "^0.56.0-alpha.1",

--- a/packages/server/plugins/clientSession.plugin.js
+++ b/packages/server/plugins/clientSession.plugin.js
@@ -1,0 +1,66 @@
+import { Suspense, createElement as el } from 'react'
+import { axios, $ } from 'startupjs'
+import { createPlugin } from '@startupjs/registry'
+
+export default createPlugin({
+  name: 'clientSession',
+  order: 'system session',
+  enabled () { return this.module.options.server },
+  server: () => ({
+    api (expressApp) {
+      expressApp.post('/api/serverSession', function (req, res) {
+        const restoreUrl = req.session.restoreUrl
+        if (restoreUrl) {
+          delete req.session.restoreUrl
+          req.model.set('_session.restoreUrl', restoreUrl)
+        }
+
+        return res.json(req.model.get('_session'))
+      })
+
+      expressApp.post('/api/restore-url', function (req, res) {
+        const { restoreUrl } = req.body
+        req.session.restoreUrl = restoreUrl
+        res.sendStatus(200)
+      })
+    }
+  }),
+  client: () => ({
+    renderRoot ({ children }) {
+      return (
+        el(Suspense, { fallback: null },
+          el(SessionInitializer, {}, children)
+        )
+      )
+    }
+  })
+})
+
+function SessionInitializer ({ children }) {
+  const sessionPromise = initSession()
+  if (sessionPromise) throw sessionPromise
+  return children
+}
+
+let sessionPromise, sessionInitialized, sessionError
+function initSession () {
+  if (sessionError) throw sessionError
+  if (sessionInitialized) return
+  if (sessionPromise) return sessionPromise
+  sessionPromise = (async () => {
+    try {
+      const res = await axios.post('/api/serverSession')
+      // TODO: handle errors like 500 etc.
+      const session = res.data || {}
+      if (typeof session !== 'object') throw Error('Invalid session data. Got: ' + JSON.stringify(session))
+      if (!session.userId) throw Error('Invalid session data - missing userId. Got: ' + JSON.stringify(session))
+      $.session.setEach(session)
+      sessionInitialized = true
+    } catch (err) {
+      sessionError = new Error('[@startupjs/app] Error retrieving _session from server: ' + err.message)
+    } finally {
+      sessionPromise = undefined
+    }
+  })()
+  return sessionPromise
+}

--- a/packages/utils/axios.cjs
+++ b/packages/utils/axios.cjs
@@ -1,0 +1,1 @@
+module.exports = require('axios/dist/browser/axios.cjs')

--- a/packages/utils/axios.d.ts
+++ b/packages/utils/axios.d.ts
@@ -1,2 +1,1 @@
 export { default } from 'axios'
-export * from 'axios'

--- a/packages/utils/axios.js
+++ b/packages/utils/axios.js
@@ -1,2 +1,0 @@
-export { default } from 'axios'
-export * from 'axios'

--- a/packages/utils/axios.server.cjs
+++ b/packages/utils/axios.server.cjs
@@ -1,0 +1,1 @@
+module.exports = require('axios/dist/node/axios.cjs')

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -18,7 +18,10 @@
     "./isWeb": "./isWeb.js",
     "./isDevelopment": "./isDevelopment.js",
     "./useIsomorphicLayoutEffect": "./useIsomorphicLayoutEffect.js",
-    "./axios": "./axios.js",
+    "./axios": {
+      "node": "./axios.server.cjs",
+      "default": "./axios.cjs"
+    },
     "./BASE_URL": {
       "node": "./BASE_URL.server.js",
       "default": "./BASE_URL.js"


### PR DESCRIPTION
- Handle cases when the plugin is initially disabled.
- Support function in 'enabled' setting of plugin to dynamically decide whether to enable the plugin before initialization.
- Add 'clientSession' plugin which passes the model's '_session' from server to the client.
- Specify a particular `axios` dist file (browser one) for our axios reexport, since the default 'axios' import doesn't resolve correctly for some reason on ios and resolves to 'node' variant instead.