### PR TITLE
feat(ui/Form): Simplify api to validate the form - useValidate() and Form(validate)

### DIFF
--- a/packages/ui/components/forms/Form/index.js
+++ b/packages/ui/components/forms/Form/index.js
@@ -13,6 +13,7 @@ function Form ({
   properties,
   order,
   row,
+  errors,
   _renderWrapper,
   validate,
   style,
@@ -87,7 +88,7 @@ function Form ({
           $value=$value
           order=order
           row=row
-          errors=$errors.get()
+          errors=errors || $errors.get()
           style=style
           inputStyle=inputStyle
           _renderWrapper=_renderWrapper

--- a/packages/ui/components/forms/Form/index.js
+++ b/packages/ui/components/forms/Form/index.js
@@ -1,13 +1,11 @@
-import React, { useMemo, useCallback, useRef, useState } from 'react'
+import React, { useMemo, useCallback, useState, useId } from 'react'
 import { pug, observer, useOn, useValue$ } from 'startupjs'
-import { transformSchema, ajv } from '@startupjs/schema'
-import _set from 'lodash/set'
-import _get from 'lodash/get'
 import _debounce from 'lodash/debounce'
 import PropTypes from 'prop-types'
 import ObjectInput from '../ObjectInput'
 import { CustomInputsContext } from './useCustomInputs'
 import { FormPropsContext } from './useFormProps'
+import { Validator } from './useValidate'
 
 function Form ({
   fields = {},
@@ -25,8 +23,7 @@ function Form ({
   if (properties) throw Error(ERROR_PROPERTIES)
   const { disabled, readonly, $value } = props
 
-  const shouldValidateRef = useRef()
-  const hasErrorsRef = useRef()
+  const formId = useId()
   const forceUpdate = useForceUpdate()
 
   const memoizedFields = useMemo(
@@ -35,14 +32,17 @@ function Form ({
   )
 
   const $errors = useValue$() // eslint-disable-line react-hooks/rules-of-hooks
+  const validator = useMemo(() => new Validator(), [])
 
-  const runValidation = useMemo(() => {
-    let schema = $fields?.get() || memoizedFields
-    // we allow extra properties in Form to let people just pass the full document
-    // instead of forcing them to pick only the fields used in schema
-    schema = transformSchema(schema, { additionalProperties: true })
-    return ajv.compile(schema)
-  }, [JSON.stringify(memoizedFields), $fields])
+  useMemo(() => {
+    validator.init({
+      fields: $fields?.get() || memoizedFields,
+      getValue: () => $value.get(),
+      $errors,
+      forceUpdate,
+      formId
+    })
+  }, [JSON.stringify(memoizedFields), $fields, $value, $errors, forceUpdate, formId])
 
   const memoizedProps = useMemo(
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -54,91 +54,28 @@ function Form ({
     () => customInputs, [...Object.keys(customInputs), ...Object.values(customInputs)]
   )
 
-  const validateNow = useCallback(() => {
-    if (!(
-      shouldValidateRef.current ||
-      (typeof validate === 'function' && validate._shouldValidate)
-    )) return
-    const valid = runValidation($value.get())
-    if (valid) {
-      if (hasErrorsRef.current) {
-        hasErrorsRef.current = false
-        $errors.del()
-        if (typeof validate === 'function') {
-          validate._hasErrors = false
-          delete validate._errors
-          if (validate._shouldForceUpdate) validate._forceUpdate()
-        }
-        forceUpdate()
-      }
-      return true
-    }
-    const localErrors = {}
-    for (const error of runValidation.errors) {
-      const path = error.instancePath.replace(/^\//, '').split('/')
-      // handle special case for 'required' fields.
-      // It happens on the level above the field which is actually required
-      // and the actual field name is located in params.missingProperty
-      let message = error.message
-      if (error.keyword === 'required') {
-        if (path.length > 0 && path[path.length - 1] === '') path.pop()
-        path.push(error.params.missingProperty)
-        message = 'This field is required'
-      }
-      if (!_get(localErrors, path)) _set(localErrors, path, [])
-      _get(localErrors, path).push(message)
-    }
-    $errors.setDiffDeep(localErrors)
-    if (!hasErrorsRef.current) {
-      hasErrorsRef.current = true
-      if (typeof validate === 'function' && !validate._hasErrors) {
-        validate._hasErrors = true
-        validate._errors = $errors.get()
-        if (validate._shouldForceUpdate) validate._forceUpdate()
-      }
-      forceUpdate()
-    }
-    return false
-  }, [runValidation, $value])
-
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const debouncedValidate = useCallback(
-    _debounce(validateNow, 30, { leading: false, trailing: true })
-    , [validateNow]
+    _debounce(() => validator.run(), 30, { leading: false, trailing: true }),
+    [validator]
   )
 
   useOn('all', $value.path() + '.**', debouncedValidate)
 
-  function resetValidate () {
-    delete validate._hasErrors
-    delete validate._errors
-    delete validate._shouldValidate
-    delete validate._validateNow
-  }
-
   useMemo(() => {
     // if validate prop is set, trigger validation right away on mount.
     if (validate === true) {
-      shouldValidateRef.current = true
-      validateNow()
+      validator.activate()
+      validator.run()
     } else if (typeof validate === 'function') {
-      const hadErrors = validate._hasErrors
-      resetValidate()
-      validate._validateNow = validateNow
+      validate.reset()
+      validate.init({ validator, formId })
       if (validate.always) {
-        validate._shouldValidate = true
-        validateNow()
-      } else {
-        if (hadErrors && validate._shouldForceUpdate) validate._forceUpdate()
+        validator.activate()
+        validator.run()
       }
-    }
-    return () => {
-      // when Form is unmounted, remove validateNow from validate function
-      if (typeof validate === 'function') {
-        const hadErrors = validate._hasErrors
-        resetValidate()
-        if (hadErrors) validate._forceUpdate()
-      }
+      // when Form is unmounted, reset the parent's validate
+      return () => validate.reset({ formId })
     }
   }, [])
 

--- a/packages/ui/components/forms/Form/index.js
+++ b/packages/ui/components/forms/Form/index.js
@@ -10,6 +10,7 @@ import { Validator } from './useValidate'
 function Form ({
   fields = {},
   $fields,
+  $errors,
   properties,
   order,
   row,
@@ -32,7 +33,7 @@ function Form ({
     () => fields, [JSON.stringify(fields)]
   )
 
-  const $errors = useValue$() // eslint-disable-line react-hooks/rules-of-hooks
+  if (!$errors) $errors = useValue$() // eslint-disable-line react-hooks/rules-of-hooks
   const validator = useMemo(() => new Validator(), [])
 
   useMemo(() => {

--- a/packages/ui/components/forms/Form/useValidate.js
+++ b/packages/ui/components/forms/Form/useValidate.js
@@ -1,38 +1,51 @@
 import { useMemo, useState, useCallback } from 'react'
+import { transformSchema, ajv } from '@startupjs/schema'
+import _set from 'lodash/set'
+import _get from 'lodash/get'
 
 export default function useValidate ({ always = false } = {}) {
-  const _forceUpdate = useForceUpdate()
-  return useMemo(() => {
-    function validate () {
-      if (!validate._validateNow) throw Error(ERRORS.notInitialized)
-      validate._shouldValidate = true
-      return validate._validateNow()
-    }
-    Object.assign(validate, {
-      _forceUpdate,
-      always
-    })
-    return new Proxy(validate, {
-      get (target, prop) {
-        // This is a hack to force update the component the parent component when the errors change
-        // if the parent component is using the errors prop to render something
-        // (like disabling a Submit button when there are errors)
-        // TODO: _shouldForceUpdate should correctly reset back to false if Form unmounts
-        if (prop === 'errors') {
-          validate._shouldForceUpdate = true
-          return Reflect.get(target, '_errors')
-        } else if (prop === 'hasErrors') {
-          validate._shouldForceUpdate = true
-          return Reflect.get(target, '_hasErrors')
-        }
-        return Reflect.get(target, prop)
+  const forceUpdate = useForceUpdate()
+  return useMemo(() => createValidateWrapper({ always, forceUpdate }), [])
+}
+
+function createValidateWrapper ({ always, forceUpdate }) {
+  const _validate = new Validate({ always, forceUpdate })
+  function validate () {
+    if (!_validate.hasValidator()) throw Error(ERRORS.notInitialized)
+    _validate.activate()
+    return _validate.run()
+  }
+  // wrap 'validate' function into Proxy to make it behave like an instance of Validate class
+  // while still being callable directly
+  const methods = new WeakMap()
+  return new Proxy(validate, {
+    get (target, prop) {
+      // This is a hack to force update the component the parent component when the errors change
+      // if the parent component is using the errors prop to render something
+      // (like disabling a Submit button when there are errors)
+      // TODO: _shouldForceUpdate should correctly reset back to false if Form unmounts
+      if (prop === 'errors') {
+        _validate.makeReactive()
+        return _validate.getErrors()
+      } else if (prop === 'hasErrors') {
+        _validate.makeReactive()
+        return _validate.getHasErrors()
       }
-    })
-  }, [])
+      let res = Reflect.get(_validate, prop)
+      // bind methods called on validate (which is a function) to the _validate object
+      if (typeof res === 'function') {
+        if (!methods.has(res)) methods.set(res, res.bind(_validate))
+        res = methods.get(res)
+      }
+      return res
+    }
+  })
 }
 
 function useForceUpdate () {
   const [, setState] = useState(Math.random())
+  // parent component's forceUpdate might be called from a child component
+  // so we need to use setTimeout to make sure it runs asynchronously
   return useCallback(() => setTimeout(() => setState(Math.random()), 0), [])
 }
 
@@ -47,4 +60,152 @@ const ERRORS = {
     const validate = useValidate()
     <Form validate={validate} ... />
   `
+}
+
+class Validate {
+  always
+
+  #isReactive
+  #lastHasErrors
+  #forceUpdate
+  #validator
+  #formId
+
+  constructor ({ forceUpdate, always }) {
+    this.#forceUpdate = forceUpdate
+    this.always = always
+  }
+
+  init ({ validator, formId }) {
+    this.#validator = validator
+    this.#formId = formId
+    this.#validator.onHasErrorsChange = ({ formId } = {}) => {
+      // only the Form which is currently associated with this 'validate' can force an update
+      if (formId && formId !== this.#formId) return
+      if (this.#isReactive) this.#forceUpdate()
+    }
+  }
+
+  activate () {
+    this.#validator.activate()
+  }
+
+  makeReactive () {
+    this.#isReactive = true
+  }
+
+  hasValidator () {
+    return !!this.#validator
+  }
+
+  run () {
+    if (!this.#validator) throw Error('Validator is not set')
+    return this.#validator.run()
+  }
+
+  getErrors () {
+    return this.#validator?.getErrors()
+  }
+
+  getHasErrors () {
+    const hasErrors = this.#validator?.getHasErrors()
+    this.#lastHasErrors = hasErrors
+    return hasErrors
+  }
+
+  reset ({ formId } = {}) {
+    // if formId is set, reset only if it matches the formId currently associated with this 'validate'.
+    // This prevents race conditions when a Form is unmounted and another Form is mounted right away
+    // which uses the same 'validate' prop.
+    // Only one Form can be associated with one 'validate' at a time.
+    // TODO: add check to init() to prevent multiple Forms from using the same 'validate'.
+    if (formId && formId !== this.#formId) return
+    this.#validator = undefined
+    this.#formId = undefined
+    this.#isReactive = undefined
+    if (this.#lastHasErrors) {
+      this.#lastHasErrors = undefined
+      this.#forceUpdate()
+    }
+  }
+}
+
+export class Validator {
+  hasErrors
+  onHasErrorsChange
+  #active
+  #validate
+  #getValue
+  #$errors
+  #initialized
+  #forceUpdate
+  #formId
+
+  init ({
+    fields, // either simplified schema or full schema
+    getValue, // obtain current value to validate (usually it will be from a closure of Form component)
+    $errors, // reactive object to store errors, this is basically a hack to use model's .setDiffDeep()
+    forceUpdate, // force update Form itself
+    formId
+  }) {
+    let schema = fields
+    // we allow extra properties in Form to let people just pass the full document
+    // instead of forcing them to pick only the fields used in schema
+    schema = transformSchema(schema, { additionalProperties: true })
+    this.#validate = ajv.compile(schema)
+    this.#getValue = getValue
+    this.#$errors = $errors
+    this.#forceUpdate = forceUpdate
+    this.#formId = formId
+    this.#initialized = true
+  }
+
+  activate () {
+    this.#active = true
+  }
+
+  run () {
+    if (!this.#active) return
+    if (!this.#initialized) throw Error('Validator is not initialized')
+    const valid = this.#validate(this.#getValue())
+    if (valid) {
+      if (this.hasErrors) {
+        delete this.hasErrors
+        this.#$errors.del()
+        this.#forceUpdate?.()
+        this.onHasErrorsChange?.({ formId: this.#formId })
+      }
+      return true
+    } else {
+      const newErrors = transformAjvErrors(this.#validate.errors)
+      const hadErrors = this.hasErrors
+      this.hasErrors = true
+      this.#$errors.setDiffDeep(newErrors)
+      if (!hadErrors) {
+        this.#forceUpdate?.()
+        this.onHasErrorsChange?.({ formId: this.#formId })
+      }
+      return false
+    }
+  }
+}
+
+// transform errors from ajv to our format
+function transformAjvErrors (errors) {
+  const res = {}
+  for (const error of errors) {
+    const path = error.instancePath.replace(/^\//, '').split('/')
+    // handle special case for 'required' fields.
+    // It happens on the level above the field which is actually required
+    // and the actual field name is located in params.missingProperty
+    let message = error.message
+    if (error.keyword === 'required') {
+      if (path.length > 0 && path[path.length - 1] === '') path.pop()
+      path.push(error.params.missingProperty)
+      message = 'This field is required'
+    }
+    if (!_get(res, path)) _set(res, path, [])
+    _get(res, path).push(message)
+  }
+  return res
 }

--- a/packages/ui/components/forms/Form/useValidate.js
+++ b/packages/ui/components/forms/Form/useValidate.js
@@ -1,0 +1,50 @@
+import { useMemo, useState, useCallback } from 'react'
+
+export default function useValidate ({ always = false } = {}) {
+  const _forceUpdate = useForceUpdate()
+  return useMemo(() => {
+    function validate () {
+      if (!validate._validateNow) throw Error(ERRORS.notInitialized)
+      validate._shouldValidate = true
+      return validate._validateNow()
+    }
+    Object.assign(validate, {
+      _forceUpdate,
+      always
+    })
+    return new Proxy(validate, {
+      get (target, prop) {
+        // This is a hack to force update the component the parent component when the errors change
+        // if the parent component is using the errors prop to render something
+        // (like disabling a Submit button when there are errors)
+        // TODO: _shouldForceUpdate should correctly reset back to false if Form unmounts
+        if (prop === 'errors') {
+          validate._shouldForceUpdate = true
+          return Reflect.get(target, '_errors')
+        } else if (prop === 'hasErrors') {
+          validate._shouldForceUpdate = true
+          return Reflect.get(target, '_hasErrors')
+        }
+        return Reflect.get(target, prop)
+      }
+    })
+  }, [])
+}
+
+function useForceUpdate () {
+  const [, setState] = useState(Math.random())
+  return useCallback(() => setTimeout(() => setState(Math.random()), 0), [])
+}
+
+const ERRORS = {
+  notInitialized: `
+    useValidate():
+    'validate' is not initialized with the Form component.
+
+    You must pass 'validate' from useValidate()
+    to the 'validate' prop of the Form component:
+
+    const validate = useValidate()
+    <Form validate={validate} ... />
+  `
+}

--- a/packages/ui/index.d.ts
+++ b/packages/ui/index.d.ts
@@ -117,6 +117,7 @@ export { default as useMedia } from './hooks/useMedia'
 export { default as useColors } from './hooks/useColors'
 export { default as useFormFields } from './hooks/useFormFields'
 export { default as useFormFields$ } from './hooks/useFormFields$'
+export { default as useValidate } from './components/forms/Form/useValidate'
 
 // UiProvider
 export { default as UiProvider } from './UiProvider'

--- a/packages/ui/index.js
+++ b/packages/ui/index.js
@@ -118,6 +118,7 @@ export { default as useMedia } from './hooks/useMedia'
 export { default as useColors } from './hooks/useColors'
 export { default as useFormFields } from './hooks/useFormFields'
 export { default as useFormFields$ } from './hooks/useFormFields$'
+export { default as useValidate } from './components/forms/Form/useValidate'
 
 // UiProvider
 export { default as UiProvider } from './UiProvider'

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -97,6 +97,7 @@
     "./useColors": "./hooks/useColors.js",
     "./useFormFields": "./hooks/useFormFields.js",
     "./useFormFields$": "./hooks/useFormFields$.js",
+    "./useValidate": "./components/forms/Form/useValidate.js",
     "./UiProvider": "./UiProvider.js",
     "./plugin": "./plugin.js",
     "./files.plugin": "./components/forms/FileInput/files.plugin.js"


### PR DESCRIPTION
By default `Form` does not run any validation.

By passing `validate=true` it will validate always.

```js
<Form validate={true} />
```

## `useValidate()`

To trigger validation manually, use `useValidate()` hook.

It will return the `validate` function which you can call manually to run the validation. It will return `true` if validation has passed (there are NO errors).

If there are errors, they will be available in `validate.hasErrors` (`true` or `false`) and `validate.errors` (errors themselves as an object of field names and an array of errors: `{ name: ['This field is required'], age: ['must be above 18'] }`)

### `useValidate({ always: true })`

By default, only after the first manual `validate()` call the `Form` will start showing errors and update them reactively (on each change to the form).

If you want the `Form` to start showing errors right away and update them reactively as soon as it renders, pass an `always: true` option to the hook.

## Example

```js
import { $ } from 'startupjs'
import { useValidate, Form, Button } from '@startupjs/ui'

const fields = {
  name: { type: 'string', required: true },
  age: { type: 'number' }
}
const { $newUser } = $.session

export default function App () {
  const validate = useValidate()

  function submit () {
    if (!validate()) return
    console.log('Create new user', $newUser.get())
  }

  return [
    <Form fields={fields} $value={$newUser} validate={validate} />,
    <Button disabled={validate.hasErrors} onPress={submit}>Submit</Button>
  ]
}
```
