### PR TITLE
feat(server/auth): add 'Login as...' provider to be used by trusted users

### DIFF
--- a/core/server/utils/clientLogin.js
+++ b/core/server/utils/clientLogin.js
@@ -4,16 +4,17 @@ import { getPlugin } from '@startupjs/registry'
 import openAuthSessionAsync from '@startupjs/utils/openAuthSessionAsync'
 import getLinkingUri from '@startupjs/utils/getLinkingUri'
 import { reload } from './reload.js'
-import { AUTH_TOKEN_KEY, AUTH_GET_URL, AUTH_PLUGIN_NAME, AUTH_URL, AUTH_LOCAL_PROVIDER } from './constants.js'
+import { AUTH_TOKEN_KEY, AUTH_GET_URL, AUTH_PLUGIN_NAME, AUTH_URL, AUTH_LOCAL_PROVIDER, AUTH_FORCE_PROVIDER } from './constants.js'
 
-export default async function login (provider, { extraScopes, redirectUrl, ...localUserinfo } = {}) {
+export default async function login (provider, { extraScopes, redirectUrl, ...props } = {}) {
   if (!provider) throw new Error('No provider specified')
   const plugin = getPlugin(AUTH_PLUGIN_NAME)
   if (!plugin.enabled) {
     throw new Error(`Plugin ${AUTH_PLUGIN_NAME} hasn't been enabled`)
   }
   redirectUrl ??= plugin.optionsByEnv.client?.redirectUrl
-  if (provider === AUTH_LOCAL_PROVIDER) return await localLogin({ redirectUrl, ...localUserinfo })
+  if (provider === AUTH_LOCAL_PROVIDER) return await localLogin({ redirectUrl, ...props })
+  if (provider === AUTH_FORCE_PROVIDER) return await forceLogin({ redirectUrl, ...props })
   const res = await axios.post(`${BASE_URL}${AUTH_GET_URL}`, { provider, extraScopes })
   let authUrl = res.data?.url
   if (!authUrl) {
@@ -80,6 +81,22 @@ async function localLogin ({ redirectUrl, register, ...userinfo } = {}) {
   //       wait for a bit, like 500ms, then set the session data, wait another 500ms and navigate
   await setSessionData(session, { silent: true })
   console.log('Auth success:', session)
+  await hardRedirect(redirectUrl)
+}
+
+async function forceLogin ({ redirectUrl, userId }) {
+  const url = `${BASE_URL}${AUTH_URL}/${AUTH_FORCE_PROVIDER}/login`
+  if (!userId) throw Error('No userId specified')
+  const res = await axios.post(url, { userId })
+  const { session, error } = res.data || {}
+  if (error) throw Error(error)
+  if (!session) throw Error('Force auth failed (no session data received). Something went wrong')
+  await setSessionData(session, { silent: true })
+  console.log('Auth success:', session)
+  await hardRedirect(redirectUrl)
+}
+
+async function hardRedirect (redirectUrl) {
   if (Platform.OS === 'web') {
     window.location.href = redirectUrl || '/'
     await new Promise(resolve => setTimeout(resolve, 30000))

--- a/core/server/utils/constants.js
+++ b/core/server/utils/constants.js
@@ -4,3 +4,4 @@ export const AUTH_GET_URL = `${AUTH_URL}/getUrl`
 export const AUTH_FINISH_URL = `${AUTH_URL}/finish`
 export const AUTH_PLUGIN_NAME = 'auth'
 export const AUTH_LOCAL_PROVIDER = 'local'
+export const AUTH_FORCE_PROVIDER = 'force'

--- a/expoapp/app/auth/login.js
+++ b/expoapp/app/auth/login.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { pug, styl, observer, useSub, $, login, logout } from 'startupjs'
-import { Content, Button, User, Card, Input, H6, Tag, Alert, Br } from '@startupjs/ui'
+import { Content, Button, User, Card, Input, H6, Tag, Alert, Br, ScrollView, Item } from '@startupjs/ui'
 
 const PROVIDERS = ['github']
 
@@ -10,9 +10,10 @@ export default observer(function Success () {
   const $auth = useSub($.auths[userId])
   const authProviderIds = $.session.authProviderIds.get() || []
   const loggedIn = $.session.loggedIn.get()
+  const $showForceLogin = $()
 
   return pug`
-    Content(padding gap full align='center' vAlign='center')
+    ScrollView(full): Content(padding gap full align='center' vAlign='center')
       if $user.get()
         Card.card
           User(
@@ -43,6 +44,9 @@ export default observer(function Success () {
           color='error'
           onPress=logout
         ) Logout
+        Input(type='checkbox' $value=$showForceLogin label='Show force login')
+        if $showForceLogin.get()
+          ForceLogin
   `
   styl`
     .card
@@ -50,6 +54,18 @@ export default observer(function Success () {
       padding-bottom 1u
     .button
       width 30u
+  `
+})
+
+const ForceLogin = observer(() => {
+  const $users = useSub($.users, {})
+  return pug`
+    Card
+      each $user in $users
+        Item(
+          key=$user.getId()
+          onPress=() => login('force', { userId: $user.getId() })
+        ) #{$user.name.get()}
   `
 })
 


### PR DESCRIPTION
provider name is `force`

## Usage on server

For a simple usecase which is implemented by default you'll need to do the following:
1. set `FORCE_CLIENT_SECRET` to a secret token
2. make a way in you app for users to set this secret token into their `auth` document: `$.auths[userId].force.token.set(token)`

In a real app you would want to change the `validateAccess` function and check if the user has admin rights:

```js
force: {
  async validateAccess ({ session }) {
    if (!await isAdmin(session.userId)) throw Error('Only admins can do it')
  }
}
```

Or if you want to let only particular managers to log into users they are responsible for, you can do something like the following:

```js
force: {
  async validateAccess ({ session, targetUserId }) {
    if (!await isManagerOf(session.userId, targetUserId)) {
      const err = Error('You are not the manager of this person')
      err.public = true
      throw err
    }
  }
}
```

## Usage on client

```jsx
import { $, useSub, login, observer } from 'startupjs'

export default observer(function UsersList () {
  const $users = useSub($.users, {})
  const $error = $()

  function loginAs (userId) {
    try {
      await login('force', { userId })
    } catch (err) {
      $error.set(err.message)
    }
  }

  return <>
    {$error.get() && <span>{$error.get()}</span>}
    {$users.map($user => (
      <button onClick={() => loginAs($user.getId())}>
        {$user.name.get()}
      </button>
    ))}
  </>
})
