### PR TITLE
fix(babel-plugin-startupjs-plugins): Use `require.context` on Metro to dynamically load `/model` folder with hot-reloading

### DIFF
--- a/expoapp/app/(tabs)/three.js
+++ b/expoapp/app/(tabs)/three.js
@@ -1,5 +1,4 @@
 import { pug, styl, observer } from 'startupjs'
-
 import { Text, View } from '@/components/Themed'
 
 export default observer(function TabThreeScreen () {

--- a/packages/babel-plugin-startupjs-plugins/README.md
+++ b/packages/babel-plugin-startupjs-plugins/README.md
@@ -40,6 +40,11 @@ const plugins = [
 ]
 ```
 
-## Licence
+## Options
+
+`useRequireContext` -- compile virtual models import to use `require.context` for dynamically
+importing things
+
+## License
 
 MIT

--- a/packages/babel-plugin-startupjs-plugins/__tests__/__snapshots__/index.spec.js.snap
+++ b/packages/babel-plugin-startupjs-plugins/__tests__/__snapshots__/index.spec.js.snap
@@ -55,7 +55,7 @@ const features = {
 const __modelsContext = require.context(
   "../../model",
   false,
-  /\\.[mc]?[jt]sx?$/
+  /^(?!.*(?:\\/|^)index\\.[mc]?[jt]sx?$).*\\.[mc]?[jt]sx?$/
 );
 const models = __modelsContext.keys().reduce((res, filename) => {
   const pattern = __getModelPattern(filename);

--- a/packages/babel-plugin-startupjs-plugins/__tests__/__snapshots__/index.spec.js.snap
+++ b/packages/babel-plugin-startupjs-plugins/__tests__/__snapshots__/index.spec.js.snap
@@ -61,7 +61,7 @@ const models = __modelsContext.keys().reduce((res, filename) => {
   const pattern = __getModelPattern(filename);
   return {
     ...res,
-    [pattern]: __modelsContext(filename),
+    [pattern]: __modelsContext(filename).default,
   };
 }, {});
 function __getModelPattern() {
@@ -75,6 +75,7 @@ function __getModelPattern() {
     );
   }
   pattern = pattern.replace(/\\[[^\\]]*\\]/g, "*");
+  pattern = pattern.replace(/^.+[\\\\/]/, "");
   pattern = pattern.replace(/\\.[^.]+$/, "");
   if (!MODEL_PATTERN_REGEX.test(pattern)) {
     throw Error(

--- a/packages/babel-plugin-startupjs-plugins/__tests__/__snapshots__/index.spec.js.snap
+++ b/packages/babel-plugin-startupjs-plugins/__tests__/__snapshots__/index.spec.js.snap
@@ -55,7 +55,7 @@ const features = {
 const __modelsContext = require.context(
   "../../model",
   false,
-  /^(?!.*(?:\\/|^)index\\.[mc]?[jt]sx?$).*\\.[mc]?[jt]sx?$/
+  /\\.[mc]?[jt]sx?$/
 );
 const models = __modelsContext.keys().reduce((res, filename) => {
   const pattern = __getModelPattern(filename);
@@ -87,6 +87,7 @@ function __getModelPattern() {
         " with '[id]' instead of '*'"
     );
   }
+  if (pattern === "index") pattern = "";
   return pattern;
 }
 config.features = features;
@@ -125,21 +126,22 @@ import config from "../../startupjs.config.js";
 import dummy from "@dummy/dummy";
 import _default from "../../model/_session.games.[id].js";
 import _default2 from "../../model/_session.games.js";
-import _default3 from "../../model/users.[id].js";
-import _default4 from "../../model/users.js";
-import _default5 from "@startupjs/server/plugins/clientSession.plugin";
-import _default6 from "@startupjs/ui/plugin";
-import _default7 from "startupjs/plugins/cssMediaUpdater.plugin";
-import _default8 from "module-1/plugin";
-import _default9 from "module-1-plugin/thePlugin.plugin";
-import _default10 from "../../dummyPlugin.plugin.js";
+import _default3 from "../../model/index.js";
+import _default4 from "../../model/users.[id].js";
+import _default5 from "../../model/users.js";
+import _default6 from "@startupjs/server/plugins/clientSession.plugin";
+import _default7 from "@startupjs/ui/plugin";
+import _default8 from "startupjs/plugins/cssMediaUpdater.plugin";
+import _default9 from "module-1/plugin";
+import _default10 from "module-1-plugin/thePlugin.plugin";
+import _default11 from "../../dummyPlugin.plugin.js";
 const plugins = [
-  _default5,
   _default6,
   _default7,
   _default8,
   _default9,
   _default10,
+  _default11,
 ];
 const features = {
   enableServer: true,
@@ -147,8 +149,9 @@ const features = {
 const models = {
   "_session.games.*": _default,
   "_session.games": _default2,
-  "users.*": _default3,
-  users: _default4,
+  "": _default3,
+  "users.*": _default4,
+  users: _default5,
 };
 config.features = features;
 registry.init(config, {
@@ -179,21 +182,22 @@ import { registry } from "startupjs/registry";
 import config from "../../startupjs.config.js";
 import _default from "../../model/_session.games.[id].js";
 import _default2 from "../../model/_session.games.js";
-import _default3 from "../../model/users.[id].js";
-import _default4 from "../../model/users.js";
-import _default5 from "@startupjs/server/plugins/clientSession.plugin";
-import _default6 from "@startupjs/ui/plugin";
-import _default7 from "startupjs/plugins/cssMediaUpdater.plugin";
-import _default8 from "module-1/plugin";
-import _default9 from "module-1-plugin/thePlugin.plugin";
-import _default10 from "../../dummyPlugin.plugin.js";
+import _default3 from "../../model/index.js";
+import _default4 from "../../model/users.[id].js";
+import _default5 from "../../model/users.js";
+import _default6 from "@startupjs/server/plugins/clientSession.plugin";
+import _default7 from "@startupjs/ui/plugin";
+import _default8 from "startupjs/plugins/cssMediaUpdater.plugin";
+import _default9 from "module-1/plugin";
+import _default10 from "module-1-plugin/thePlugin.plugin";
+import _default11 from "../../dummyPlugin.plugin.js";
 const plugins = [
-  _default5,
   _default6,
   _default7,
   _default8,
   _default9,
   _default10,
+  _default11,
 ];
 const features = {
   enableServer: true,
@@ -201,8 +205,9 @@ const features = {
 const models = {
   "_session.games.*": _default,
   "_session.games": _default2,
-  "users.*": _default3,
-  users: _default4,
+  "": _default3,
+  "users.*": _default4,
+  users: _default5,
 };
 config.features = features;
 registry.init(config, {

--- a/packages/babel-plugin-startupjs-plugins/__tests__/__snapshots__/index.spec.js.snap
+++ b/packages/babel-plugin-startupjs-plugins/__tests__/__snapshots__/index.spec.js.snap
@@ -13,6 +13,93 @@ console.log(config);
 
 `;
 
+exports[`@startupjs/babel-plugin-startupjs-plugins On Metro uses require.context for models: On Metro uses require.context for models 1`] = `
+
+import { registry } from 'startupjs/registry'
+import config from './startupjs.config.virtual.js'
+import models from './startupjs.models.virtual.js'
+import features from './startupjs.features.virtual.js'
+import plugins from './startupjs.plugins.virtual.js'
+import dummy from '@dummy/dummy'
+
+config.features = features
+registry.init(config, { plugins, models })
+
+const x = 'xxx'
+dummy(x)
+
+export default () => {}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { registry } from "startupjs/registry";
+import config from "../../startupjs.config.js";
+import dummy from "@dummy/dummy";
+import _default from "@startupjs/server/plugins/clientSession.plugin";
+import _default2 from "@startupjs/ui/plugin";
+import _default3 from "startupjs/plugins/cssMediaUpdater.plugin";
+import _default4 from "module-1/plugin";
+import _default5 from "module-1-plugin/thePlugin.plugin";
+import _default6 from "../../dummyPlugin.plugin.js";
+const plugins = [
+  _default,
+  _default2,
+  _default3,
+  _default4,
+  _default5,
+  _default6,
+];
+const features = {
+  enableServer: true,
+};
+const __modelsContext = require.context(
+  "../../model",
+  false,
+  /\\.[mc]?[jt]sx?$/
+);
+const models = __modelsContext.keys().reduce((res, filename) => {
+  const pattern = __getModelPattern(filename);
+  return {
+    ...res,
+    [pattern]: __modelsContext(filename),
+  };
+}, {});
+function __getModelPattern() {
+  const modelFilename = arguments[0];
+  const MODEL_PATTERN_REGEX = /^[a-zA-Z0-9$_*.]+$/;
+  let pattern = modelFilename;
+  if (/\\*/.test(pattern)) {
+    throw Error(
+      "[models] Instead of '*' in model filename use '[id]'. Got: " +
+        modelFilename
+    );
+  }
+  pattern = pattern.replace(/\\[[^\\]]*\\]/g, "*");
+  pattern = pattern.replace(/\\.[^.]+$/, "");
+  if (!MODEL_PATTERN_REGEX.test(pattern)) {
+    throw Error(
+      "[models] Invalid model filename pattern: " +
+        modelFilename +
+        "\\n" +
+        "It has to comply with the following regex: " +
+        MODEL_PATTERN_REGEX.toString() +
+        " with '[id]' instead of '*'"
+    );
+  }
+  return pattern;
+}
+config.features = features;
+registry.init(config, {
+  plugins,
+  models,
+});
+const x = "xxx";
+dummy(x);
+export default () => {};
+
+
+`;
+
 exports[`@startupjs/babel-plugin-startupjs-plugins Processes files with a magic import: Processes files with a magic import 1`] = `
 
 import { registry } from 'startupjs/registry'
@@ -41,10 +128,18 @@ import _default3 from "../../model/users.[id].js";
 import _default4 from "../../model/users.js";
 import _default5 from "@startupjs/server/plugins/clientSession.plugin";
 import _default6 from "@startupjs/ui/plugin";
-import _default7 from "module-1/plugin";
-import _default8 from "module-1-plugin/thePlugin.plugin";
-import _default9 from "../../dummyPlugin.plugin.js";
-const plugins = [_default5, _default6, _default7, _default8, _default9];
+import _default7 from "startupjs/plugins/cssMediaUpdater.plugin";
+import _default8 from "module-1/plugin";
+import _default9 from "module-1-plugin/thePlugin.plugin";
+import _default10 from "../../dummyPlugin.plugin.js";
+const plugins = [
+  _default5,
+  _default6,
+  _default7,
+  _default8,
+  _default9,
+  _default10,
+];
 const features = {
   enableServer: true,
 };
@@ -87,10 +182,18 @@ import _default3 from "../../model/users.[id].js";
 import _default4 from "../../model/users.js";
 import _default5 from "@startupjs/server/plugins/clientSession.plugin";
 import _default6 from "@startupjs/ui/plugin";
-import _default7 from "module-1/plugin";
-import _default8 from "module-1-plugin/thePlugin.plugin";
-import _default9 from "../../dummyPlugin.plugin.js";
-const plugins = [_default5, _default6, _default7, _default8, _default9];
+import _default7 from "startupjs/plugins/cssMediaUpdater.plugin";
+import _default8 from "module-1/plugin";
+import _default9 from "module-1-plugin/thePlugin.plugin";
+import _default10 from "../../dummyPlugin.plugin.js";
+const plugins = [
+  _default5,
+  _default6,
+  _default7,
+  _default8,
+  _default9,
+  _default10,
+];
 const features = {
   enableServer: true,
 };

--- a/packages/babel-plugin-startupjs-plugins/__tests__/index.spec.js
+++ b/packages/babel-plugin-startupjs-plugins/__tests__/index.spec.js
@@ -41,3 +41,34 @@ pluginTester({
       readFileSync(join(FIXTURES_PATH, './node_modules/config/index.js'), 'utf8')
   }
 })
+
+pluginTester({
+  plugin,
+  pluginName,
+  snapshot: true,
+  pluginOptions: {
+    root: FIXTURES_PATH,
+    useRequireContext: true
+  },
+  babelOptions: {
+    filename: join(FIXTURES_PATH, './node_modules/config/index.js')
+  },
+  tests: {
+    'On Metro uses require.context for models': /* js */`
+      import { registry } from 'startupjs/registry'
+      import config from './startupjs.config.virtual.js'
+      import models from './startupjs.models.virtual.js'
+      import features from './startupjs.features.virtual.js'
+      import plugins from './startupjs.plugins.virtual.js'
+      import dummy from '@dummy/dummy'
+
+      config.features = features
+      registry.init(config, { plugins, models })
+
+      const x = 'xxx'
+      dummy(x)
+
+      export default () => {}
+    `
+  }
+})

--- a/packages/babel-plugin-startupjs-plugins/fixtures/model/index.js
+++ b/packages/babel-plugin-startupjs-plugins/fixtures/model/index.js
@@ -1,0 +1,1 @@
+export default class RootModel {}

--- a/packages/babel-plugin-startupjs-plugins/index.js
+++ b/packages/babel-plugin-startupjs-plugins/index.js
@@ -109,8 +109,13 @@ function loadVirtualModels ($import, { $program, filename, t, template, root }) 
 }
 
 function loadVirtualModelsRequireContext ($import, { $program, filename, t, template, root }) {
+  // model/index.js file is ignored
   const buildModelsConst = template(/* js */`
-    const __modelsContext = require.context(%%folder%%, false, /\\.[mc]?[jt]sx?$/)
+    const __modelsContext = require.context(
+      %%folder%%,
+      false,
+      /^(?!.*(?:\\/|^)index\\.[mc]?[jt]sx?$).*\\.[mc]?[jt]sx?$/
+    )
     const %%name%% = __modelsContext.keys().reduce(
       (res, filename) => {
         const pattern = __getModelPattern(filename)

--- a/packages/babel-plugin-startupjs-plugins/index.js
+++ b/packages/babel-plugin-startupjs-plugins/index.js
@@ -253,7 +253,7 @@ function getModelPatternFunction ({ precompiled = false, functionName = '__getMo
     // for usage in the babel plugin itself
     // replace placeholder with $import to build a code frame error at compile time
     functionBody = functionBody.replace('/* $1 */', 'const $import = arguments[1]')
-    functionBody = functionBody.replace('throw Error', 'throw $import.buildCodeFrameError')
+    functionBody = functionBody.replace(/throw Error/g, 'throw $import.buildCodeFrameError')
     return new Function(functionBody) // eslint-disable-line no-new-func
   }
 }

--- a/packages/babel-plugin-startupjs-plugins/index.js
+++ b/packages/babel-plugin-startupjs-plugins/index.js
@@ -111,11 +111,7 @@ function loadVirtualModels ($import, { $program, filename, t, template, root }) 
 function loadVirtualModelsRequireContext ($import, { $program, filename, t, template, root }) {
   // model/index.js file is ignored
   const buildModelsConst = template(/* js */`
-    const __modelsContext = require.context(
-      %%folder%%,
-      false,
-      /^(?!.*(?:\\/|^)index\\.[mc]?[jt]sx?$).*\\.[mc]?[jt]sx?$/
-    )
+    const __modelsContext = require.context(%%folder%%, false, /\\.[mc]?[jt]sx?$/)
     const %%name%% = __modelsContext.keys().reduce(
       (res, filename) => {
         const pattern = __getModelPattern(filename)
@@ -237,6 +233,8 @@ function getModelPatternFunction ({ precompiled = false, functionName = '__getMo
         "It has to comply with the following regex: " + MODEL_PATTERN_REGEX.toString() +
         " with '[id]' instead of '*'")
     }
+    // 'index' is a special case -- root model
+    if (pattern === 'index') pattern = ''
     return pattern
   `
   if (precompiled) {

--- a/packages/babel-plugin-startupjs-plugins/index.js
+++ b/packages/babel-plugin-startupjs-plugins/index.js
@@ -2,14 +2,13 @@ const { statSync } = require('fs')
 const { addDefault } = require('@babel/helper-module-imports')
 const {
   getRelativePluginImports, getRelativeConfigImport, getConfigFilePaths,
-  getRelativeModelImports, getFeatures
+  getRelativeModelImports, getFeatures, getRelativeModelRequireContextPath
 } = require('./loader')
 
 const VIRTUAL_CONFIG_IMPORT_REGEX = /(?:^|\/)startupjs\.config\.virtual\.js$/
 const VIRTUAL_MODELS_IMPORT_REGEX = /(?:^|\/)startupjs\.models\.virtual\.js$/
 const VIRTUAL_PLUGINS_IMPORT_REGEX = /(?:^|\/)startupjs\.plugins\.virtual\.js$/
 const VIRTUAL_FEATURES_IMPORT_REGEX = /(?:^|\/)startupjs\.features\.virtual\.js$/
-const MODEL_PATTERN_REGEX = /^[a-zA-Z0-9$_*.]+$/
 
 module.exports = function (api, options) {
   const { types: t, template } = api
@@ -39,7 +38,11 @@ module.exports = function (api, options) {
         } else if (isVirtualImport($this, VIRTUAL_PLUGINS_IMPORT_REGEX)) {
           return loadVirtualPlugins($this, { $program, filename, t, template, root: options.root })
         } else if (isVirtualImport($this, VIRTUAL_MODELS_IMPORT_REGEX)) {
-          return loadVirtualModels($this, { $program, filename, t, template, root: options.root })
+          if (options.useRequireContext) {
+            return loadVirtualModelsRequireContext($this, { $program, filename, t, template, root: options.root })
+          } else {
+            return loadVirtualModels($this, { $program, filename, t, template, root: options.root })
+          }
         } else if (isVirtualImport($this, VIRTUAL_FEATURES_IMPORT_REGEX)) {
           return loadVirtualFeatures($this, { $program, t, template, root: options.root })
         }
@@ -101,6 +104,34 @@ function loadVirtualModels ($import, { $program, filename, t, template, root }) 
 
   // dummy usage of plugins to make sure they are not removed by dead code elimination
   const modelsConst = buildModelsConst({ name, models })
+  const $lastImport = $program.get('body').filter($i => $i.isImportDeclaration()).pop()
+  $lastImport.insertAfter(modelsConst)
+}
+
+function loadVirtualModelsRequireContext ($import, { $program, filename, t, template, root }) {
+  const buildModelsConst = template(/* js */`
+    const __modelsContext = require.context(%%folder%%, false, /\\.[mc]?[jt]sx?$/)
+    const %%name%% = __modelsContext.keys().reduce(
+      (res, filename) => {
+        const pattern = __getModelPattern(filename)
+        return { ...res, [pattern]: __modelsContext(filename).default }
+      },
+      {}
+    )
+    ${getModelPatternFunction({ precompiled: true, functionName: '__getModelPattern' })}
+  `)
+  validateModelsImport($import)
+
+  const requireContextFolder = getRelativeModelRequireContextPath(filename, root)
+
+  // remove the original magic import
+  const name = $import.get('specifiers.0.local').node.name
+  $import.remove()
+
+  const modelsConst = buildModelsConst({
+    name,
+    folder: t.stringLiteral(requireContextFolder)
+  })
   const $lastImport = $program.get('body').filter($i => $i.isImportDeclaration()).pop()
   $lastImport.insertAfter(modelsConst)
 }
@@ -173,21 +204,53 @@ function validateFeaturesImport ($import) {
   }
 }
 
-function getModelPattern (modelFilename, $import) {
-  let pattern = modelFilename
-  if (/\*/.test(pattern)) {
-    throw $import.buildCodeFrameError('Instead of `*` in model filename use `[id]`. Got: ' + modelFilename)
+const getModelPattern = getModelPatternFunction()
+
+// IMPORTANT: this function is used in both in the babel plugin itself and
+//            can be output to the generated code when using require.context for models.
+//            - default implementation is for usage in the generated code and throws runtime errors.
+//            - when using in babel instead of `throw Error` we do `throw $import.buildCodeFrameError`
+function getModelPatternFunction ({ precompiled = false, functionName = '__getModelPattern' } = {}) {
+  let functionBody = /* js */`
+    const modelFilename = arguments[0]
+    /* $1 */
+    const MODEL_PATTERN_REGEX = /^[a-zA-Z0-9$_*.]+$/
+    let pattern = modelFilename
+    if (/\\*/.test(pattern)) {
+      throw Error("[models] Instead of '*' in model filename use '[id]'. Got: " + modelFilename)
+    }
+    // replace [id] with *
+    pattern = pattern.replace(/\\[[^\\]]*\\]/g, '*')
+    // remove leading path
+    pattern = pattern.replace(/^.+[\\\\/]/, '')
+    // remove extension
+    pattern = pattern.replace(/\\.[^.]+$/, '')
+    // validate pattern
+    if (!MODEL_PATTERN_REGEX.test(pattern)) {
+      throw Error(
+        "[models] Invalid model filename pattern: " + modelFilename + "\\n" +
+        "It has to comply with the following regex: " + MODEL_PATTERN_REGEX.toString() +
+        " with '[id]' instead of '*'")
+    }
+    return pattern
+  `
+  if (precompiled) {
+    // for usage in the generated code
+    if (typeof functionName !== 'string') throw Error('functionName has to be a string')
+    // guard from possible injections
+    if (!/^[a-zA-Z_]+$/.test(functionName)) throw Error('functionName can only contain letters and an underscore')
+    // get rid of the placeholder since we just throw runtime errors
+    functionBody = functionBody.replace('/* $1 */', '')
+    return `
+      function ${functionName} () {
+        ${functionBody}
+      }
+    `
+  } else {
+    // for usage in the babel plugin itself
+    // replace placeholder with $import to build a code frame error at compile time
+    functionBody = functionBody.replace('/* $1 */', 'const $import = arguments[1]')
+    functionBody = functionBody.replace('throw Error', 'throw $import.buildCodeFrameError')
+    return new Function(functionBody) // eslint-disable-line no-new-func
   }
-  // replace [id] with *
-  pattern = pattern.replace(/\[[^\]]*\]/g, '*')
-  // remove extension
-  pattern = pattern.replace(/\.[^.]+$/, '')
-  // validate pattern
-  if (!MODEL_PATTERN_REGEX.test(pattern)) {
-    throw $import.buildCodeFrameError(
-      'Invalid model filename pattern: ' + modelFilename + '\n' +
-      'It has to comply with the following regex: ' + MODEL_PATTERN_REGEX.toString() +
-      ' with `[id]` instead of `*`')
-  }
-  return pattern
 }

--- a/packages/babel-plugin-startupjs-plugins/loader.js
+++ b/packages/babel-plugin-startupjs-plugins/loader.js
@@ -45,6 +45,11 @@ exports.getRelativeConfigImport = (sourceFilename, root = ROOT) => {
   return relativePath
 }
 
+exports.getRelativeModelRequireContextPath = (sourceFilename, root = ROOT) => {
+  const modelFolder = join(root, 'model')
+  return relative(dirname(pathResolve(root, sourceFilename)), modelFolder)
+}
+
 exports.getRelativeModelImports = (sourceFilename, root = ROOT) => {
   // find model folder
   const modelFolder = join(root, 'model')

--- a/packages/babel-plugin-startupjs-plugins/loader.js
+++ b/packages/babel-plugin-startupjs-plugins/loader.js
@@ -58,8 +58,6 @@ exports.getRelativeModelImports = (sourceFilename, root = ROOT) => {
   const modelImports = {}
   for (const filename of readdirSync(modelFolder)) {
     if (!/\.[mc]?[jt]sx?$/.test(filename)) continue
-    // ignore index.js file if it exists
-    if (/index\.[mc]?[jt]sx?$/.test(filename)) continue
     modelImports[filename] = relative(dirname(pathResolve(root, sourceFilename)), join(modelFolder, filename))
   }
   return modelImports

--- a/packages/bundler/lib/eliminatorLoader.js
+++ b/packages/bundler/lib/eliminatorLoader.js
@@ -16,6 +16,8 @@ module.exports = function eliminatorLoader (source) {
   const envs = this.query.envs
   if (!envs) throw Error("eliminatorLoader: envs not provided (for example ['features', 'isomorphic', 'client'])")
 
+  const useRequireContext = this.query.useRequireContext
+
   let code = source
 
   // STEP 1: convert pug to jsx and auto-load startupjs plugins
@@ -37,7 +39,7 @@ module.exports = function eliminatorLoader (source) {
       }],
       // traverse "exports" of package.json and all dependencies to find all startupjs plugins
       // and automatically import them in the main startupjs.config.js file
-      require('@startupjs/babel-plugin-startupjs-plugins')
+      [require('@startupjs/babel-plugin-startupjs-plugins'), { useRequireContext }]
     ]
   }).code
 

--- a/packages/bundler/metro-babel-transformer.js
+++ b/packages/bundler/metro-babel-transformer.js
@@ -32,7 +32,10 @@ module.exports.transform = async function startupjsMetroBabelTransform ({
 
   // js transformations
   if (/\.[mc]?[jt]sx?$/.test(filename)) {
-    src = callLoader(eliminatorLoader, src, filename, { envs: ['features', 'isomorphic', 'client'] })
+    src = callLoader(eliminatorLoader, src, filename, {
+      envs: ['features', 'isomorphic', 'client'],
+      useRequireContext: true
+    })
   }
   if ((/\.mdx?$/.test(filename) || /\.[mc]?[jt]sx?$/.test(filename)) && /['"](?:startupjs|@env)['"]/.test(src)) {
     src = callLoader(startupjsLoader, src, filename, { platform })


### PR DESCRIPTION
on Metro when handling the virtual model folder import it's now transformed into `require.context` (which follows Webpack spec).

So now if you create the `model` folder and add files to it -- it will dynamically add them and reload the page.

on Node we load as usual (will add some workaround later for dynamically updating models on Node too).

Also, handle `/model/index.js` file as the root model.