### PR TITLE
[codex] Install Expo picker peers in UI template

### DIFF
--- a/core/create-startupjs/install/ui-expo/package.json
+++ b/core/create-startupjs/install/ui-expo/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "expo-document-picker": "^13.0.1",
-    "expo-image-picker": "^16.0.2"
+    "expo-document-picker": "^14.0.0",
+    "expo-image-picker": "^17.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- Update the `create-startupjs` Expo UI template to install the picker packages required by `startupjs-ui` file input.
- Use caret ranges derived from the `startupjs-ui` file-input package ranges: `expo-document-picker@^14.0.0` and `expo-image-picker@^17.0.0`.

## Validation
- Parsed the `ui` and `ui-expo` template package JSON files and asserted picker packages are only in `ui-expo` with the expected ranges.
- pre-commit hook: TypeScript check completed successfully.