### PR TITLE
Add async worker job API

### DIFF
--- a/core/worker/README.md
+++ b/core/worker/README.md
@@ -48,6 +48,132 @@ import runJob from '@startupjs/worker'
 const result = await runJob('sendWelcomeEmail', { userId: 'u1' })
 ```
 
+## Fire-and-forget jobs
+
+Use `enqueueJob()` when the request should return immediately and another part
+of your app will track the job status.
+
+```js
+import { enqueueJob } from '@startupjs/worker'
+
+const jobRef = await enqueueJob('sendWelcomeEmail', { userId: 'u1' })
+```
+
+`jobRef` is serializable:
+
+```js
+{
+  id: '123',
+  worker: 'default',
+  name: 'sendWelcomeEmail'
+}
+```
+
+You can wait for it later:
+
+```js
+import { waitJob } from '@startupjs/worker'
+
+const result = await waitJob(jobRef)
+```
+
+`runJob(name, data, options)` is still available and still waits for completion.
+Internally it is equivalent to `enqueueJob()` followed by `waitJob()`.
+
+## Job status, logs and counts
+
+```js
+import {
+  getJobLogs,
+  getJobStatus,
+  getJobsCount,
+  queryJobs
+} from '@startupjs/worker'
+
+const status = await getJobStatus(jobRef)
+const logs = await getJobLogs(jobRef)
+
+const activeCount = await getJobsCount({
+  trackingKey: `course:${courseId}:voiceovers`,
+  states: ['waiting', 'delayed', 'active']
+})
+
+const jobs = await queryJobs({
+  trackingKey: `course:${courseId}:voiceovers`,
+  states: ['failed'],
+  limit: 20
+})
+```
+
+Use `trackingKey` when you need to query jobs by domain entity. Without a
+`trackingKey`, BullMQ can count jobs by queue state, but it can not efficiently
+answer domain queries like "active voiceover jobs for this course".
+`getJobsCount({ name })` also requires `trackingKey`; otherwise the result would
+be a capped scan instead of an exact count.
+
+```js
+await enqueueJob('generateCourseVoiceovers', { courseId }, {
+  trackingKey: `course:${courseId}:voiceovers`
+})
+```
+
+## Delayed jobs
+
+```js
+await enqueueJob('sendReminder', { userId }, {
+  delay: 60_000
+})
+
+await enqueueJob('sendReminder', { userId }, {
+  startAt: Date.now() + 60_000
+})
+```
+
+Use either `delay` or `startAt`, not both.
+
+## Per-call singleton and queue selection
+
+Job files can still export `singleton`, but you can also set it per enqueue call:
+
+```js
+await enqueueJob('rebuildUserFeed', { userId }, {
+  singleton: { key: userId }
+})
+```
+
+You can override the queue at runtime:
+
+```js
+await enqueueJob('sendOtp', { userId }, {
+  worker: 'priority'
+})
+```
+
+## Debounce and throttle
+
+Basic debounce and leading throttle are exposed through a package-level API and
+implemented with BullMQ deduplication.
+
+```js
+await enqueueJob('rebuildSearchIndex', { entityId }, {
+  debounce: {
+    key: entityId,
+    delay: 3000
+  }
+})
+
+await enqueueJob('recalculateStats', { lessonId }, {
+  throttle: {
+    key: lessonId,
+    ttl: 3000
+  }
+})
+```
+
+`throttle.trailing` is not supported yet.
+For debounce, `debounce.delay` is also used as the BullMQ job delay, so do not
+pass a separate `delay` or `startAt` option.
+
 ## Production Deployment (Important)
 
 Default behavior:
@@ -213,6 +339,11 @@ Your handler receives:
 - `log.warn(message, { data, err })`
 - `log.error(message, { data, err })`
 - `job` (raw queue job object)
+- `jobRef` (serializable job reference)
+- `progress(value)` (updates BullMQ job progress)
+- `enqueueJob(name, data, options)`
+- `waitJob(jobRef, options)`
+- `getJobStatus(jobRef)`
 
 Use `log(...)` instead of `console.log(...)` when you want logs visible in the queue dashboard.
 
@@ -353,7 +484,9 @@ export default {
         autoStart: true,
         autoStartProduction: true,
         concurrency: 300,
+        ensureBackend: true,
         jobTimeout: 30000,
+        queuePrefix: undefined,
         useSeparateProcess: false,
         useWorkerThreads: true,
         dashboard: {
@@ -370,7 +503,9 @@ Option meanings:
 - `autoStart` (`true` by default): auto-initialize workers on server startup.
 - `autoStartProduction` (`true` by default): if `false`, workers do not auto-start when `NODE_ENV=production`.
 - `concurrency` (`300`): per-worker concurrency.
+- `ensureBackend` (`true`): initialize StartupJS backend before running a job. Set to `false` only for pure BullMQ jobs/tests that do not use model/backend APIs.
 - `jobTimeout` (`30000` ms): default timeout for jobs.
+- `queuePrefix` (`redisPrefix`): BullMQ Redis key prefix. Mostly useful for isolated tests or dedicated deployments.
 - `useSeparateProcess` (`false`): execute job handlers in sandboxed child runner.
 - `useWorkerThreads` (`true`): when sandbox is on, use worker threads.
 - `dashboard`: queue UI settings. Provide `route` to enable the dashboard route.
@@ -414,12 +549,21 @@ If you split only in production, set `autoStartProduction: false` so dev/stage b
 ## Public Exports
 
 ```js
