### PR TITLE
fix(popups/Drawer): removes redundant z-index from elements

### DIFF
--- a/core/ui/components/popups/Drawer/index.js
+++ b/core/ui/components/popups/Drawer/index.js
@@ -137,7 +137,7 @@ function Drawer ({
               TouchableWithoutFeedback.overlayCase(onPress=onDismiss)
                 Animated.View.overlay(style={ opacity: animateStates.opacity })
 
-            Animated.View.content(
+            Animated.View(
               ref=refContent
               styleName={
                 contentDefault: isShow,

--- a/core/ui/components/popups/Drawer/index.styl
+++ b/core/ui/components/popups/Drawer/index.styl
@@ -2,7 +2,6 @@
   width 100%
   height 100%
   position absolute
-  z-index 9999
 
 .overlay
   position absolute
@@ -18,10 +17,6 @@
   height 100%
   width 100%
   position absolute
-  z-index 9999
-
-.content
-  z-index 9999
 
 .contentDefault
   background-color #ffffff
@@ -41,4 +36,3 @@
 
 .responder
   position absolute
-  z-index 999


### PR DESCRIPTION
<img width="371" alt="Снимок экрана 2024-07-24 в 18 10 28" src="https://github.com/user-attachments/assets/26af539e-e169-43cd-9f09-c52d0ee79411">
