### PR TITLE
fix: header title on mobile

### DIFF
--- a/core/ui/components/Modal/ModalHeader/index.styl
+++ b/core/ui/components/Modal/ModalHeader/index.styl
@@ -11,6 +11,7 @@ $gutter = $UI.gutters.m
 
 .title
   font(h5)
+  flex 1
 
 .close
   margin-left 2u


### PR DESCRIPTION
<img width="289" alt="Screenshot 2024-10-30 at 12 44 09" src="https://github.com/user-attachments/assets/bfb0a169-5a89-42a7-a806-a1ea9450042c">