-import runJob from '@startupjs/worker'
+import runJob, {
+  cancelJob,
+  enqueueJob,
+  getJobLogs,
+  getJobStatus,
+  getJobsCount,
+  queryJobs,
+  waitJob
+} from '@startupjs/worker'
 import initWorker from '@startupjs/worker/init'
 import '@startupjs/worker/plugin'
 ```
 
 - `@startupjs/worker`: `runJob(name, data?, options?)`
+- `@startupjs/worker`: named job helpers listed above
 - `@startupjs/worker/init`: `initWorker(options?)`
 - `@startupjs/worker/plugin`: StartupJS plugin export used by plugin registry
 

--- a/core/worker/index.js
+++ b/core/worker/index.js
@@ -1,64 +1,10 @@
-import { getJobsMap, getQueue, getQueueEvents, getRuntimeOptions } from './runtime.js'
-
-export default async function runJob (name, data = {}, options = {}) {
-  if (typeof name !== 'string' || !name.trim()) {
-    throw new Error('[@startupjs/worker] runJob: "name" must be a non-empty string')
-  }
-
-  const jobs = await getJobsMap()
-  const jobDefinition = jobs.get(name)
-
-  if (!jobDefinition) {
-    const availableJobs = Array.from(jobs.keys())
-    throw new Error(
-      `[@startupjs/worker] runJob: job "${name}" not found.` +
-        (availableJobs.length
-          ? ` Available jobs: ${availableJobs.join(', ')}`
-          : ' No jobs are currently registered.')
-    )
-  }
-
-  const queue = getQueue(jobDefinition.worker)
-  const queueEvents = getQueueEvents(jobDefinition.worker)
-
-  const payload = {
-    type: name,
-    timeout: options.timeout ?? getRuntimeOptions().jobTimeout,
-    data
-  }
-
-  const jobOptions = {
-    ...(options.jobOptions || {})
-  }
-
-  const deduplicationId = await getSingletonDeduplicationId(jobDefinition, data)
-  if (deduplicationId) {
-    jobOptions.deduplication = {
-      ...(jobOptions.deduplication || {}),
-      id: deduplicationId
-    }
-  }
-
-  const job = await queue.add(name, payload, jobOptions)
-  return await job.waitUntilFinished(queueEvents)
-}
-
-async function getSingletonDeduplicationId (jobDefinition, data) {
-  const { singleton, name, worker } = jobDefinition
-  if (!singleton) return
-
-  if (singleton === true) {
-    return `singleton:${worker}:${name}`
-  }
-
-  const singletonPayload = await Promise.resolve(singleton(data))
-  const hash = JSON.stringify(singletonPayload)
-
-  if (typeof hash !== 'string') {
-    throw new Error(
-      `[@startupjs/worker] runJob: singleton function for "${name}" must return a JSON-serializable value`
-    )
-  }
-
-  return `singleton:${worker}:${name}:${hash}`
-}
+export { default, default as runJob } from './runJob.js'
+export {
+  cancelJob,
+  enqueueJob,
+  getJobLogs,
+  getJobStatus,
+  getJobsCount,
+  queryJobs,
+  waitJob
+} from './jobApi.js'

--- a/core/worker/init.js
+++ b/core/worker/init.js
@@ -1,4 +1,3 @@
-import { redisPrefix } from 'startupjs/server'
 import { Worker } from 'bullmq'
 import { fileURLToPath } from 'url'
 import {
@@ -37,8 +36,11 @@ export default async function init (options = {}) {
   }
 }
 
-export async function closeWorkers () {
-  await gracefulShutdown(0, { exitProcess: false })
+export async function closeWorkers (options = {}) {
+  await gracefulShutdown(0, {
+    exitProcess: false,
+    force: Boolean(options.force)
+  })
 }
 
 function startWorker (workerName, runtimeOptions) {
@@ -48,7 +50,7 @@ function startWorker (workerName, runtimeOptions) {
     workerName,
     runtimeOptions.useSeparateProcess ? PROCESS_JOB_PATH : processJob,
     {
-      prefix: redisPrefix,
+      prefix: runtimeOptions.queuePrefix,
       connection: getWorkerConnection(),
       concurrency: runtimeOptions.concurrency,
       useWorkerThreads: runtimeOptions.useSeparateProcess && runtimeOptions.useWorkerThreads,
@@ -110,7 +112,7 @@ function attachShutdownHandlers () {
   })
 }
 
-async function gracefulShutdown (exitCode = 0, { exitProcess = true } = {}) {
+async function gracefulShutdown (exitCode = 0, { exitProcess = true, force = false } = {}) {
   if (shutdownPromise) return shutdownPromise
 
   shutdownPromise = (async () => {
@@ -127,7 +129,7 @@ async function gracefulShutdown (exitCode = 0, { exitProcess = true } = {}) {
     }
 
     try {
-      await Promise.allSettled(workers.map(worker => worker.close()))
+      await Promise.allSettled(workers.map(worker => worker.close(force)))
       activeWorkers.clear()
       await closeRuntimeResources()
     } finally {

--- a/core/worker/jobApi.js
+++ b/core/worker/jobApi.js
@@ -1,0 +1,316 @@
+import {
+  AVAILABLE_WORKERS,
+  getJobsMap,
+  getQueue,
+  getQueueEvents,
+  getRuntimeOptions
+} from './runtime.js'
+import {
+  buildEnqueueConfig,
+  createJobNotFoundError,
+  normalizeLimit,
+  normalizeStates,
+  validateJobName
+} from './jobOptions.js'
+import { createJobRef, normalizeJobRef } from './jobRef.js'
+import { createJobFailedError, serializeJobStatus } from './jobStatus.js'
+import { getTrackedJobRefs, trackJob, untrackJobRef } from './tracking.js'
+
+export async function enqueueJob (name, data = {}, options = {}) {
+  return await enqueueJobInternal(name, data, options, 'enqueueJob')
+}
+
+export async function enqueueJobInternal (name, data = {}, options = {}, caller = 'enqueueJob') {
+  validateJobName(name, caller)
+
+  const jobs = await getJobsMap()
+  const jobDefinition = jobs.get(name)
+
+  if (!jobDefinition) throw createJobNotFoundError(name, jobs, caller)
+
+  const {
+    worker,
+    payload,
+    jobOptions,
+    trackingKey
+  } = await buildEnqueueConfig({
+    name,
+    data,
+    options,
+    jobDefinition,
+    defaultTimeout: getRuntimeOptions().jobTimeout,
+    caller
+  })
+
+  const queue = getQueue(worker)
+  const job = await queue.add(name, payload, jobOptions)
+  const ref = {
+    ...createJobRef(job, worker),
+    name
+  }
+
+  if (trackingKey) {
+    try {
+      await trackJob({ ref, name, trackingKey })
+    } catch (error) {
+      throw await createJobTrackingError({ error, ref, job, jobOptions })
+    }
+  }
+
+  return ref
+}
+
+export async function waitJob (jobRef, options = {}) {
+  const { ref, queue, job } = await getJobByRef(jobRef, 'waitJob')
+
+  if (!job) {
+    throw new Error(`[@startupjs/worker] waitJob: job "${ref.worker}:${ref.id}" not found`)
+  }
+
+  const state = await job.getState()
+  if (state === 'completed') {
+    if (job.returnvalue != null) return job.returnvalue
+    return await getCompletedReturnValue(queue, ref.id)
+  }
+  if (state === 'failed') throw await createJobFailedError(job, ref)
+
+  try {
+    const result = await job.waitUntilFinished(getQueueEvents(ref.worker), options.timeout)
+    const completedJob = await queue.getJob(ref.id)
+
+    if (result == null) {
+      return await getCompletedReturnValue(queue, ref.id)
+    }
+
+    if (completedJob && await completedJob.getState() === 'completed') {
+      return completedJob.returnvalue
+    }
+
+    return result
+  } catch (error) {
+    const currentState = await job.getState()
+    if (currentState === 'failed') throw await createJobFailedError(job, ref, error)
+    throw error
+  }
+}
+
+async function getCompletedReturnValue (queue, jobId) {
+  let returnvalue
+
+  for (let attempt = 0; attempt < 100; attempt++) {
+    const job = await queue.getJob(jobId)
+
+    if (!job) return
+    const state = await job.getState()
+    returnvalue = job.returnvalue
+
+    if (returnvalue != null) return returnvalue
+    if (state === 'completed') {
+      await new Promise(resolve => setTimeout(resolve, 10))
+      continue
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+
+  const job = await queue.getJob(jobId)
+  return job?.returnvalue ?? returnvalue
+}
+
+export async function getJobStatus (jobRef) {
+  const { ref, job } = await getJobByRef(jobRef, 'getJobStatus')
+  return await serializeJobStatus(job, ref)
+}
+
+export async function getJobLogs (jobRef, options = {}) {
+  const {
+    start = 0,
+    end = -1,
+    asc = true
+  } = options
+  const ref = normalizeJobRef(jobRef, 'getJobLogs')
+  const queue = getQueue(ref.worker)
+  return await queue.getJobLogs(ref.id, start, end, asc)
+}
+
+export async function queryJobs (query = {}) {
+  const {
+    trackingKey,
+    name,
+    worker,
+    asc = true
+  } = query
+  const limit = normalizeLimit(query.limit)
+  const states = normalizeStates(query.states)
+
+  if (trackingKey) {
+    return await queryTrackedJobs({ trackingKey, name, worker, states, limit })
+  }
+
+  const workers = worker ? [worker] : AVAILABLE_WORKERS
+  const result = []
+
+  for (const workerName of workers) {
+    const queue = getQueue(workerName)
+    const jobs = await queue.getJobs(states, 0, Math.max(limit - result.length - 1, 0), asc)
+
+    for (const job of jobs) {
+      if (name && job.name !== name) continue
+      result.push(await serializeJobStatus(job, {
+        ...createJobRef(job, workerName),
+        name: job.name
+      }))
+      if (result.length >= limit) return result
+    }
+  }
+
+  return result
+}
+
+export async function getJobsCount (query = {}) {
+  const {
+    trackingKey,
+    name,
+    worker
+  } = query
+  const states = normalizeStates(query.states)
+
+  if (name && !trackingKey) {
+    throw new Error(
+      '[@startupjs/worker] getJobsCount: "name" filter requires "trackingKey". ' +
+        'BullMQ can count jobs by queue state, but exact job-name counts require worker tracking.'
+    )
+  }
+
+  if (trackingKey) {
+    return await countTrackedJobs({ trackingKey, name, worker, states })
+  }
+
+  const workers = worker ? [worker] : AVAILABLE_WORKERS
+  let count = 0
+
+  for (const workerName of workers) {
+    const counts = await getQueue(workerName).getJobCounts(...states)
+    count += Object.values(counts).reduce((sum, value) => sum + Number(value || 0), 0)
+  }
+
+  return count
+}
+
+export async function cancelJob (jobRef, options = {}) {
+  const { ref, job } = await getJobByRef(jobRef, 'cancelJob')
+
+  if (!job) {
+    await untrackJobRef(ref)
+    return { ref, cancelled: false, state: 'unknown' }
+  }
+
+  const state = await job.getState()
+  if (state === 'active' && !options.force) {
+    throw new Error('[@startupjs/worker] cancelJob: active jobs can not be cancelled')
+  }
+
+  await job.remove()
+  await untrackJobRef(ref)
+
+  return { ref, cancelled: true, state }
+}
+
+async function createJobTrackingError ({ error, ref, job, jobOptions }) {
+  let rolledBack = false
+  let rollbackError
+
+  if (canRollbackTrackingFailure(jobOptions)) {
+    try {
+      await job.remove()
+      rolledBack = true
+    } catch (error) {
+      rollbackError = error
+    }
+  }
+
+  const trackingError = new Error(
+    '[@startupjs/worker] enqueueJob: job was enqueued but tracking failed.' +
+      (rolledBack
+        ? ' The enqueued job was removed.'
+        : ' Use error.jobRef to inspect or cancel the job manually.')
+  )
+
+  trackingError.cause = error
+  trackingError.jobRef = ref
+  trackingError.rolledBack = rolledBack
+  if (rollbackError) trackingError.rollbackError = rollbackError
+
+  return trackingError
+}
+
+function canRollbackTrackingFailure (jobOptions) {
+  return !jobOptions.deduplication && jobOptions.jobId == null
+}
+
+async function queryTrackedJobs ({ trackingKey, name, worker, states, limit }) {
+  const refs = await getTrackedJobRefs(trackingKey)
+  const stateSet = new Set(states)
+  const result = []
+
+  for (const ref of refs) {
+    if (worker && ref.worker !== worker) continue
+
+    const queue = getQueue(ref.worker)
+    const job = await queue.getJob(ref.id)
+
+    if (!job) {
+      await untrackJobRef(ref, trackingKey)
+      continue
+    }
+
+    if (name && job.name !== name) continue
+
+    const state = await job.getState()
+    if (!stateSet.has(state)) continue
+
+    result.push(await serializeJobStatus(job, {
+      ...ref,
+      name: job.name
+    }))
+
+    if (result.length >= limit) return result
+  }
+
+  return result
+}
+
+async function countTrackedJobs ({ trackingKey, name, worker, states }) {
+  const refs = await getTrackedJobRefs(trackingKey)
+  const stateSet = new Set(states)
+  let count = 0
+
+  for (const ref of refs) {
+    if (worker && ref.worker !== worker) continue
+
+    const queue = getQueue(ref.worker)
+    const job = await queue.getJob(ref.id)
+
+    if (!job) {
+      await untrackJobRef(ref, trackingKey)
+      continue
+    }
+
+    if (name && job.name !== name) continue
+
+    const state = await job.getState()
+    if (!stateSet.has(state)) continue
+
+    count++
+  }
+
+  return count
+}
+
+async function getJobByRef (jobRef, caller) {
+  const ref = normalizeJobRef(jobRef, caller)
+  const queue = getQueue(ref.worker)
+  const job = await queue.getJob(ref.id)
+
+  return { ref, queue, job }
+}

--- a/core/worker/jobOptions.js
+++ b/core/worker/jobOptions.js
@@ -1,0 +1,288 @@
+const DEFAULT_ACTIVE_STATES = Object.freeze([
+  'waiting',
+  'delayed',
+  'prioritized',
+  'active',
+  'waiting-children'
+])
+
+export function validateJobName (name, caller) {
+  if (typeof name !== 'string' || !name.trim()) {
+    throw new Error(`[@startupjs/worker] ${caller}: "name" must be a non-empty string`)
+  }
+}
+
+export function createJobNotFoundError (name, jobs, caller) {
+  const availableJobs = Array.from(jobs.keys())
+  return new Error(
+    `[@startupjs/worker] ${caller}: job "${name}" not found.` +
+      (availableJobs.length
+        ? ` Available jobs: ${availableJobs.join(', ')}`
+        : ' No jobs are currently registered.')
+  )
+}
+
+export async function buildEnqueueConfig ({
+  name,
+  data,
+  options = {},
+  jobDefinition,
+  defaultTimeout,
+  caller
+}) {
+  validateJobName(name, caller)
+
+  const worker = resolveWorker({ jobDefinition, options, caller })
+  const timeout = options.timeout ?? defaultTimeout
+  const trackingKey = normalizeTrackingKey(options.trackingKey)
+
+  const payload = {
+    type: name,
+    timeout,
+    data,
+    meta: {
+      enqueuedAt: Date.now(),
+      worker,
+      ...(trackingKey ? { trackingKey } : {})
+    }
+  }
+
+  const jobOptions = {
+    ...(options.jobOptions || {})
+  }
+
+  applyDelayOptions(jobOptions, options, caller)
+  applyKnownJobOptions(jobOptions, options)
+
+  const deduplicationConfig = await resolveDeduplication({
+    name,
+    data,
+    worker,
+    options,
+    jobDefinition,
+    caller
+  })
+
+  if (deduplicationConfig) {
+    if (deduplicationConfig.delay != null) {
+      jobOptions.delay = deduplicationConfig.delay
+    }
+
+    jobOptions.deduplication = {
+      ...(jobOptions.deduplication || {}),
+      ...deduplicationConfig.options
+    }
+  }
+
+  return {
+    worker,
+    payload,
+    jobOptions,
+    trackingKey
+  }
+}
+
+export function normalizeStates (states) {
+  if (states == null) return DEFAULT_ACTIVE_STATES.slice()
+  const list = Array.isArray(states) ? states : [states]
+  return list
+    .map(state => String(state).trim())
+    .filter(Boolean)
+}
+
+export function normalizeLimit (limit, defaultValue = 100) {
+  if (limit == null) return defaultValue
+
+  const normalizedLimit = Number(limit)
+  if (!Number.isFinite(normalizedLimit) || normalizedLimit < 1) return defaultValue
+
+  return Math.floor(normalizedLimit)
+}
+
+export function normalizeTrackingKey (trackingKey) {
+  if (trackingKey == null || trackingKey === '') return undefined
+  if (typeof trackingKey === 'string') return trackingKey
+  return stableStringify(trackingKey)
+}
+
+function resolveWorker ({ jobDefinition, options, caller }) {
+  const worker = options.worker ?? jobDefinition.worker
+  if (typeof worker !== 'string' || !worker.trim()) {
+    throw new Error(`[@startupjs/worker] ${caller}: worker must be a non-empty string`)
+  }
+  return worker
+}
+
+function applyDelayOptions (jobOptions, options, caller) {
+  const hasDelay = options.delay != null
+  const hasStartAt = options.startAt != null
+
+  if (hasDelay && hasStartAt) {
+    throw new Error(`[@startupjs/worker] ${caller}: use either "delay" or "startAt", not both`)
+  }
+
+  if (options.debounce && (hasDelay || hasStartAt)) {
+    throw new Error(
+      `[@startupjs/worker] ${caller}: debounce controls job delay; do not pass "delay" or "startAt" with debounce`
+    )
+  }
+
+  if (hasDelay) {
+    jobOptions.delay = normalizeDelay(options.delay, caller)
+    return
+  }
+
+  if (hasStartAt) {
+    const startAt = options.startAt instanceof Date
+      ? options.startAt.getTime()
+      : Number(options.startAt)
+
+    if (!Number.isFinite(startAt)) {
+      throw new Error(`[@startupjs/worker] ${caller}: "startAt" must be a Date or timestamp`)
+    }
+
+    jobOptions.delay = Math.max(0, startAt - Date.now())
+  }
+}
+
+function applyKnownJobOptions (jobOptions, options) {
+  for (const key of [
+    'priority',
+    'attempts',
+    'backoff',
+    'removeOnComplete',
+    'removeOnFail'
+  ]) {
+    if (options[key] !== undefined) jobOptions[key] = options[key]
+  }
+}
+
+function normalizeDelay (delay, caller) {
+  const normalizedDelay = Number(delay)
+  if (!Number.isFinite(normalizedDelay) || normalizedDelay < 0) {
+    throw new Error(`[@startupjs/worker] ${caller}: "delay" must be a non-negative number`)
+  }
+  return normalizedDelay
+}
+
+async function resolveDeduplication ({
+  name,
+  data,
+  worker,
+  options,
+  jobDefinition,
+  caller
+}) {
+  if (options.debounce) {
+    return resolveDebounceDeduplication({ name, worker, debounce: options.debounce, caller })
+  }
+
+  if (options.throttle) {
+    return {
+      options: resolveThrottleDeduplication({ name, worker, throttle: options.throttle, caller })
+    }
+  }
+
+  const singleton = options.singleton ?? jobDefinition.singleton
+  const singletonId = await getSingletonDeduplicationId({ singleton, name, worker }, data, caller)
+  if (!singletonId) return
+
+  return {
+    options: { id: singletonId }
+  }
+}
+
+export async function getSingletonDeduplicationId (jobDefinition, data, caller = 'enqueueJob') {
+  const { singleton, name, worker } = jobDefinition
+  if (!singleton) return
+
+  if (singleton === true) {
+    return `singleton:${worker}:${name}`
+  }
+
+  let singletonPayload
+
+  if (typeof singleton === 'function') {
+    singletonPayload = await Promise.resolve(singleton(data))
+  } else if (typeof singleton === 'object') {
+    singletonPayload = singleton.key
+  } else {
+    throw new Error(
+      `[@startupjs/worker] ${caller}: singleton must be true, false, a function or { key }`
+    )
+  }
+
+  const hash = stableStringify(singletonPayload)
+
+  if (typeof hash !== 'string') {
+    throw new Error(
+      `[@startupjs/worker] ${caller}: singleton function for "${name}" must return a JSON-serializable value`
+    )
+  }
+
+  return `singleton:${worker}:${name}:${hash}`
+}
+
+function resolveDebounceDeduplication ({ name, worker, debounce, caller }) {
+  if (!debounce || typeof debounce !== 'object') {
+    throw new Error(`[@startupjs/worker] ${caller}: debounce must be an object`)
+  }
+
+  const key = normalizeRequiredKey(debounce.key, 'debounce.key', caller)
+  const delay = normalizeDelay(debounce.delay ?? debounce.ttl, caller)
+
+  return {
+    delay,
+    options: {
+      id: `debounce:${worker}:${name}:${key}`,
+      ttl: delay,
+      extend: debounce.extend ?? true,
+      replace: debounce.replace ?? true
+    }
+  }
+}
+
+function resolveThrottleDeduplication ({ name, worker, throttle, caller }) {
+  if (!throttle || typeof throttle !== 'object') {
+    throw new Error(`[@startupjs/worker] ${caller}: throttle must be an object`)
+  }
+
+  if (throttle.trailing) {
+    throw new Error(
+      `[@startupjs/worker] ${caller}: throttle.trailing is not supported yet`
+    )
+  }
+
+  const key = normalizeRequiredKey(throttle.key, 'throttle.key', caller)
+  const ttl = normalizeDelay(throttle.ttl, caller)
+
+  return {
+    id: `throttle:${worker}:${name}:${key}`,
+    ttl
+  }
+}
+
+function normalizeRequiredKey (value, label, caller) {
+  const key = normalizeTrackingKey(value)
+  if (!key) {
+    throw new Error(`[@startupjs/worker] ${caller}: ${label} is required`)
+  }
+  return key
+}
+
+function stableStringify (value) {
+  if (typeof value === 'string') return value
+  if (value == null) return String(value)
+
+  return JSON.stringify(sortObject(value))
+}
+
+function sortObject (value) {
+  if (!value || typeof value !== 'object') return value
+  if (Array.isArray(value)) return value.map(sortObject)
+
+  return Object.keys(value).sort().reduce((result, key) => {
+    result[key] = sortObject(value[key])
+    return result
+  }, {})
+}

--- a/core/worker/jobRef.js
+++ b/core/worker/jobRef.js
@@ -1,0 +1,65 @@
+const JOB_REF_SEPARATOR = ':'
+
+export function createJobRef (job, worker) {
+  const id = job?.id
+  if (!id) {
+    throw new Error('[@startupjs/worker] createJobRef: job.id is required')
+  }
+  validateWorker(worker, 'createJobRef')
+
+  return {
+    id: String(id),
+    worker
+  }
+}
+
+export function normalizeJobRef (jobRef, caller = 'normalizeJobRef') {
+  if (typeof jobRef === 'string') return parseJobRef(jobRef, caller)
+
+  if (!jobRef || typeof jobRef !== 'object') {
+    throw new Error(`[@startupjs/worker] ${caller}: jobRef must be an object or string`)
+  }
+
+  const { id, worker } = jobRef
+
+  if (id == null || id === '') {
+    throw new Error(`[@startupjs/worker] ${caller}: jobRef.id is required`)
+  }
+  validateWorker(worker, caller)
+
+  return {
+    id: String(id),
+    worker,
+    ...(jobRef.name ? { name: jobRef.name } : {})
+  }
+}
+
+export function serializeJobRef (jobRef) {
+  const ref = normalizeJobRef(jobRef, 'serializeJobRef')
+  return `${ref.worker}${JOB_REF_SEPARATOR}${ref.id}`
+}
+
+export function parseJobRef (value, caller = 'parseJobRef') {
+  if (typeof value !== 'string' || !value.includes(JOB_REF_SEPARATOR)) {
+    throw new Error(
+      `[@startupjs/worker] ${caller}: serialized jobRef must look like "worker:id"`
+    )
+  }
+
+  const separatorIndex = value.indexOf(JOB_REF_SEPARATOR)
+  const worker = value.slice(0, separatorIndex)
+  const id = value.slice(separatorIndex + 1)
+
+  if (!id) {
+    throw new Error(`[@startupjs/worker] ${caller}: serialized jobRef id is required`)
+  }
+  validateWorker(worker, caller)
+
+  return { worker, id }
+}
+
+function validateWorker (worker, caller) {
+  if (typeof worker !== 'string' || !worker.trim()) {
+    throw new Error(`[@startupjs/worker] ${caller}: jobRef.worker is required`)
+  }
+}

--- a/core/worker/jobStatus.js
+++ b/core/worker/jobStatus.js
@@ -1,0 +1,36 @@
+export async function serializeJobStatus (job, ref) {
+  if (!job) {
+    return {
+      ref,
+      state: 'unknown'
+    }
+  }
+
+  const state = await job.getState()
+  const payload = job.data || {}
+
+  return {
+    ref,
+    state,
+    progress: job.progress,
+    result: job.returnvalue,
+    error: job.failedReason,
+    failedReason: job.failedReason,
+    stacktrace: job.stacktrace,
+    createdAt: job.timestamp,
+    processedAt: job.processedOn,
+    finishedAt: job.finishedOn,
+    attemptsMade: job.attemptsMade,
+    attemptsStarted: job.attemptsStarted,
+    data: payload.data,
+    meta: payload.meta
+  }
+}
+
+export async function createJobFailedError (job, ref, cause) {
+  const status = await serializeJobStatus(job, ref)
+  const error = new Error(job.failedReason || cause?.message || '[@startupjs/worker] Job failed')
+  error.job = status
+  if (cause) error.cause = cause
+  return error
+}

--- a/core/worker/package.json
+++ b/core/worker/package.json
@@ -7,6 +7,11 @@
   "description": "Worker based on bullmq",
   "type": "module",
   "main": "index.js",
+  "scripts": {
+    "test": "yarn test:unit && yarn test:integration",
+    "test:unit": "node --test test/job*.test.js",
+    "test:integration": "node --test test/*.integration.test.js"
+  },
   "exports": {
     ".": "./index.js",
     "./init": "./init.js",

--- a/core/worker/processJob.js
+++ b/core/worker/processJob.js
@@ -1,5 +1,7 @@
 import { isBackendInitialized } from 'startupjs/server'
 import { ensureBackendReady, getJobsMap, getRuntimeOptions } from './runtime.js'
+import { createJobRef } from './jobRef.js'
+import { enqueueJob, getJobStatus, waitJob } from './jobApi.js'
 
 export default async function processJob (job) {
   const payload = job.data || {}
@@ -20,20 +22,40 @@ export default async function processJob (job) {
     throw new Error(message)
   }
 
-  const { useSeparateProcess, jobTimeout: defaultTimeout } = getRuntimeOptions()
-  if (useSeparateProcess || !isBackendInitialized()) {
+  const {
+    ensureBackend,
+    useSeparateProcess,
+    jobTimeout: defaultTimeout
+  } = getRuntimeOptions()
+  if (ensureBackend && (useSeparateProcess || !isBackendInitialized())) {
     await ensureBackendReady()
   }
 
   const timeout = toNumber(payload.timeout, defaultTimeout)
   const data = payload.data
+  const worker = payload.meta?.worker || job.queueName || jobDefinition.worker
+  const jobRef = {
+    ...createJobRef(job, worker),
+    name: type
+  }
   const log = createJobLog(job)
+  const progress = async value => {
+    await job.updateProgress(value)
+  }
 
   try {
     return await runWithTimeout({
       timeout,
       type,
-      execute: () => Promise.resolve(jobDefinition.handler(data, { log, job }))
+      execute: () => Promise.resolve(jobDefinition.handler(data, {
+        log,
+        job,
+        jobRef,
+        progress,
+        enqueueJob,
+        waitJob,
+        getJobStatus
+      }))
     })
   } catch (error) {
     await writeJobLog(job, `[${type}] ${formatError(error)}`, 'error')
@@ -74,14 +96,21 @@ async function runWithTimeout ({ timeout, type, execute }) {
     return await execute()
   }
 
-  return await Promise.race([
-    execute(),
-    new Promise((resolve, reject) => {
-      setTimeout(() => {
-        reject(new JobTimeoutError(type, timeout))
-      }, timeout)
-    })
-  ])
+  let timeoutId
+
+  try {
+    return await Promise.race([
+      execute(),
+      new Promise((resolve, reject) => {
+        timeoutId = setTimeout(() => {
+          timeoutId = undefined
+          reject(new JobTimeoutError(type, timeout))
+        }, timeout)
+      })
+    ])
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId)
+  }
 }
 
 class JobTimeoutError extends Error {

--- a/core/worker/runJob.js
+++ b/core/worker/runJob.js
@@ -1,0 +1,6 @@
+import { enqueueJobInternal, waitJob } from './jobApi.js'
+
+export default async function runJob (name, data = {}, options = {}) {
+  const jobRef = await enqueueJobInternal(name, data, options, 'runJob')
+  return await waitJob(jobRef)
+}

--- a/core/worker/runtime.js
+++ b/core/worker/runtime.js
@@ -17,9 +17,11 @@ export const AVAILABLE_WORKERS = Object.freeze(['default', 'priority'])
 
 const DEFAULT_OPTIONS = {
   concurrency: 300,
+  ensureBackend: true,
   useSeparateProcess: false,
   useWorkerThreads: true,
-  jobTimeout: 30000
+  jobTimeout: 30000,
+  queuePrefix: redisPrefix
 }
 
 const DEFAULT_JOB_OPTIONS = {
@@ -29,6 +31,7 @@ const DEFAULT_JOB_OPTIONS = {
 
 const queues = new Map()
 const queueEvents = new Map()
+const redisConnections = new Set()
 
 let backendInitPromise
 let jobsPromise
@@ -47,6 +50,7 @@ export function getRuntimeOptions (override = {}) {
 
   return {
     concurrency: toNumber(mergedOptions.concurrency, DEFAULT_OPTIONS.concurrency),
+    ensureBackend: toBoolean(mergedOptions.ensureBackend, DEFAULT_OPTIONS.ensureBackend),
     useSeparateProcess: toBoolean(
       mergedOptions.useSeparateProcess,
       DEFAULT_OPTIONS.useSeparateProcess
@@ -55,7 +59,8 @@ export function getRuntimeOptions (override = {}) {
       mergedOptions.useWorkerThreads,
       DEFAULT_OPTIONS.useWorkerThreads
     ),
-    jobTimeout: toNumber(mergedOptions.jobTimeout, DEFAULT_OPTIONS.jobTimeout)
+    jobTimeout: toNumber(mergedOptions.jobTimeout, DEFAULT_OPTIONS.jobTimeout),
+    queuePrefix: normalizeQueuePrefix(mergedOptions.queuePrefix, DEFAULT_OPTIONS.queuePrefix)
   }
 }
 
@@ -89,33 +94,37 @@ export function getWorkersToStart (workers) {
 
 export function getQueue (queueName) {
   validateWorkerName(queueName)
+  const queuePrefix = getRuntimeOptions().queuePrefix
+  const queueKey = `${queuePrefix}:${queueName}`
 
-  if (!queues.has(queueName)) {
-    queues.set(queueName, new Queue(queueName, {
-      prefix: redisPrefix,
+  if (!queues.has(queueKey)) {
+    queues.set(queueKey, new Queue(queueName, {
+      prefix: queuePrefix,
       connection: createQueueConnection()
     }))
   }
 
-  return queues.get(queueName)
+  return queues.get(queueKey)
 }
 
 export function getQueueEvents (queueName) {
   validateWorkerName(queueName)
+  const queuePrefix = getRuntimeOptions().queuePrefix
+  const queueKey = `${queuePrefix}:${queueName}`
 
-  if (!queueEvents.has(queueName)) {
+  if (!queueEvents.has(queueKey)) {
     const queueEventsInstance = new QueueEvents(queueName, {
-      prefix: redisPrefix,
+      prefix: queuePrefix,
       connection: createQueueConnection()
     })
 
     // Multiple concurrent runJob().waitUntilFinished() calls attach listeners to
     // the same QueueEvents instance, which can exceed Node's default of 10.
     queueEventsInstance.setMaxListeners(0)
-    queueEvents.set(queueName, queueEventsInstance)
+    queueEvents.set(queueKey, queueEventsInstance)
   }
 
-  return queueEvents.get(queueName)
+  return queueEvents.get(queueKey)
 }
 
 export function getQueueJobOptions () {
@@ -136,10 +145,15 @@ export async function closeRuntimeResources () {
     ...queuesToClose.map(queue => queue.close()),
     ...queueEventsToClose.map(events => events.close())
   ])
+
+  const connectionsToClose = Array.from(redisConnections.values())
+  redisConnections.clear()
+
+  await Promise.allSettled(connectionsToClose.map(closeRedisConnection))
 }
 
 export function getWorkerConnection () {
-  return getRedis({
+  return createRedisConnection({
     ...getRedisOptions({ addPrefix: false }),
     maxRetriesPerRequest: null
   })
@@ -170,10 +184,22 @@ export async function getJobsMap ({ refresh = false } = {}) {
 }
 
 function createQueueConnection () {
-  return getRedis({
+  return createRedisConnection({
     ...getRedisOptions({ addPrefix: false }),
     maxRetriesPerRequest: null,
     enableOfflineQueue: false
+  })
+}
+
+function createRedisConnection (options) {
+  const connection = getRedis(options)
+  redisConnections.add(connection)
+  return connection
+}
+
+async function closeRedisConnection (connection) {
+  await connection.quit().catch(() => {
+    connection.disconnect()
   })
 }
 
@@ -335,4 +361,11 @@ function toNumber (value, defaultValue) {
   if (value == null) return defaultValue
   const normalizedValue = Number(value)
   return Number.isFinite(normalizedValue) ? normalizedValue : defaultValue
+}
+
+function normalizeQueuePrefix (value, defaultValue) {
+  if (value == null || value === '') return defaultValue
+
+  const normalizedValue = String(value).trim()
+  return normalizedValue || defaultValue
 }

--- a/core/worker/test/jobOptions.test.js
+++ b/core/worker/test/jobOptions.test.js
@@ -1,0 +1,213 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  buildEnqueueConfig,
+  getSingletonDeduplicationId,
+  normalizeLimit,
+  normalizeStates,
+  normalizeTrackingKey
+} from '../jobOptions.js'
+
+test('builds default enqueue payload', async () => {
+  const config = await buildEnqueueConfig({
+    name: 'sendEmail',
+    data: { userId: 'u1' },
+    options: {},
+    jobDefinition: {
+      name: 'sendEmail',
+      worker: 'default'
+    },
+    defaultTimeout: 30000,
+    caller: 'test'
+  })
+
+  assert.equal(config.worker, 'default')
+  assert.equal(config.payload.type, 'sendEmail')
+  assert.equal(config.payload.timeout, 30000)
+  assert.deepEqual(config.payload.data, { userId: 'u1' })
+  assert.equal(config.payload.meta.worker, 'default')
+  assert.deepEqual(config.jobOptions, {})
+})
+
+test('supports runtime worker, trackingKey, delay and known job options', async () => {
+  const config = await buildEnqueueConfig({
+    name: 'generate',
+    data: {},
+    options: {
+      worker: 'priority',
+      trackingKey: { entity: 'course', id: 'c1' },
+      delay: 1000,
+      priority: 10,
+      attempts: 3,
+      removeOnComplete: { age: 60 }
+    },
+    jobDefinition: {
+      name: 'generate',
+      worker: 'default'
+    },
+    defaultTimeout: 30000,
+    caller: 'test'
+  })
+
+  assert.equal(config.worker, 'priority')
+  assert.equal(config.trackingKey, '{"entity":"course","id":"c1"}')
+  assert.equal(config.payload.meta.trackingKey, '{"entity":"course","id":"c1"}')
+  assert.equal(config.payload.meta.worker, 'priority')
+  assert.equal(config.jobOptions.delay, 1000)
+  assert.equal(config.jobOptions.priority, 10)
+  assert.equal(config.jobOptions.attempts, 3)
+  assert.deepEqual(config.jobOptions.removeOnComplete, { age: 60 })
+})
+
+test('supports module singleton and per-call singleton', async () => {
+  assert.equal(
+    await getSingletonDeduplicationId({
+      name: 'sync',
+      worker: 'default',
+      singleton: true
+    }, {}),
+    'singleton:default:sync'
+  )
+
+  assert.equal(
+    await getSingletonDeduplicationId({
+      name: 'sync',
+      worker: 'default',
+      singleton: data => ({ id: data.id, type: data.type })
+    }, { type: 'course', id: 'c1' }),
+    'singleton:default:sync:{"id":"c1","type":"course"}'
+  )
+
+  const config = await buildEnqueueConfig({
+    name: 'sync',
+    data: {},
+    options: {
+      singleton: { key: 'manual-key' }
+    },
+    jobDefinition: {
+      name: 'sync',
+      worker: 'default',
+      singleton: true
+    },
+    defaultTimeout: 30000,
+    caller: 'test'
+  })
+
+  assert.equal(config.jobOptions.deduplication.id, 'singleton:default:sync:manual-key')
+})
+
+test('maps debounce and leading throttle to BullMQ deduplication', async () => {
+  const debounceConfig = await buildEnqueueConfig({
+    name: 'search',
+    data: {},
+    options: {
+      debounce: {
+        key: 'user:u1',
+        delay: 300
+      }
+    },
+    jobDefinition: {
+      name: 'search',
+      worker: 'default'
+    },
+    defaultTimeout: 30000,
+    caller: 'test'
+  })
+
+  assert.equal(debounceConfig.jobOptions.delay, 300)
+  assert.deepEqual(debounceConfig.jobOptions.deduplication, {
+    id: 'debounce:default:search:user:u1',
+    ttl: 300,
+    extend: true,
+    replace: true
+  })
+
+  const throttleConfig = await buildEnqueueConfig({
+    name: 'search',
+    data: {},
+    options: {
+      throttle: {
+        key: 'user:u1',
+        ttl: 300
+      }
+    },
+    jobDefinition: {
+      name: 'search',
+      worker: 'default'
+    },
+    defaultTimeout: 30000,
+    caller: 'test'
+  })
+
+  assert.deepEqual(throttleConfig.jobOptions.deduplication, {
+    id: 'throttle:default:search:user:u1',
+    ttl: 300
+  })
+})
+
+test('rejects unsupported or ambiguous options', async () => {
+  await assert.rejects(() => buildEnqueueConfig({
+    name: 'job',
+    data: {},
+    options: {
+      delay: 1,
+      startAt: Date.now()
+    },
+    jobDefinition: {
+      name: 'job',
+      worker: 'default'
+    },
+    defaultTimeout: 30000,
+    caller: 'test'
+  }), /either "delay" or "startAt"/)
+
+  await assert.rejects(() => buildEnqueueConfig({
+    name: 'job',
+    data: {},
+    options: {
+      delay: 1,
+      debounce: {
+        key: 'k',
+        delay: 1
+      }
+    },
+    jobDefinition: {
+      name: 'job',
+      worker: 'default'
+    },
+    defaultTimeout: 30000,
+    caller: 'test'
+  }), /do not pass "delay" or "startAt" with debounce/)
+
+  await assert.rejects(() => buildEnqueueConfig({
+    name: 'job',
+    data: {},
+    options: {
+      throttle: {
+        key: 'k',
+        ttl: 1,
+        trailing: true
+      }
+    },
+    jobDefinition: {
+      name: 'job',
+      worker: 'default'
+    },
+    defaultTimeout: 30000,
+    caller: 'test'
+  }), /throttle.trailing is not supported yet/)
+})
+
+test('normalizes states and tracking keys', () => {
+  assert.deepEqual(normalizeStates('active'), ['active'])
+  assert.deepEqual(normalizeStates(['active', '', ' delayed ']), ['active', 'delayed'])
+  assert.equal(normalizeTrackingKey({ b: 2, a: 1 }), '{"a":1,"b":2}')
+})
+
+test('normalizes limits', () => {
+  assert.equal(normalizeLimit(undefined), 100)
+  assert.equal(normalizeLimit('10'), 10)
+  assert.equal(normalizeLimit(10.8), 10)
+  assert.equal(normalizeLimit(0), 100)
+  assert.equal(normalizeLimit('bad', 10000), 10000)
+})

--- a/core/worker/test/jobRef.test.js
+++ b/core/worker/test/jobRef.test.js
@@ -1,0 +1,44 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  createJobRef,
+  normalizeJobRef,
+  parseJobRef,
+  serializeJobRef
+} from '../jobRef.js'
+
+test('creates serializable job refs from BullMQ jobs', () => {
+  const ref = createJobRef({ id: 123 }, 'default')
+
+  assert.deepEqual(ref, {
+    id: '123',
+    worker: 'default'
+  })
+})
+
+test('serializes and parses job refs', () => {
+  const ref = {
+    id: 'abc',
+    worker: 'priority'
+  }
+
+  assert.equal(serializeJobRef(ref), 'priority:abc')
+  assert.deepEqual(parseJobRef('priority:abc'), ref)
+})
+
+test('normalizes object and string job refs', () => {
+  assert.deepEqual(normalizeJobRef({ id: 1, worker: 'default' }), {
+    id: '1',
+    worker: 'default'
+  })
+  assert.deepEqual(normalizeJobRef('default:1'), {
+    id: '1',
+    worker: 'default'
+  })
+})
+
+test('throws on malformed job refs', () => {
+  assert.throws(() => normalizeJobRef({ id: 1 }), /worker is required/)
+  assert.throws(() => normalizeJobRef('default:'), /id is required/)
+  assert.throws(() => normalizeJobRef('bad'), /must look like/)
+})

--- a/core/worker/test/workerApi.integration.test.js
+++ b/core/worker/test/workerApi.integration.test.js
@@ -1,0 +1,362 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const JOBS = {
+  echo: `
+    export default async function echo (data) {
+      return { ok: true, data }
+    }
+  `,
+  fail: `
+    export default async function fail () {
+      throw new Error('expected failure')
+    }
+  `,
+  logAndProgress: `
+    export default async function logAndProgress (data, {
+      getJobStatus,
+      jobRef,
+      log,
+      progress
+    }) {
+      await log('integration log message', { data })
+      await progress({ percent: 50 })
+
+      const status = await getJobStatus(jobRef)
+      return {
+        jobRef,
+        progress: status.progress
+      }
+    }
+  `,
+  parent: `
+    export default async function parent (data, { enqueueJob, waitJob }) {
+      const childRef = await enqueueJob('echo', { from: 'parent' }, {
+        trackingKey: data.trackingKey
+      })
+
+      return await waitJob(childRef)
+    }
+  `,
+  priorityOnly: `
+    export const worker = 'priority'
+
+    export default async function priorityOnly (data) {
+      return { worker: 'priority', data }
+    }
+  `,
+  slow: `
+    export default async function slow (data) {
+      await new Promise(resolve => setTimeout(resolve, data.delay || 50))
+      return data
+    }
+  `
+}
+
+test('worker public API with Redis and BullMQ', async t => {
+  const api = await setupWorkerRuntime(t)
+
+  await t.test('runJob keeps wait-and-return behavior', async () => {
+    const result = await api.runJob('echo', { value: 1 })
+
+    assert.deepEqual(result, {
+      ok: true,
+      data: { value: 1 }
+    })
+  })
+
+  await t.test('enqueueJob returns jobRef and waitJob returns result', async () => {
+    const ref = await api.enqueueJob('echo', { value: 2 }, {
+      trackingKey: api.trackingKey('basic')
+    })
+
+    assert.equal(typeof ref.id, 'string')
+    assert.equal(ref.name, 'echo')
+    assert.equal(ref.worker, 'default')
+
+    const result = await api.waitJob(ref, { timeout: 5000 })
+    assert.deepEqual(result, {
+      ok: true,
+      data: { value: 2 }
+    })
+
+    const status = await api.getJobStatus(ref)
+    assert.equal(status.state, 'completed')
+    assert.deepEqual(status.result, result)
+  })
+
+  await t.test('waitJob throws enriched error for failed jobs', async () => {
+    const ref = await api.enqueueJob('fail')
+
+    await assert.rejects(
+      () => api.waitJob(ref, { timeout: 5000 }),
+      error => {
+        assert.match(error.message, /expected failure/)
+        assert.equal(error.job.ref.id, ref.id)
+        assert.equal(error.job.state, 'failed')
+        return true
+      }
+    )
+
+    const status = await api.getJobStatus(ref)
+    assert.equal(status.state, 'failed')
+    assert.match(status.error, /expected failure/)
+  })
+
+  await t.test('trackingKey query/count works and cancelJob removes delayed jobs', async () => {
+    const trackingKey = api.trackingKey('delayed')
+    const ref = await api.enqueueJob('echo', { delayed: true }, {
+      trackingKey,
+      delay: 5000
+    })
+
+    assert.equal(await api.getJobsCount({
+      trackingKey,
+      name: 'echo',
+      states: ['delayed']
+    }), 1)
+
+    await assert.rejects(
+      () => api.getJobsCount({
+        name: 'echo',
+        states: ['delayed']
+      }),
+      /"name" filter requires "trackingKey"/
+    )
+
+    const jobs = await api.queryJobs({
+      trackingKey,
+      states: ['delayed'],
+      limit: 10
+    })
+
+    assert.equal(jobs.length, 1)
+    assert.equal(jobs[0].ref.id, ref.id)
+
+    const cancelResult = await api.cancelJob(ref)
+    assert.equal(cancelResult.cancelled, true)
+    assert.equal(cancelResult.state, 'delayed')
+
+    assert.equal(await api.getJobsCount({
+      trackingKey,
+      states: ['delayed', 'waiting']
+    }), 0)
+  })
+
+  await t.test('startAt schedules delayed job and waitJob resolves it', async () => {
+    const ref = await api.enqueueJob('echo', { scheduled: true }, {
+      startAt: Date.now() + 100
+    })
+
+    const initialStatus = await api.getJobStatus(ref)
+    assert.ok(['delayed', 'waiting'].includes(initialStatus.state))
+
+    const result = await api.waitJob(ref, { timeout: 5000 })
+    assert.deepEqual(result, {
+      ok: true,
+      data: { scheduled: true }
+    })
+  })
+
+  await t.test('runtime worker override and module worker selection work', async () => {
+    assert.deepEqual(await api.runJob('echo', { via: 'priority' }, {
+      worker: 'priority'
+    }), {
+      ok: true,
+      data: { via: 'priority' }
+    })
+
+    assert.deepEqual(await api.runJob('priorityOnly', { value: 1 }), {
+      worker: 'priority',
+      data: { value: 1 }
+    })
+  })
+
+  await t.test('handler context exposes logs, progress and jobRef', async () => {
+    const ref = await api.enqueueJob('logAndProgress', { value: 3 })
+    const result = await api.waitJob(ref, { timeout: 5000 })
+
+    assert.equal(result.jobRef.id, ref.id)
+    assert.deepEqual(result.progress, { percent: 50 })
+
+    const status = await api.getJobStatus(ref)
+    assert.deepEqual(status.progress, { percent: 50 })
+
+    const logs = await api.getJobLogs(ref)
+    assert.equal(logs.count, 1)
+    assert.match(logs.logs[0], /integration log message/)
+  })
+
+  await t.test('handler context can enqueue and wait for child jobs', async () => {
+    const trackingKey = api.trackingKey('child')
+    const result = await api.runJob('parent', { trackingKey })
+
+    assert.deepEqual(result, {
+      ok: true,
+      data: { from: 'parent' }
+    })
+
+    assert.equal(await api.getJobsCount({
+      trackingKey,
+      states: ['completed']
+    }), 1)
+  })
+
+  await t.test('per-call singleton deduplicates delayed jobs', async () => {
+    const singleton = { key: api.trackingKey('singleton') }
+    const firstRef = await api.enqueueJob('echo', { value: 1 }, {
+      delay: 5000,
+      singleton
+    })
+    const secondRef = await api.enqueueJob('echo', { value: 2 }, {
+      delay: 5000,
+      singleton
+    })
+
+    assert.equal(secondRef.id, firstRef.id)
+    await api.cancelJob(firstRef)
+  })
+
+  await t.test('debounce replaces delayed payload', async () => {
+    const key = api.trackingKey('debounce')
+
+    const firstRef = await api.enqueueJob('echo', { value: 1 }, {
+      debounce: {
+        key,
+        delay: 100
+      }
+    })
+    const secondRef = await api.enqueueJob('echo', { value: 2 }, {
+      debounce: {
+        key,
+        delay: 100
+      }
+    })
+
+    const result = await api.waitJob(secondRef, { timeout: 5000 })
+    assert.deepEqual(result, {
+      ok: true,
+      data: { value: 2 }
+    })
+
+    if (firstRef.id !== secondRef.id) {
+      assert.equal((await api.getJobStatus(firstRef)).state, 'unknown')
+    }
+  })
+})
+
+async function setupWorkerRuntime (t) {
+  const previousCwd = process.cwd()
+  const previousRedisUrl = process.env.REDIS_URL
+  const tmpDir = await mkdtemp(join(tmpdir(), 'startupjs-worker-'))
+  const jobsDir = join(tmpDir, 'workerJobs')
+  const queuePrefix = `startupjs-worker-test:${process.pid}:${Date.now()}`
+
+  await mkdir(jobsDir)
+  await writeFile(join(tmpDir, 'package.json'), JSON.stringify({
+    name: 'startupjs-worker-integration-test',
+    private: true,
+    type: 'module'
+  }))
+  await Promise.all(Object.entries(JOBS).map(([name, source]) => {
+    return writeFile(join(jobsDir, `${name}.js`), source)
+  }))
+
+  process.chdir(tmpDir)
+  process.env.REDIS_URL ||= 'redis://127.0.0.1:6379'
+
+  const workerApi = await import('../index.js')
+  const initWorkerModule = await import('../init.js')
+  const runtimeModule = await import('../runtime.js')
+  const trackingModule = await import('../tracking.js')
+
+  runtimeModule.setRuntimeOptionsOverrides({
+    concurrency: 10,
+    ensureBackend: false,
+    jobTimeout: 5000,
+    queuePrefix,
+    useSeparateProcess: false
+  })
+
+  await initWorkerModule.default({
+    concurrency: 10,
+    ensureBackend: false,
+    jobTimeout: 5000,
+    queuePrefix,
+    useSeparateProcess: false,
+    workers: ['default', 'priority']
+  })
+
+  t.after(async () => {
+    await initWorkerModule.closeWorkers({ force: true })
+    await trackingModule.closeTrackingRedis()
+    await removeRedisKeys(queuePrefix)
+    await runtimeModule.closeRuntimeResources()
+    await closeTeamplayBackendResources()
+    if (previousRedisUrl == null) {
+      delete process.env.REDIS_URL
+    } else {
+      process.env.REDIS_URL = previousRedisUrl
+    }
+    process.chdir(previousCwd)
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  return {
+    ...workerApi,
+    queuePrefix,
+    trackingKey: suffix => `${queuePrefix}:${suffix}:${Date.now()}`
+  }
+}
+
+async function closeTeamplayBackendResources () {
+  const backendUrl = await import.meta.resolve('@teamplay/backend')
+  const redisModule = await import(new URL('./redis/index.js', backendUrl).href)
+  const dbModule = await import(new URL('./db/index.js', backendUrl).href)
+
+  await new Promise(resolve => {
+    if (!redisModule.pubsub?.close) return resolve()
+    redisModule.pubsub.close(() => resolve())
+  })
+
+  redisModule.redis?.disconnect?.()
+  redisModule.redisObserver?.disconnect?.()
+
+  await new Promise(resolve => {
+    if (!dbModule.sqlite?.close) return resolve()
+    dbModule.sqlite.close(() => resolve())
+  })
+
+  await dbModule.mongoClient?.close?.()
+}
+
+async function removeRedisKeys (queuePrefix) {
+  const { getRedis, getRedisOptions } = await import('startupjs/server')
+  const redis = getRedis({
+    ...getRedisOptions({ addPrefix: false })
+  })
+
+  try {
+    let cursor = '0'
+
+    do {
+      const [nextCursor, keys] = await redis.scan(
+        cursor,
+        'MATCH',
+        `${queuePrefix}:*`,
+        'COUNT',
+        1000
+      )
+
+      if (keys.length) await redis.del(keys)
+      cursor = nextCursor
+    } while (cursor !== '0')
+  } finally {
+    await redis.quit().catch(() => {
+      redis.disconnect()
+    })
+  }
+}

--- a/core/worker/tracking.js
+++ b/core/worker/tracking.js
@@ -1,0 +1,89 @@
+import { getRedis, getRedisOptions } from 'startupjs/server'
+import { normalizeTrackingKey } from './jobOptions.js'
+import { normalizeJobRef, serializeJobRef } from './jobRef.js'
+import { getRuntimeOptions } from './runtime.js'
+
+const TRACKING_META_TTL_SECONDS = 7 * 24 * 60 * 60
+
+let redis
+
+export async function trackJob ({ ref, name, trackingKey }) {
+  const normalizedTrackingKey = normalizeTrackingKey(trackingKey)
+  if (!normalizedTrackingKey) return
+
+  const normalizedRef = normalizeJobRef(ref, 'trackJob')
+  const member = serializeJobRef(normalizedRef)
+  const client = getTrackingRedis()
+  const setKey = getTrackingSetKey(normalizedTrackingKey)
+  const metaKey = getTrackingMetaKey(normalizedRef)
+
+  await client
+    .multi()
+    .sadd(setKey, member)
+    .expire(setKey, TRACKING_META_TTL_SECONDS)
+    .hset(metaKey, {
+      id: normalizedRef.id,
+      worker: normalizedRef.worker,
+      name: name || '',
+      trackingKey: normalizedTrackingKey,
+      createdAt: String(Date.now())
+    })
+    .expire(metaKey, TRACKING_META_TTL_SECONDS)
+    .exec()
+}
+
+export async function getTrackedJobRefs (trackingKey) {
+  const normalizedTrackingKey = normalizeTrackingKey(trackingKey)
+  if (!normalizedTrackingKey) return []
+
+  const members = await getTrackingRedis().smembers(getTrackingSetKey(normalizedTrackingKey))
+  return members.map(member => normalizeJobRef(member, 'getTrackedJobRefs'))
+}
+
+export async function untrackJobRef (jobRef, trackingKey) {
+  const ref = normalizeJobRef(jobRef, 'untrackJobRef')
+  const client = getTrackingRedis()
+  const member = serializeJobRef(ref)
+  const metaKey = getTrackingMetaKey(ref)
+
+  if (!trackingKey) {
+    const meta = await client.hgetall(metaKey)
+    trackingKey = meta?.trackingKey
+  }
+
+  const normalizedTrackingKey = normalizeTrackingKey(trackingKey)
+  const commands = client.multi().del(metaKey)
+
+  if (normalizedTrackingKey) {
+    commands.srem(getTrackingSetKey(normalizedTrackingKey), member)
+  }
+
+  await commands.exec()
+}
+
+export async function closeTrackingRedis () {
+  if (!redis) return
+
+  const client = redis
+  redis = undefined
+  await client.quit().catch(() => {
+    client.disconnect()
+  })
+}
+
+function getTrackingRedis () {
+  if (!redis) {
+    redis = getRedis({
+      ...getRedisOptions({ addPrefix: false })
+    })
+  }
+  return redis
+}
+
+function getTrackingSetKey (trackingKey) {
+  return `${getRuntimeOptions().queuePrefix}:worker:tracking:${trackingKey}`
+}
+
+function getTrackingMetaKey (ref) {
+  return `${getRuntimeOptions().queuePrefix}:worker:tracking-meta:${ref.worker}:${ref.id}`
+}


### PR DESCRIPTION
## Summary
- add fire-and-forget worker API: enqueueJob, waitJob, status/log/count/query/cancel helpers
- add serializable jobRef, trackingKey Redis index, delay/startAt, runtime worker override, per-call singleton
- add basic debounce and leading throttle via BullMQ deduplication
- expand handler context with jobRef, progress, enqueueJob, waitJob and getJobStatus
- add unit and Redis/BullMQ integration coverage

## Verification
- yarn workspace @startupjs/worker test
- node --check core/worker/*.js core/worker/test/*.js
- npx --no-install eslint core/worker/index.js core/worker/runJob.js core/worker/jobApi.js core/worker/jobOptions.js core/worker/jobRef.js core/worker/jobStatus.js core/worker/processJob.js core/worker/runtime.js core/worker/tracking.js core/worker/init.js core/worker/test/jobOptions.test.js core/worker/test/jobRef.test.js core/worker/test/workerApi.integration.test.js
- git diff --check