### PR TITLE
feat(orm): Autoload orm models from 'model' folder

### DIFF
--- a/expoapp/model/testCounts.[id].mjs
+++ b/expoapp/model/testCounts.[id].mjs
@@ -1,0 +1,14 @@
+import { BaseModel } from 'startupjs/orm'
+
+export default class TestCountModel extends BaseModel {
+  async addSelf () {
+    await this.root.add(this.getCollection(), {
+      id: this.getId(),
+      value: 0
+    })
+  }
+
+  async reset () {
+    await this.set('value', 0)
+  }
+}

--- a/expoapp/startupjs.config.mjs
+++ b/expoapp/startupjs.config.mjs
@@ -1,7 +1,6 @@
 import React from 'react'
 import { createPlugin } from 'startupjs/registry'
 import { pug, styl, $, observer } from 'startupjs'
-import { BaseModel } from 'startupjs/orm'
 import { Span, Div, Button, alert } from '@startupjs/ui'
 import { faTimes } from '@fortawesome/free-solid-svg-icons/faTimes'
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons/faInfoCircle'
@@ -12,12 +11,7 @@ const plugins = createPlugins()
 
 export default {
   isomorphic: {
-    server: true,
-    init: options => ({
-      orm: racer => {
-        racer.orm('testCounts.*', TestCountModel)
-      }
-    })
+    server: true
   },
   server: {
     init: options => ({
@@ -98,16 +92,3 @@ const Banner = observer(({ children, message }) => {
         display none
   `
 })
-
-class TestCountModel extends BaseModel {
-  async addSelf () {
-    await this.root.add(this.getCollection(), {
-      id: this.getId(),
-      value: 0
-    })
-  }
-
-  async reset () {
-    await this.set('value', 0)
-  }
-}

--- a/packages/babel-plugin-startupjs-plugins/__tests__/__snapshots__/index.spec.js.snap
+++ b/packages/babel-plugin-startupjs-plugins/__tests__/__snapshots__/index.spec.js.snap
@@ -16,7 +16,8 @@ console.log(config);
 exports[`@startupjs/babel-plugin-startupjs-plugins Processes files with a magic import: Processes files with a magic import 1`] = `
 
 import { registry } from 'startupjs/registry'
-import config from './startupjs.config.magic.js'
+import config from './startupjs.config.virtual.js'
+import plugins from './startupjs.plugins.virtual.js'
 import dummy from '@dummy/dummy'
 
 registry.init(config)
@@ -26,19 +27,24 @@ dummy(x)
 
 export default () => {}
 
+;(() => {})(plugins)
+
       ↓ ↓ ↓ ↓ ↓ ↓
 
 import { registry } from "startupjs/registry";
 import config from "../../startupjs.config.js";
 import dummy from "@dummy/dummy";
-import _default from "module-1/plugin";
-import _default2 from "module-1-plugin/thePlugin.plugin";
-import _default3 from "../../dummyPlugin.plugin.js";
-(() => {})([_default, _default2, _default3]);
+import _default from "@startupjs/server/plugins/clientSession.plugin";
+import _default2 from "@startupjs/ui/plugin";
+import _default3 from "module-1/plugin";
+import _default4 from "module-1-plugin/thePlugin.plugin";
+import _default5 from "../../dummyPlugin.plugin.js";
+const plugins = [_default, _default2, _default3, _default4, _default5];
 registry.init(config);
 const x = "xxx";
 dummy(x);
 export default () => {};
+(() => {})(plugins);
 
 
 `;
@@ -46,19 +52,25 @@ export default () => {};
 exports[`@startupjs/babel-plugin-startupjs-plugins Test sample file from fixtures which loads config: Test sample file from fixtures which loads config 1`] = `
 
 import { registry } from 'startupjs/registry'
-import config from './startupjs.config.magic.js'
+import config from './startupjs.config.virtual.js'
+import plugins from './startupjs.plugins.virtual.js'
 
 registry.init(config)
+
+;(() => {})(plugins)
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
 import { registry } from "startupjs/registry";
 import config from "../../startupjs.config.js";
-import _default from "module-1/plugin";
-import _default2 from "module-1-plugin/thePlugin.plugin";
-import _default3 from "../../dummyPlugin.plugin.js";
-(() => {})([_default, _default2, _default3]);
+import _default from "@startupjs/server/plugins/clientSession.plugin";
+import _default2 from "@startupjs/ui/plugin";
+import _default3 from "module-1/plugin";
+import _default4 from "module-1-plugin/thePlugin.plugin";
+import _default5 from "../../dummyPlugin.plugin.js";
+const plugins = [_default, _default2, _default3, _default4, _default5];
 registry.init(config);
+(() => {})(plugins);
 
 
 `;

--- a/packages/babel-plugin-startupjs-plugins/__tests__/__snapshots__/index.spec.js.snap
+++ b/packages/babel-plugin-startupjs-plugins/__tests__/__snapshots__/index.spec.js.snap
@@ -17,34 +17,45 @@ exports[`@startupjs/babel-plugin-startupjs-plugins Processes files with a magic 
 
 import { registry } from 'startupjs/registry'
 import config from './startupjs.config.virtual.js'
+import models from './startupjs.models.virtual.js'
 import plugins from './startupjs.plugins.virtual.js'
 import dummy from '@dummy/dummy'
 
-registry.init(config)
+registry.init(config, { plugins, models })
 
 const x = 'xxx'
 dummy(x)
 
 export default () => {}
 
-;(() => {})(plugins)
-
       ↓ ↓ ↓ ↓ ↓ ↓
 
 import { registry } from "startupjs/registry";
 import config from "../../startupjs.config.js";
 import dummy from "@dummy/dummy";
-import _default from "@startupjs/server/plugins/clientSession.plugin";
-import _default2 from "@startupjs/ui/plugin";
-import _default3 from "module-1/plugin";
-import _default4 from "module-1-plugin/thePlugin.plugin";
-import _default5 from "../../dummyPlugin.plugin.js";
-const plugins = [_default, _default2, _default3, _default4, _default5];
-registry.init(config);
+import _default from "../../model/_session.games.[id].js";
+import _default2 from "../../model/_session.games.js";
+import _default3 from "../../model/users.[id].js";
+import _default4 from "../../model/users.js";
+import _default5 from "@startupjs/server/plugins/clientSession.plugin";
+import _default6 from "@startupjs/ui/plugin";
+import _default7 from "module-1/plugin";
+import _default8 from "module-1-plugin/thePlugin.plugin";
+import _default9 from "../../dummyPlugin.plugin.js";
+const plugins = [_default5, _default6, _default7, _default8, _default9];
+const models = {
+  "_session.games.*": _default,
+  "_session.games": _default2,
+  "users.*": _default3,
+  users: _default4,
+};
+registry.init(config, {
+  plugins,
+  models,
+});
 const x = "xxx";
 dummy(x);
 export default () => {};
-(() => {})(plugins);
 
 
 `;
@@ -53,24 +64,35 @@ exports[`@startupjs/babel-plugin-startupjs-plugins Test sample file from fixture
 
 import { registry } from 'startupjs/registry'
 import config from './startupjs.config.virtual.js'
+import models from './startupjs.models.virtual.js'
 import plugins from './startupjs.plugins.virtual.js'
 
-registry.init(config)
-
-;(() => {})(plugins)
+registry.init(config, { plugins, models })
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
 import { registry } from "startupjs/registry";
 import config from "../../startupjs.config.js";
-import _default from "@startupjs/server/plugins/clientSession.plugin";
-import _default2 from "@startupjs/ui/plugin";
-import _default3 from "module-1/plugin";
-import _default4 from "module-1-plugin/thePlugin.plugin";
-import _default5 from "../../dummyPlugin.plugin.js";
-const plugins = [_default, _default2, _default3, _default4, _default5];
-registry.init(config);
-(() => {})(plugins);
+import _default from "../../model/_session.games.[id].js";
+import _default2 from "../../model/_session.games.js";
+import _default3 from "../../model/users.[id].js";
+import _default4 from "../../model/users.js";
+import _default5 from "@startupjs/server/plugins/clientSession.plugin";
+import _default6 from "@startupjs/ui/plugin";
+import _default7 from "module-1/plugin";
+import _default8 from "module-1-plugin/thePlugin.plugin";
+import _default9 from "../../dummyPlugin.plugin.js";
+const plugins = [_default5, _default6, _default7, _default8, _default9];
+const models = {
+  "_session.games.*": _default,
+  "_session.games": _default2,
+  "users.*": _default3,
+  users: _default4,
+};
+registry.init(config, {
+  plugins,
+  models,
+});
 
 
 `;

--- a/packages/babel-plugin-startupjs-plugins/__tests__/index.spec.js
+++ b/packages/babel-plugin-startupjs-plugins/__tests__/index.spec.js
@@ -24,17 +24,16 @@ pluginTester({
     'Processes files with a magic import': /* js */`
       import { registry } from 'startupjs/registry'
       import config from './startupjs.config.virtual.js'
+      import models from './startupjs.models.virtual.js'
       import plugins from './startupjs.plugins.virtual.js'
       import dummy from '@dummy/dummy'
 
-      registry.init(config)
+      registry.init(config, { plugins, models })
 
       const x = 'xxx'
       dummy(x)
 
       export default () => {}
-
-      ;(() => {})(plugins)
     `,
     'Test sample file from fixtures which loads config':
       readFileSync(join(FIXTURES_PATH, './node_modules/config/index.js'), 'utf8')

--- a/packages/babel-plugin-startupjs-plugins/__tests__/index.spec.js
+++ b/packages/babel-plugin-startupjs-plugins/__tests__/index.spec.js
@@ -23,7 +23,8 @@ pluginTester({
     `,
     'Processes files with a magic import': /* js */`
       import { registry } from 'startupjs/registry'
-      import config from './startupjs.config.magic.js'
+      import config from './startupjs.config.virtual.js'
+      import plugins from './startupjs.plugins.virtual.js'
       import dummy from '@dummy/dummy'
 
       registry.init(config)
@@ -32,6 +33,8 @@ pluginTester({
       dummy(x)
 
       export default () => {}
+
+      ;(() => {})(plugins)
     `,
     'Test sample file from fixtures which loads config':
       readFileSync(join(FIXTURES_PATH, './node_modules/config/index.js'), 'utf8')

--- a/packages/babel-plugin-startupjs-plugins/fixtures/model/_session.games.[id].js
+++ b/packages/babel-plugin-startupjs-plugins/fixtures/model/_session.games.[id].js
@@ -1,0 +1,1 @@
+export default class GameModel {}

--- a/packages/babel-plugin-startupjs-plugins/fixtures/model/_session.games.js
+++ b/packages/babel-plugin-startupjs-plugins/fixtures/model/_session.games.js
@@ -1,0 +1,1 @@
+export default class GamesModel {}

--- a/packages/babel-plugin-startupjs-plugins/fixtures/model/users.[id].js
+++ b/packages/babel-plugin-startupjs-plugins/fixtures/model/users.[id].js
@@ -1,0 +1,1 @@
+export default class UserModel {}

--- a/packages/babel-plugin-startupjs-plugins/fixtures/model/users.js
+++ b/packages/babel-plugin-startupjs-plugins/fixtures/model/users.js
@@ -1,0 +1,1 @@
+export default class UsersModel {}

--- a/packages/babel-plugin-startupjs-plugins/fixtures/node_modules/config/index.js
+++ b/packages/babel-plugin-startupjs-plugins/fixtures/node_modules/config/index.js
@@ -1,4 +1,7 @@
 import { registry } from 'startupjs/registry'
-import config from './startupjs.config.magic.js'
+import config from './startupjs.config.virtual.js'
+import plugins from './startupjs.plugins.virtual.js'
 
 registry.init(config)
+
+;(() => {})(plugins)

--- a/packages/babel-plugin-startupjs-plugins/fixtures/node_modules/config/index.js
+++ b/packages/babel-plugin-startupjs-plugins/fixtures/node_modules/config/index.js
@@ -1,7 +1,6 @@
 import { registry } from 'startupjs/registry'
 import config from './startupjs.config.virtual.js'
+import models from './startupjs.models.virtual.js'
 import plugins from './startupjs.plugins.virtual.js'
 
-registry.init(config)
-
-;(() => {})(plugins)
+registry.init(config, { plugins, models })

--- a/packages/babel-plugin-startupjs-plugins/index.js
+++ b/packages/babel-plugin-startupjs-plugins/index.js
@@ -1,10 +1,13 @@
 const { statSync } = require('fs')
 const { addDefault } = require('@babel/helper-module-imports')
-const { getRelativePluginImports, getRelativeConfigImport, getConfigFilePaths } = require('./loader')
+const {
+  getRelativePluginImports, getRelativeConfigImport, getConfigFilePaths, getRelativeModelImports
+} = require('./loader')
 
 const VIRTUAL_CONFIG_IMPORT_REGEX = /(?:^|\/)startupjs\.config\.virtual\.js$/
-// const VIRTUAL_MODEL_IMPORT_REGEX = /(?:^|\/)startupjs\.model\.virtual\.js$/
+const VIRTUAL_MODELS_IMPORT_REGEX = /(?:^|\/)startupjs\.models\.virtual\.js$/
 const VIRTUAL_PLUGINS_IMPORT_REGEX = /(?:^|\/)startupjs\.plugins\.virtual\.js$/
+const MODEL_PATTERN_REGEX = /^[a-zA-Z0-9$_*.]+$/
 
 module.exports = function (api, options) {
   const { types: t, template } = api
@@ -33,6 +36,8 @@ module.exports = function (api, options) {
           return loadVirtualConfig($this, { $program, filename, t, root: options.root })
         } else if (isVirtualImport($this, VIRTUAL_PLUGINS_IMPORT_REGEX)) {
           return loadVirtualPlugins($this, { $program, filename, t, template, root: options.root })
+        } else if (isVirtualImport($this, VIRTUAL_MODELS_IMPORT_REGEX)) {
+          return loadVirtualModels($this, { $program, filename, t, template, root: options.root })
         }
       }
     }
@@ -64,10 +69,35 @@ function loadVirtualPlugins ($import, { $program, filename, t, template, root })
     plugins.push(addDefaultImport($program, pluginImport))
   }
 
-  // dummy usage of plugins to make sure they are not removed by dead code elimination
   const pluginsConst = buildPluginsConst({ name, plugins: t.arrayExpression(plugins) })
   const $lastImport = $program.get('body').filter($i => $i.isImportDeclaration()).pop()
   $lastImport.insertAfter(pluginsConst)
+}
+
+function loadVirtualModels ($import, { $program, filename, t, template, root }) {
+  const buildModelsConst = template('const %%name%% = %%models%%')
+
+  // find all models in the project's `models` directory
+  const modelImports = getRelativeModelImports(filename, root)
+
+  const models = t.objectExpression([])
+  for (const modelFilename in modelImports) {
+    const modelPattern = getModelPattern(modelFilename, $import)
+    models.properties.push(t.objectProperty(
+      t.stringLiteral(modelPattern),
+      addDefaultImport($program, modelImports[modelFilename])
+    ))
+  }
+
+  // remove the original magic import
+  validateModelsImport($import)
+  const name = $import.get('specifiers.0.local').node.name
+  $import.remove()
+
+  // dummy usage of plugins to make sure they are not removed by dead code elimination
+  const modelsConst = buildModelsConst({ name, models })
+  const $lastImport = $program.get('body').filter($i => $i.isImportDeclaration()).pop()
+  $lastImport.insertAfter(modelsConst)
 }
 
 // Handle only magic import which imports a magic function
@@ -92,10 +122,33 @@ function addDefaultImport ($program, sourceName) {
 
 function validatePluginsImport ($import) {
   const $specifiers = $import.get('specifiers')
-  if ($specifiers.length === 0 || $specifiers.length > 1) {
-    throw $import.buildCodeFrameError('Expected a single default import')
+  if ($specifiers.length === 0 || $specifiers.length > 1 || !$specifiers[0].isImportDefaultSpecifier()) {
+    throw $import.buildCodeFrameError('Virtual plugins import must have a single default import')
   }
-  if (!$specifiers[0].isImportDefaultSpecifier()) {
-    throw $import.buildCodeFrameError('Expected a single default import')
+}
+
+function validateModelsImport ($import) {
+  const $specifiers = $import.get('specifiers')
+  if ($specifiers.length === 0 || $specifiers.length > 1 || !$specifiers[0].isImportDefaultSpecifier()) {
+    throw $import.buildCodeFrameError('Virtual models import must have a single default import')
   }
+}
+
+function getModelPattern (modelFilename, $import) {
+  let pattern = modelFilename
+  if (/\*/.test(pattern)) {
+    throw $import.buildCodeFrameError('Instead of `*` in model filename use `[id]`. Got: ' + modelFilename)
+  }
+  // replace [id] with *
+  pattern = pattern.replace(/\[[^\]]*\]/g, '*')
+  // remove extension
+  pattern = pattern.replace(/\.[^.]+$/, '')
+  // validate pattern
+  if (!MODEL_PATTERN_REGEX.test(pattern)) {
+    throw $import.buildCodeFrameError(
+      'Invalid model filename pattern: ' + modelFilename + '\n' +
+      'It has to comply with the following regex: ' + MODEL_PATTERN_REGEX.toString() +
+      ' with `[id]` instead of `*`')
+  }
+  return pattern
 }

--- a/packages/babel-plugin-startupjs-plugins/loader.js
+++ b/packages/babel-plugin-startupjs-plugins/loader.js
@@ -21,7 +21,7 @@
  * The plugins found in "exports" are going to be automatically imported in the main startupjs.config.js file
  * where createProject() is called
  */
-const { existsSync, readFileSync } = require('fs')
+const { existsSync, readFileSync, readdirSync } = require('fs')
 const { join, dirname, relative, resolve: pathResolve } = require('path')
 const resolve = require('resolve')
 
@@ -43,6 +43,21 @@ exports.getRelativeConfigImport = (sourceFilename, root = ROOT) => {
   const relativePath = relative(dirname(pathResolve(root, sourceFilename)), configFilePath)
   if (!relativePath.startsWith('.')) return './' + relativePath
   return relativePath
+}
+
+exports.getRelativeModelImports = (sourceFilename, root = ROOT) => {
+  // find model folder
+  const modelFolder = join(root, 'model')
+  if (!existsSync(modelFolder)) return {}
+  // find all files in the model folder
+  const modelImports = {}
+  for (const filename of readdirSync(modelFolder)) {
+    if (!/\.[mc]?[jt]sx?$/.test(filename)) continue
+    // ignore index.js file if it exists
+    if (/index\.[mc]?[jt]sx?$/.test(filename)) continue
+    modelImports[filename] = relative(dirname(pathResolve(root, sourceFilename)), join(modelFolder, filename))
+  }
+  return modelImports
 }
 
 exports.getRelativePluginImports = (sourceFilename, root = ROOT) => {

--- a/packages/babel-plugin-startupjs-plugins/loader.js
+++ b/packages/babel-plugin-startupjs-plugins/loader.js
@@ -18,8 +18,8 @@
  *                   }
  * 4. scan all dependencies and repeat for each of them
  *
- * The plugins found in "exports" are going to be automatically imported in the main startupjs.config.js file
- * where createProject() is called
+ * The plugins found in "exports" are going to be automatically imported in
+ * @startupjs/registry/loadStartupjsConfig.js file
  */
 const { existsSync, readFileSync, readdirSync } = require('fs')
 const { join, dirname, relative, resolve: pathResolve } = require('path')

--- a/packages/bundler/metro-config.js
+++ b/packages/bundler/metro-config.js
@@ -9,7 +9,8 @@ exports.getDefaultConfig = function getDefaultConfig (projectRoot, { upstreamCon
     ...upstreamConfig,
     transformer: {
       ...upstreamConfig.transformer,
-      babelTransformerPath: require.resolve('./metro-babel-transformer.js')
+      babelTransformerPath: require.resolve('./metro-babel-transformer.js'),
+      unstable_allowRequireContext: true
     },
     resolver: {
       ...upstreamConfig.resolver,

--- a/packages/registry/createRegistry.js
+++ b/packages/registry/createRegistry.js
@@ -87,15 +87,14 @@ export default function createRegistry ({ RegistryClass = Registry, rootModuleNa
     },
 
     /**
-     * Create a project with global configuration.
-     * This is also used to initialize the registry with all the modules and plugins.
-     * And a way to pass options to plugins.
-     * `createProject` is also used as a marker to trigger the babel-plugin-eliminator,
-     * which will keep only the code relevant for a specific env (client/server/isomorphic/build)
-     * in the plugin options.
+     * Initialize the registry with all the modules, plugins and ORM models.
+     * This will also pass options to plugins.
      */
-    createProject (config = {}) {
-      // TODO: Think whether it makes sense to make a separate class for project which will extend Registry
+    initRegistry (config = {}, { plugins, models = {} } = {}) {
+      // TODO: only load models if 'isomorphic' env is present
+      registry.rootModule.on('orm', racer => {
+        for (const modelPattern in models) racer.orm(modelPattern, models[modelPattern])
+      })
       registry.init(config)
       return registry
     }

--- a/packages/registry/index.js
+++ b/packages/registry/index.js
@@ -18,5 +18,6 @@ export const {
   ROOT_MODULE, // root module ('startupjs' framework itself)
   getModule,
   createPlugin,
-  createModule
+  createModule,
+  initRegistry
 } = createRegistry({ RegistryClass, rootModuleName: ROOT_MODULE_NAME })

--- a/packages/registry/loadStartupjsConfig.js
+++ b/packages/registry/loadStartupjsConfig.js
@@ -1,5 +1,10 @@
-import config from './startupjs.config.magic.js'
-import { registry } from './index.js'
+// will import: { ... }
+import config from './virtual/startupjs.config.virtual.js'
+// will import: { 'users': $1, 'users.*': $2, '_session.games': $3, '_session.games.*': $4 }
+import models from './virtual/startupjs.models.virtual.js'
+// will import: [$1, $2, $3, ...]
+import plugins from './virtual/startupjs.plugins.virtual.js'
+import { initRegistry } from './index.js'
 
 let loaded = false
 let wasCustomConfig = false
@@ -16,5 +21,5 @@ export default function loadStartupjsConfig (customConfig) {
   }
   if (customConfig) wasCustomConfig = true
   loaded = true
-  registry.init(customConfig || config || {})
+  initRegistry(customConfig || config || {}, { plugins, models })
 }

--- a/packages/registry/virtual/startupjs.config.virtual.js
+++ b/packages/registry/virtual/startupjs.config.virtual.js
@@ -2,7 +2,7 @@
 //
 // Babel plugin '@startupjs/babel-plugin-startupjs-plugins' will transform
 // ```
-// import './startupjs.config.magic.js'
+// import config from './startupjs.config.virtual.js'
 // ```
 // into the relative path to the actual config file.
 //

--- a/packages/registry/virtual/startupjs.models.virtual.js
+++ b/packages/registry/virtual/startupjs.models.virtual.js
@@ -1,0 +1,30 @@
+// This is virtual module for loading ORM models into startupjs.
+//
+// Babel plugin '@startupjs/babel-plugin-startupjs-plugins' will transform
+// ```
+// import models from './startupjs.models.virtual.js'
+// ```
+// into a imports for each model file from the project's 'model' folder.
+// Filename is used as the path templates for the model.
+//
+// Example:
+//
+//   /model
+//     /users.js
+//     /users.[id].js
+//     /_session.games.js
+//     /_session.games.[id].js
+//
+// Will be transformed into:
+//
+//   import { default as $1 } from './model/users.js'
+//   import { default as $2 } from './model/users.[id].js'
+//   import { default as $3 } from './model/_session.games.js'
+//   import { default as $4 } from './model/_session.games.[id].js'
+//   const models = { users: $1, 'users.*': $2, '_session.games': $3, '_session.games.*': $4 }
+//
+// NOTE: Instead of '*' which used by racer.orm() you must use '[id]' in the filename.
+//
+// This file is only being used directly as a mock if 'model' folder does not exist in the project.
+
+export default {}

--- a/packages/registry/virtual/startupjs.plugins.virtual.js
+++ b/packages/registry/virtual/startupjs.plugins.virtual.js
@@ -1,0 +1,20 @@
+// This is a default startupjs config.
+//
+// Babel plugin '@startupjs/babel-plugin-startupjs-plugins' will transform
+// ```
+// import plugins './startupjs.plugins.virtual.js'
+// ```
+// into a bunch of imports for each plugin found by traversing all "exports"
+// in the project's 'package.json'.
+//
+// Example:
+//   "exports": {
+//     "./plugin": "./plugin.js",
+//     "./advanced/plugin": "./advanced/plugin/index.js",
+//
+// Will be transformed into:
+//   import { default as $1 } from './plugin.js'
+//   import { default as $2 } from './advanced/plugin/index.js'
+//   const plugins = [$1, $2]
+
+export default []

--- a/packages/startupjs/templates/simple/startupjs.config.js
+++ b/packages/startupjs/templates/simple/startupjs.config.js
@@ -1,5 +1,3 @@
-import { createProject } from 'startupjs/registry'
-
-export default createProject({
+export default {
   plugins: {}
-})
+}

--- a/styleguide/startupjs.config.js
+++ b/styleguide/startupjs.config.js
@@ -1,6 +1,4 @@
-import { createProject } from 'startupjs/registry'
-
-export default createProject({
+export default {
   plugins: {
     'serve-static-promo': {
       client: {
@@ -23,4 +21,4 @@ export default createProject({
       }
     }
   }
-})
+}


### PR DESCRIPTION
Implement file-system model loading.

Automatically scan `model` folder in the project's root and load all model from there.

Model filesnames must be named as the pattern which will be used for loading.

Instead of `*` use `[id]`, for example:

```
/model
  users.js
  users.[id].js
  _session.games.js
  _session.games.[id].js
```