### PR TITLE
FileInput: Azure error fixed

### DIFF
--- a/core/ui/components/forms/FileInput/providers/azureblob.js
+++ b/core/ui/components/forms/FileInput/providers/azureblob.js
@@ -2,7 +2,7 @@ import { BlobServiceClient } from '@azure/storage-blob';
 
 // Replace with your Azure Blob Storage connection string or Azurite connection string
 const AZURE_BLOB_STORAGE_CONNECTION_STRING = process.env.AZURE_BLOB_STORAGE_CONNECTION_STRING
-const CONTAINER_NAME = 'fs' // Container name for storing blobs
+const CONTAINER_NAME = 'files' // Container name for storing blobs
 
 let blobServiceClient;
 let containerClient;


### PR DESCRIPTION
Azure Blob Storage does not allow containers 2 chars length.