### PR TITLE
fix(ui/Link): abstract away usage of router to support both expo-router and react-router

### DIFF
--- a/packages/ui/components/Layout/index.js
+++ b/packages/ui/components/Layout/index.js
@@ -1,28 +1,24 @@
 import React from 'react'
 import { SafeAreaView, StatusBar } from 'react-native'
-import { useHistory } from 'react-router-native'
 import { pug, observer, useBackPress } from 'startupjs'
 import PropTypes from 'prop-types'
+import useRouter from '../../hooks/useRouter'
 import themed from '../../theming/themed'
 import STYLES from './index.styl'
 
-const {
-  config: {
-    bgColor
-  }
-} = STYLES
+const { config: { bgColor } } = STYLES
 
-function Layout ({ style, children }) {
-  const history = useHistory()
+function Layout ({ children }) {
+  const { back, canGoBack } = useRouter()
 
   useBackPress((backHandler) => {
-    if (!history.index) return // if first page then exit app
-    history.goBack()
+    if (!canGoBack()) return // if first page then exit app
+    back()
     return true
   })
 
   return pug`
-    SafeAreaView.root(style=style)
+    SafeAreaView.root(part='root')
       StatusBar(
         backgroundColor=bgColor
         barStyle='dark-content'

--- a/packages/ui/components/Link/index.js
+++ b/packages/ui/components/Link/index.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { Platform, Linking } from 'react-native'
-import { useHistory } from 'react-router-native'
 import { pug, observer } from 'startupjs'
 import PropTypes from 'prop-types'
+import useRouter from '../../hooks/useRouter'
 import Div from './../Div'
 import Button from './../Button'
 import Span from './../typography/Span'
@@ -19,20 +19,27 @@ const EXTERNAL_LINK_REGEXP = /^(https?:\/\/|\/\/)/i
 function Link ({
   style,
   to,
+  href, // alias for `to`
   color,
   theme,
   display,
+  push,
   replace,
   children,
   onPress,
   ...props
 }) {
   if (!display) display = typeof children === 'string' ? 'inline' : 'block'
+  if (href) to = href
 
   const isBlock = display === 'block'
   const Component = isBlock ? Div : Span
   const extraProps = { accessibilityRole: 'link', onPress: handlePress }
-  const history = useHistory()
+  const {
+    navigate: routerNavigate,
+    push: routerPush,
+    replace: routerReplace
+  } = useRouter()
 
   // modifier keys does not work without href attribute
   if (isWeb) extraProps.href = to
@@ -55,7 +62,10 @@ function Link ({
           ? window.open(to, '_blank')
           : Linking.openURL(to)
       } else {
-        const method = replace ? history.replace : history.push
+        let method
+        if (push) method = routerPush
+        else if (replace) method = routerReplace
+        else method = routerNavigate
         method(to)
       }
     }
@@ -99,7 +109,9 @@ Link.propTypes = {
   bold: Span.propTypes.bold,
   italic: Span.propTypes.italic,
   children: PropTypes.node,
-  to: PropTypes.string.isRequired,
+  to: PropTypes.string,
+  href: PropTypes.string,
+  push: PropTypes.bool,
   replace: PropTypes.bool,
   display: PropTypes.oneOf(['inline', 'block']),
   color: PropTypes.oneOf(['default', 'primary'])

--- a/packages/ui/hooks/useRouter.expo.js
+++ b/packages/ui/hooks/useRouter.expo.js
@@ -1,0 +1,6 @@
+import { useRouter as _useRouter } from 'expo-router'
+
+export default function useRouter () {
+  const { replace, push, back, canGoBack, navigate } = _useRouter()
+  return { replace, push, back, canGoBack, navigate }
+}

--- a/packages/ui/hooks/useRouter.js
+++ b/packages/ui/hooks/useRouter.js
@@ -1,0 +1,18 @@
+// this is a universal router hook with a universal interface
+// to use in both react-router (pure RN) and expo-router (Expo) projects.
+// This is a default implementation for pure RN which uses react-router (our 'startupjs/app' package)
+// Expo implementation is in the .expo.js file and uses expo-router.
+// The API emulates the expo-router API.
+import { useCallback } from 'react'
+import { useHistory } from 'react-router'
+
+export default function useRouter () {
+  const history = useHistory()
+  return {
+    replace: history.replace,
+    push: history.push,
+    back: history.goBack,
+    navigate: history.push, // on expo-router this automatically decides to use push or replace
+    canGoBack: useCallback(() => Boolean(history.index), [history])
+  }
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -111,9 +111,7 @@
     "react-native-collapsible": "^1.6.1",
     "react-native-color-picker": "^0.6.0",
     "react-native-drawer-layout-polyfill": "^2.0.0",
-    "react-native-tab-view": "^3.0.0",
-    "react-router-dom": "^5.1.2",
-    "react-router-native": "^5.1.2"
+    "react-native-tab-view": "^3.0.0"
   },
   "peerDependencies": {
     "@react-native-picker/picker": "*",
@@ -122,7 +120,17 @@
     "react-native-gesture-handler": "*",
     "react-native-pager-view": "*",
     "react-native-svg": "*",
-    "startupjs": "*"
+    "startupjs": "*",
+    "react-router": "*",
+    "expo-router": "*"
+  },
+  "peerDependenciesMeta": {
+    "react-router": {
+      "optional": true
+    },
+    "expo-router": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -115,20 +115,20 @@
   },
   "peerDependencies": {
     "@react-native-picker/picker": "*",
+    "expo-router": "*",
     "react": "*",
     "react-native": "*",
     "react-native-gesture-handler": "*",
     "react-native-pager-view": "*",
     "react-native-svg": "*",
-    "startupjs": "*",
     "react-router": "*",
-    "expo-router": "*"
+    "startupjs": "*"
   },
   "peerDependenciesMeta": {
-    "react-router": {
+    "expo-router": {
       "optional": true
     },
-    "expo-router": {
+    "react-router": {
       "optional": true
     }
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8710,16 +8710,21 @@ __metadata:
     react-native-color-picker: "npm:^0.6.0"
     react-native-drawer-layout-polyfill: "npm:^2.0.0"
     react-native-tab-view: "npm:^3.0.0"
-    react-router-dom: "npm:^5.1.2"
-    react-router-native: "npm:^5.1.2"
   peerDependencies:
     "@react-native-picker/picker": "*"
+    expo-router: "*"
     react: "*"
     react-native: "*"
     react-native-gesture-handler: "*"
     react-native-pager-view: "*"
     react-native-svg: "*"
+    react-router: "*"
     startupjs: "*"
+  peerDependenciesMeta:
+    expo-router:
+      optional: true
+    react-router:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
- remove direct dependency on `react-router-web` and `react-router-native` - use `react-router` instead and as a peerDependency.
- add support for 'expo-router'