### PR TITLE
Add generic worker lifecycle API

### DIFF
--- a/core/server/index.d.ts
+++ b/core/server/index.d.ts
@@ -35,6 +35,7 @@ export default function startServer (options?: ServerOptions): Promise<ServerPro
 export function createServer (options?: CreateServerOptions): Promise<ServerProps>
 export function createMiddleware (options?: CreateMiddlewareOptions): Promise<MiddlewareProps>
 export function createBackend (options?: ServerOptions): any // Replace 'any' with the actual backend type
+export function getBackend (): any // Replace 'any' with the actual backend type
 export function NO_DEAD_CODE_ELIMINATION (): [any, any] // Replace 'any' with actual types if known
 
 // Assuming the types for the below exports are defined in 'teamplay/server' module

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -28,6 +28,7 @@ const defaultOptions = {
 }
 
 let backendInitialized = false
+let currentBackend
 
 export default async function startServer (options) {
   const props = await createServer(options)
@@ -43,6 +44,7 @@ export async function createServer (options = {}) {
   const { default: createServer } = await import('./server/createServer.js')
   options = transformOptions(options)
   const backend = _createBackend({ ...options, models: MODULE.models })
+  currentBackend = backend
   MODULE.hook('backend', backend)
   const sessionRef = {}
   if (!options.enableOAuth2) sessionRef.session = _createSession(options)
@@ -57,6 +59,7 @@ export async function createMiddleware (options = {}) {
   const { default: createMiddleware } = await import('./server/createMiddleware.js')
   options = transformOptions(options)
   const backend = _createBackend({ ...options, models: MODULE.models })
+  currentBackend = backend
   MODULE.hook('backend', backend)
   const sessionRef = {}
   if (!options.enableOAuth2) sessionRef.session = _createSession(options)
@@ -70,6 +73,7 @@ export async function createMiddleware (options = {}) {
 export function createBackend (options = {}) {
   options = transformOptions(options)
   const backend = _createBackend({ ...options, models: MODULE.models })
+  currentBackend = backend
   MODULE.hook('backend', backend)
   _initConnection(backend, { fetchOnly: FETCH_ONLY })
   markBackendInitialized()
@@ -78,6 +82,14 @@ export function createBackend (options = {}) {
 
 export function isBackendInitialized () {
   return backendInitialized
+}
+
+export function getBackend () {
+  if (currentBackend) return currentBackend
+
+  throw new Error(
+    '[startupjs/server] Backend is not initialized. Call createServer(), createMiddleware() or createBackend() first.'
+  )
 }
 
 function transformOptions (options = {}) {

--- a/core/worker/README.md
+++ b/core/worker/README.md
@@ -77,6 +77,30 @@ import { waitJob } from '@startupjs/worker'
 const result = await waitJob(jobRef)
 ```
 
+If you need to know whether enqueue created a new job or reused/deduped an
+existing one, pass `returnMeta: true`:
+
+```js
+const result = await enqueueJob('sendWelcomeEmail', { userId: 'u1' }, {
+  returnMeta: true
+})
+
+// result:
+// {
+//   ref: { id, worker, name },
+//   created: true,
+//   deduped: false,
+//   skipped: false,
+//   replaced: false,
+//   reason: null,
+//   policy: 'created',
+//   duplicateOf: null
+// }
+```
+
+Without `returnMeta`, `enqueueJob()` keeps the old behavior and returns only
+`jobRef`.
+
 `runJob(name, data, options)` is still available and still waits for completion.
 Internally it is equivalent to `enqueueJob()` followed by `waitJob()`.
 
@@ -141,6 +165,18 @@ await enqueueJob('rebuildUserFeed', { userId }, {
 })
 ```
 
+By default duplicates return the existing in-flight job ref. For per-call
+singleton you can choose a different duplicate policy:
+
+```js
+await enqueueJob('rebuildUserFeed', { userId }, {
+  singleton: {
+    key: userId,
+    onDuplicate: 'skip' // 'return-existing' | 'skip' | 'throw'
+  }
+})
+```
+
 You can override the queue at runtime:
 
 ```js
@@ -151,8 +187,10 @@ await enqueueJob('sendOtp', { userId }, {
 
 ## Debounce and throttle
 
-Basic debounce and leading throttle are exposed through a package-level API and
-implemented with BullMQ deduplication.
+Debounce and throttle are exposed through a package-level API.
+Basic debounce and leading throttle are implemented with BullMQ deduplication.
+Trailing throttle keeps the first job immediate and schedules one latest-value
+job at the end of the throttle window.
 
 ```js
 await enqueueJob('rebuildSearchIndex', { entityId }, {
@@ -168,11 +206,32 @@ await enqueueJob('recalculateStats', { lessonId }, {
     ttl: 3000
   }
 })
+
+await enqueueJob('recalculateStats', { lessonId, value }, {
+  throttle: {
+    key: lessonId,
+    ttl: 3000,
+    trailing: true
+  }
+})
 ```
 
-`throttle.trailing` is not supported yet.
 For debounce, `debounce.delay` is also used as the BullMQ job delay, so do not
 pass a separate `delay` or `startAt` option.
+
+For debounce duplicates, the default policy is `replace`, so the latest delayed
+payload wins. You can opt out with `replace: false` or choose an explicit
+`onDuplicate` policy:
+
+```js
+await enqueueJob('rebuildSearchIndex', { entityId }, {
+  debounce: {
+    key: entityId,
+    delay: 3000,
+    onDuplicate: 'replace' // 'replace' | 'return-existing' | 'skip' | 'throw'
+  }
+})
+```
 
 ## Production Deployment (Important)
 
@@ -344,8 +403,70 @@ Your handler receives:
 - `enqueueJob(name, data, options)`
 - `waitJob(jobRef, options)`
 - `getJobStatus(jobRef)`
+- `backend`
+- `createModel()`
 
 Use `log(...)` instead of `console.log(...)` when you want logs visible in the queue dashboard.
+
+When the worker backend is initialized, handlers can use model helpers:
+
+```js
+export default async function updateSomething (data, { createModel }) {
+  const $ = createModel()
+  // ...
+  $.close()
+}
+```
+
+`createModel()` throws if worker backend initialization is disabled with
+`ensureBackend: false`.
+
+## Worker Lifecycle Events
+
+Use `events` in worker server config when you need a generic integration point
+for metrics, domain status rows, notifications or custom tracking.
+
+```js
+// startupjs.config.js
+export default {
+  plugins: {
+    worker: {
+      server: {
+        events: {
+          onQueued: event => {},
+          onDeduped: event => {},
+          onStarted: event => {},
+          onProgress: event => {},
+          onCompleted: event => {},
+          onFailed: event => {}
+        }
+      }
+    }
+  }
+}
+```
+
+Each event contains:
+- `ref`: serializable job ref
+- `name`: job name
+- `worker`: queue name
+- `data`: job payload data
+- `meta`: worker metadata
+- `state`
+- `job`: raw BullMQ job object
+
+`onCompleted` also receives `result`, `onFailed` receives `error`, and
+`onProgress` receives `progress`.
+
+Lifecycle hooks are managed best-effort:
+- hook errors are logged and do not change BullMQ job outcome
+- `onStarted` / `onProgress` / `onCompleted` / `onFailed` run from parent
+  BullMQ `Worker` events
+- worker shutdown waits for currently pending hook promises before closing
+  runtime resources
+
+Use BullMQ job state as the source of truth and lifecycle hooks for metrics,
+notifications or eventually consistent read models.
 
 ## Examples By Use Case
 

--- a/core/worker/STAGE2_GENERIC_API_PLAN.md
+++ b/core/worker/STAGE2_GENERIC_API_PLAN.md
@@ -1,0 +1,520 @@
+# Stage 2: generic API для `@startupjs/worker`
+
+## Контекст
+
+`@startupjs/worker@0.62.2` уже содержит первый BullMQ-based public API:
+
+- `runJob(name, data, options)` сохранил старый blocking contract: поставить job
+  и дождаться результата.
+- `enqueueJob(name, data, options)` ставит job и сразу возвращает serializable
+  `jobRef`.
+- `waitJob(jobRef)`, `getJobStatus(jobRef)`, `queryJobs()`,
+  `getJobsCount()`, `cancelJob()` уже есть.
+- `trackingKey`, `delay`, `startAt`, runtime `worker`, basic `singleton`,
+  `debounce`, leading `throttle` уже есть.
+
+Следующий шаг должен оставаться generic и additive. LMS нужен этот слой для
+временного legacy `tasks` bridge, но `@startupjs/worker` не должен знать про
+LMS-specific `tasks`, `taskId`, `uniqId`, `refused` или Mongo read model.
+
+Главная проблема: legacy bridge не может безопасно использовать BullMQ dedup
+вслепую. Если enqueue вернул уже существующий job, отдельный legacy status doc
+может остаться в ожидании навсегда, если вызывающий код не видит, что вызов
+был deduped/skipped/throttled.
+
+## Статус реализации
+
+Реализовано в ветке `worker-stage2-generic-api`:
+
+- lazy dashboard import в worker plugin;
+- `enqueueJob(..., { returnMeta: true })`;
+- duplicate metadata для singleton/debounce/throttle;
+- duplicate policies `return-existing`, `skip`, `throw`;
+- debounce policy `replace` по умолчанию;
+- `throttle.trailing` как leading + latest-payload trailing job;
+- lifecycle hooks `onQueued`, `onDeduped`, `onStarted`, `onProgress`,
+  `onCompleted`, `onFailed` как managed best-effort события: они не меняют
+  BullMQ outcome, но pending hook promises flush-ятся при shutdown;
+- handler context `backend` / `createModel()`, включая reuse уже
+  инициализированного StartupJS backend через `startupjs/server.getBackend()`;
+- README и unit/integration coverage.
+
+## Не цели
+
+- Не добавлять collection `tasks`.
+- Не добавлять LMS statuses (`new`, `executing`, `done`, `error`, `refused`) как
+  worker package semantics.
+- Не менять default behavior `runJob()`.
+- Не менять default return shape `enqueueJob()`.
+- Не добавлять patch-package patch в LMS для новой версии worker. Если нужен
+  bugfix, он должен быть внесен и опубликован в `@startupjs/worker`.
+- Не делать browser React hooks в этом PR. Status/query API уже есть; client
+  hooks можно делать позже в package или app-layer.
+
+## Порядок работ
+
+### 1. Lazy imports в plugin
+
+Файл:
+
+- `core/worker/plugin.js`
+
+Сейчас:
+
+```js
+import initDashboardRoute from './initDashboardRoute.js'
+```
+
+импортируется на top-level. Apps могут загрузить plugin во время server
+bootstrap даже при выключенном dashboard и `autoStart: false`. Это слишком рано
+тащит runtime/dashboard зависимости и уже вынудило LMS сделать локальный patch.
+Правка должна жить upstream.
+
+Что поменять:
+
+- убрать top-level import `initDashboardRoute`;
+- импортировать dashboard route динамически только внутри `serverRoutes()` и
+  только когда `dashboard` truthy;
+- оставить `initWorker` dynamic import за `shouldAutoStart`;
+- не менять существующие options/defaults.
+
+Тесты:
+
+- import `@startupjs/worker/plugin` не импортирует `initDashboardRoute.js`;
+- dashboard route все еще инициализируется, когда включен `dashboard`;
+- `autoStart: false` не импортирует и не стартует `init.js`.
+
+### 2. Structured enqueue result
+
+Файлы:
+
+- `core/worker/jobApi.js`
+- `core/worker/jobOptions.js`
+- `core/worker/jobRef.js`
+
+Текущее поведение:
+
+```js
+const ref = await enqueueJob(name, data, options)
+```
+
+возвращает только `jobRef`.
+
+Нужно добавить opt-in режим:
+
+```js
+const result = await enqueueJob(name, data, {
+  ...options,
+  returnMeta: true
+})
+```
+
+Форма для созданного job:
+
+```js
+{
+  ref,
+  created: true,
+  deduped: false,
+  skipped: false,
+  reason: null,
+  policy: 'created',
+  duplicateOf: null
+}
+```
+
+Форма для duplicate/dedup:
+
+```js
+{
+  ref: existingRef,
+  created: false,
+  deduped: true,
+  skipped: false,
+  reason: 'singleton' | 'debounce' | 'throttle',
+  policy: 'return-existing',
+  duplicateOf: existingRef
+}
+```
+
+Правило совместимости:
+
+- без `returnMeta` `enqueueJob()` возвращает ровно текущий `jobRef`;
+- `runJob()` продолжает идти через простой `jobRef` path.
+
+Техническая деталь:
+
+BullMQ не возвращает флаг `created`. Для opt-in `returnMeta` path надо
+генерировать internal candidate `jobId`, если caller не передал custom
+`jobOptions.jobId`.
+
+Flow:
+
+1. `buildEnqueueConfig()` дополнительно возвращает metadata:
+
+```js
+{
+  deduplication: {
+    id,
+    reason: 'singleton' | 'debounce' | 'throttle',
+    policy
+  }
+}
+```
+
+2. `enqueueJobInternal()` ставит `jobOptions.jobId = candidateJobId` только для
+   `returnMeta` вызовов, где нужно надежно определить dedup.
+3. `queue.add()` возвращает `job`.
+4. Если `job.id !== candidateJobId`, BullMQ вернул уже существующий deduped job.
+
+Про custom `jobOptions.jobId`:
+
+- не менять custom job id semantics;
+- если user передал `jobOptions.jobId`, `returnMeta` может надежно определить
+  dedup только когда BullMQ вернул другой id;
+- duplicate-by-jobId не является worker duplicate policy, это low-level BullMQ
+  behavior. Его нужно задокументировать отдельно.
+
+Тесты:
+
+- старый `enqueueJob()` return shape не изменился;
+- `enqueueJob(..., { returnMeta: true })` возвращает `{ created: true }`;
+- singleton duplicate возвращает `{ created: false, deduped: true }`;
+- `runJob()` все еще возвращает handler result.
+
+### 3. Duplicate policy
+
+Файлы:
+
+- `core/worker/jobOptions.js`
+- `core/worker/jobApi.js`
+
+Target API:
+
+```js
+await enqueueJob('syncUser', data, {
+  singleton: {
+    key: data.userId,
+    onDuplicate: 'return-existing'
+  }
+})
+```
+
+Policies:
+
+- `return-existing`: default, сохранить текущее поведение, вернуть existing
+  `jobRef`;
+- `skip`: duplicate не считается новой execution; с `returnMeta` вернуть
+  `{ skipped: true, reason }`; без `returnMeta` вернуть existing `ref`, чтобы не
+  ломать простых callers;
+- `throw`: бросить `DuplicateJobError` с `.jobRef`, `.reason`, `.policy`.
+
+Scope:
+
+- поддержать policy для `singleton`, `debounce`, `throttle`;
+- default должен сохранить текущее поведение;
+- policy применяется после `queue.add()`, потому что именно BullMQ атомарно
+  выбирает winner duplicate/dedup.
+
+Тесты:
+
+- default duplicate возвращает existing ref;
+- `returnMeta + skip` возвращает skipped metadata;
+- `throw` reject-ит controlled error с existing ref и reason.
+
+### 4. Полный `throttle.trailing`
+
+Файл:
+
+- `core/worker/jobOptions.js`
+
+До этой доработки:
+
+```js
+throttle: { key, ttl, trailing: true }
+```
+
+вызывал `throttle.trailing is not supported yet`.
+
+Target API:
+
+```js
+await enqueueJob('recalculateStats', data, {
+  throttle: {
+    key: data.lessonId,
+    ttl: 3000,
+    trailing: true
+  }
+})
+```
+
+Семантика:
+
+- первый вызов в окне сразу ставит leading job;
+- вызовы внутри TTL не ставят новый leading job;
+- если `trailing: true`, последний payload внутри TTL планируется как один
+  delayed trailing job после оставшегося TTL;
+- если до запуска trailing приходят новые вызовы, trailing payload заменяется
+  последним payload;
+- `returnMeta` сообщает, вызов создал leading execution, trailing execution или
+  был skipped.
+
+Дизайн реализации:
+
+Добавить небольшой generic helper, вероятно:
+
+- `core/worker/throttle.js`
+
+Redis keys:
+
+```txt
+${queuePrefix}:worker:throttle:${worker}:${name}:${key}
+${queuePrefix}:worker:throttle-trailing:${worker}:${name}:${key}
+```
+
+Flow для `throttle.trailing`:
+
+1. Нормализовать `key` и `ttl` в `jobOptions.js`.
+2. В `enqueueJobInternal()` до обычного `queue.add()` вызвать helper:
+
+```js
+const decision = await resolveThrottleWindow({ worker, name, key, ttl, trailing })
+```
+
+3. Если active window нет:
+   - поставить lock key через `PX ttl NX`;
+   - enqueue leading job без delay;
+   - вернуть reason `null`.
+4. Если active window есть и `trailing: false`:
+   - не создавать новый job;
+   - вернуть duplicate metadata, по возможности с current leading ref.
+5. Если active window есть и `trailing: true`:
+   - вычислить оставшийся TTL через `PTTL`;
+   - enqueue delayed job:
+
+```js
+delay: remainingTtl
+deduplication: {
+  id: `throttle-trailing:${worker}:${name}:${key}`,
+  ttl: remainingTtl,
+  extend: true,
+  replace: true
+}
+```
+
+Так BullMQ delayed replace даст "last payload wins".
+
+Важное отличие:
+
+- leading throttle можно оставить на текущем BullMQ dedup path для совместимости;
+- trailing throttle требует custom lock + delayed replace, потому что BullMQ
+  dedup сам по себе не создает trailing job.
+
+Тесты:
+
+- `throttle.trailing` больше не throws;
+- первый вызов запускается сразу;
+- второй и третий вызовы внутри TTL схлопываются в один delayed trailing job;
+- trailing job получает последний payload;
+- `returnMeta` показывает leading/trailing/skipped outcomes.
+
+### 5. Lifecycle hooks
+
+Файлы:
+
+- `core/worker/runtime.js`
+- `core/worker/jobApi.js`
+- `core/worker/processJob.js`
+- `core/worker/init.js`
+
+Target API в plugin/server options:
+
+```js
+plugins: {
+  worker: {
+    server: {
+      events: {
+        async onQueued (event) {},
+        async onDeduped (event) {},
+        async onStarted (event) {},
+        async onProgress (event) {},
+        async onCompleted (event) {},
+        async onFailed (event) {}
+      }
+    }
+  }
+}
+```
+
+Event shape:
+
+```js
+{
+  ref,
+  name,
+  worker,
+  data,
+  meta,
+  state,
+  reason,
+  result,
+  error,
+  job
+}
+```
+
+Реализация:
+
+- добавить `events` в `getRuntimeOptions()`;
+- добавить helper `emitWorkerEvent(name, payload, options)`;
+- вызывать `onQueued` после успешного created enqueue;
+- вызывать `onDeduped` после duplicate/dedup result;
+- вызывать `onStarted`, `onProgress`, `onCompleted`, `onFailed` через BullMQ
+  `Worker` events в родительском процессе, а не изнутри `processJob()`;
+- `progress()` внутри handler только вызывает `job.updateProgress(value)`.
+
+Почему не из `processJob()`:
+
+- при `useSeparateProcess` job handler выполняется в child runner;
+- функции из server config не являются serializable worker payload;
+- parent-side BullMQ events дают одинаковую точку интеграции для same-process и
+  separate-process режимов.
+
+Failure policy:
+
+- default: hook failures логируются и не меняют job outcome;
+- lifecycle hooks подходят для eventually consistent read-model/status layer;
+- BullMQ job state остается source of truth;
+- shutdown ожидает уже запущенные hook promises перед закрытием runtime resources;
+- optional future flag: `strictEvents: true` может фейлить job при ошибке hook.
+  Не добавлять strict mode, пока нет конкретного caller-а.
+
+Plugin hook alternative:
+
+- если нужно дать другим StartupJS plugins подписываться без функций в config,
+  можно дополнительно дергать `MODULE.asyncHook('workerJobQueued', event)` и
+  аналогичные hook names;
+- для первого implementation достаточно `server.events`.
+
+Тесты:
+
+- hooks вызываются в ожидаемом порядке для successful job;
+- failed job вызывает `onStarted` и `onFailed`, но не `onCompleted`;
+- progress hook получает progress payload;
+- hook failure логируется и не фейлит job.
+
+### 6. `backend/createModel` в job context
+
+Файлы:
+
+- `core/worker/runtime.js`
+- `core/worker/processJob.js`
+- возможно `core/server/index.js`
+
+Текущий context:
+
+```js
+{
+  log,
+  job,
+  jobRef,
+  progress,
+  enqueueJob,
+  waitJob,
+  getJobStatus
+}
+```
+
+Target context:
+
+```js
+{
+  backend,
+  createModel
+}
+```
+
+Минимальная реализация:
+
+- сохранить backend, созданный `ensureBackendReady()`, внутри worker runtime;
+- экспортировать `getWorkerBackend()` и `createWorkerModel()`;
+- в `processJob()` добавить:
+
+```js
+const createModel = () => createWorkerModel()
+```
+
+Поведение:
+
+- если `ensureBackend: true`, `createModel()` возвращает новый model от worker
+  backend;
+- caller сам отвечает за `model.close()`;
+- если backend отключен или недоступен, `createModel()` throws понятную ошибку.
+
+App-server auto-start case:
+
+- если backend был инициализирован вне worker runtime, `ensureBackendReady()`
+  берет его через `startupjs/server.getBackend()`;
+- если backend отключен (`ensureBackend: false`) или реально не инициализирован,
+  `createModel()` throws controlled error.
+
+Тесты:
+
+- handler context содержит `createModel`;
+- при `ensureBackend: false` вызов `createModel()` throws controlled error;
+- если feasible в integration, при `ensureBackend: true` создается model, и
+  caller может его закрыть.
+
+### 7. README/docs
+
+Файл:
+
+- `core/worker/README.md`
+
+Документировать:
+
+- `returnMeta`;
+- duplicate policy;
+- `throttle.trailing`;
+- lifecycle events;
+- `createModel`;
+- явное правило: default `enqueueJob` и `runJob` behavior не изменились.
+
+## Рекомендуемый порядок реализации
+
+1. Lazy plugin import.
+2. Structured enqueue result и duplicate policy.
+3. Lifecycle hooks.
+4. `backend/createModel` context.
+5. `throttle.trailing`.
+6. README update.
+7. Полный unit + Redis integration test pass.
+
+Так самый рискованный пункт (`throttle.trailing`) остается изолированным до
+того момента, когда уже есть observable enqueue metadata.
+
+## Проверки
+
+Из repo root или `core/worker`:
+
+```bash
+cd core/worker
+yarn test:unit
+yarn test:integration
+yarn test
+```
+
+Также запустить root lint/test для измененных файлов, если он доступен.
+
+Для Redis integration tests использовать isolated `queuePrefix`, как уже
+делают текущие тесты.
+
+## Acceptance criteria
+
+- LMS не нужен patch-package patch для `@startupjs/worker@0.62.x`.
+- Existing public API остается backward compatible.
+- `enqueueJob(..., { returnMeta: true })` отличает created от deduped.
+- `throttle.trailing` работает как leading + last-payload trailing.
+- Lifecycle hooks позволяют app строить временный read model без monkey-patch.
+- Job handlers могут создать model через generic context API.
+- Unit и Redis/BullMQ integration tests покрывают новое поведение.

--- a/core/worker/init.js
+++ b/core/worker/init.js
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'url'
 import {
   AVAILABLE_WORKERS,
   closeRuntimeResources,
+  emitWorkerEvent,
   getJobsMap,
   getQueue,
   getQueueJobOptions,
@@ -11,6 +12,7 @@ import {
   getWorkerConnection,
   getWorkersToStart
 } from './runtime.js'
+import { createJobRef } from './jobRef.js'
 import processJob from './processJob.js'
 
 const PROCESS_JOB_PATH = fileURLToPath(new URL('./processJob.js', import.meta.url))
@@ -61,9 +63,76 @@ function startWorker (workerName, runtimeOptions) {
   worker.on('error', error => {
     console.error(`[@startupjs/worker] Worker "${workerName}" error:`, error)
   })
+  attachWorkerLifecycleEvents(worker, workerName)
 
   activeWorkers.set(workerName, worker)
   return worker
+}
+
+function attachWorkerLifecycleEvents (worker, workerName) {
+  worker.on('active', job => {
+    emitWorkerLifecycleEvent('started', createWorkerEvent(job, workerName, {
+      state: 'active'
+    }))
+  })
+
+  worker.on('progress', (job, progress) => {
+    emitWorkerLifecycleEvent('progress', createWorkerEvent(job, workerName, {
+      state: 'active',
+      progress
+    }))
+  })
+
+  worker.on('completed', (job, result) => {
+    emitWorkerLifecycleEvent('completed', createWorkerEvent(job, workerName, {
+      state: 'completed',
+      result
+    }))
+  })
+
+  worker.on('failed', (job, error) => {
+    emitWorkerLifecycleEvent('failed', createWorkerEvent(job, workerName, {
+      state: 'failed',
+      error
+    }))
+  })
+}
+
+function emitWorkerLifecycleEvent (eventName, event) {
+  emitWorkerEvent(eventName, event).catch(error => {
+    console.error(`[@startupjs/worker] Failed to emit "${eventName}" lifecycle event:`, error)
+  })
+}
+
+function createWorkerEvent (job, workerName, event = {}) {
+  if (!job) {
+    return {
+      ref: null,
+      name: null,
+      worker: workerName,
+      data: undefined,
+      meta: undefined,
+      job: undefined,
+      ...event
+    }
+  }
+
+  const payload = job.data || {}
+  const name = payload.type || job.name
+  const worker = payload.meta?.worker || workerName
+
+  return {
+    ref: {
+      ...createJobRef(job, worker),
+      name
+    },
+    name,
+    worker,
+    data: payload.data,
+    meta: payload.meta,
+    job,
+    ...event
+  }
 }
 
 async function syncSchedulers (workerName, jobs, runtimeOptions) {

--- a/core/worker/jobApi.js
+++ b/core/worker/jobApi.js
@@ -1,9 +1,11 @@
+import { randomUUID } from 'node:crypto'
 import {
   AVAILABLE_WORKERS,
   getJobsMap,
   getQueue,
   getQueueEvents,
-  getRuntimeOptions
+  getRuntimeOptions,
+  emitWorkerEvent
 } from './runtime.js'
 import {
   buildEnqueueConfig,
@@ -15,6 +17,7 @@ import {
 import { createJobRef, normalizeJobRef } from './jobRef.js'
 import { createJobFailedError, serializeJobStatus } from './jobStatus.js'
 import { getTrackedJobRefs, trackJob, untrackJobRef } from './tracking.js'
+import { attachThrottleLeadingJob, resolveThrottleTrailing } from './throttle.js'
 
 export async function enqueueJob (name, data = {}, options = {}) {
   return await enqueueJobInternal(name, data, options, 'enqueueJob')
@@ -32,7 +35,8 @@ export async function enqueueJobInternal (name, data = {}, options = {}, caller 
     worker,
     payload,
     jobOptions,
-    trackingKey
+    trackingKey,
+    deduplication
   } = await buildEnqueueConfig({
     name,
     data,
@@ -43,13 +47,93 @@ export async function enqueueJobInternal (name, data = {}, options = {}, caller 
   })
 
   const queue = getQueue(worker)
+  const returnMeta = Boolean(options.returnMeta)
+  let effectiveDeduplication = deduplication
+  let throttleDecision
+  let throttleClient
+
+  if (deduplication?.trailing) {
+    throttleClient = await queue.client
+    throttleDecision = await resolveThrottleTrailing({
+      client: throttleClient,
+      deduplication
+    })
+
+    if (throttleDecision.action === 'trailing') {
+      const delay = Math.max(0, throttleDecision.delay)
+
+      jobOptions.delay = delay
+      jobOptions.deduplication = {
+        ...(jobOptions.deduplication || {}),
+        id: deduplication.trailingId,
+        ttl: Math.max(delay, 1),
+        extend: true,
+        replace: true
+      }
+      effectiveDeduplication = {
+        ...deduplication,
+        id: deduplication.trailingId,
+        deduped: true,
+        createsJobOnDuplicate: true
+      }
+    } else {
+      effectiveDeduplication = undefined
+    }
+  }
+
+  const needsDuplicateDetection = Boolean(
+    effectiveDeduplication?.id &&
+    (
+      returnMeta ||
+      effectiveDeduplication.deduped ||
+      effectiveDeduplication.policy === 'skip' ||
+      effectiveDeduplication.policy === 'throw'
+    )
+  )
+  const previousDeduplicatedJobId = needsDuplicateDetection
+    ? await getDeduplicationJobId(queue, effectiveDeduplication.id)
+    : undefined
+  let candidateJobId
+
+  if (needsDuplicateDetection && jobOptions.jobId == null) {
+    candidateJobId = createCandidateJobId()
+    jobOptions.jobId = candidateJobId
+  } else if (jobOptions.jobId != null) {
+    candidateJobId = String(jobOptions.jobId)
+  }
+
   const job = await queue.add(name, payload, jobOptions)
   const ref = {
     ...createJobRef(job, worker),
     name
   }
+  const enqueueResult = createEnqueueResult({
+    ref,
+    deduplication: effectiveDeduplication,
+    candidateJobId,
+    previousDeduplicatedJobId
+  })
 
-  if (trackingKey) {
+  if (throttleDecision?.action === 'leading') {
+    await attachThrottleLeadingJob({
+      client: throttleClient,
+      lockKey: throttleDecision.lockKey,
+      ref
+    })
+  }
+
+  if (enqueueResult.deduped && enqueueResult.policy === 'throw') {
+    await emitWorkerEvent('deduped', createEnqueueEvent({
+      enqueueResult,
+      name,
+      worker,
+      payload,
+      job
+    }))
+    throw createDuplicateJobError(enqueueResult)
+  }
+
+  if (trackingKey && shouldTrackEnqueueResult(enqueueResult)) {
     try {
       await trackJob({ ref, name, trackingKey })
     } catch (error) {
@@ -57,6 +141,27 @@ export async function enqueueJobInternal (name, data = {}, options = {}, caller 
     }
   }
 
+  if (enqueueResult.deduped) {
+    await emitWorkerEvent('deduped', createEnqueueEvent({
+      enqueueResult,
+      name,
+      worker,
+      payload,
+      job
+    }))
+  }
+
+  if (enqueueResult.created && !enqueueResult.skipped) {
+    await emitWorkerEvent('queued', createEnqueueEvent({
+      enqueueResult,
+      name,
+      worker,
+      payload,
+      job
+    }))
+  }
+
+  if (returnMeta) return enqueueResult
   return ref
 }
 
@@ -246,6 +351,105 @@ async function createJobTrackingError ({ error, ref, job, jobOptions }) {
 
 function canRollbackTrackingFailure (jobOptions) {
   return !jobOptions.deduplication && jobOptions.jobId == null
+}
+
+async function getDeduplicationJobId (queue, deduplicationId) {
+  const client = await queue.client
+  return await client.get(`${queue.keys.de}:${deduplicationId}`)
+}
+
+function createCandidateJobId () {
+  return `meta-${randomUUID()}`
+}
+
+function createEnqueueResult ({
+  ref,
+  deduplication,
+  candidateJobId,
+  previousDeduplicatedJobId
+}) {
+  const matchedCandidate = candidateJobId && ref.id === candidateJobId
+  const returnedExistingJob = Boolean(candidateJobId && !matchedCandidate)
+  const replaced = Boolean(
+    deduplication &&
+    matchedCandidate &&
+    previousDeduplicatedJobId &&
+    (
+      deduplication.policy === 'replace' ||
+      deduplication.policy === 'trailing'
+    )
+  )
+  const hasDetectedDuplicate = Boolean(
+    deduplication &&
+    (
+      deduplication.deduped ||
+      replaced ||
+      returnedExistingJob
+    )
+  )
+  const created = !hasDetectedDuplicate || replaced || Boolean(
+    deduplication?.createsJobOnDuplicate && matchedCandidate
+  )
+  const skipped = hasDetectedDuplicate && deduplication.policy === 'skip'
+  const duplicateOfId = previousDeduplicatedJobId || (returnedExistingJob ? ref.id : undefined)
+  const duplicateOf = duplicateOfId
+    ? {
+        ...ref,
+        id: duplicateOfId
+      }
+    : null
+
+  return {
+    ref,
+    created,
+    deduped: hasDetectedDuplicate,
+    skipped,
+    replaced,
+    reason: hasDetectedDuplicate ? deduplication.reason : null,
+    policy: deduplication?.policy || 'created',
+    duplicateOf
+  }
+}
+
+function shouldTrackEnqueueResult (enqueueResult) {
+  return !enqueueResult.skipped
+}
+
+function createDuplicateJobError (enqueueResult) {
+  const error = new Error(
+    `[@startupjs/worker] enqueueJob: duplicate ${enqueueResult.reason || 'job'} job`
+  )
+  error.name = 'DuplicateJobError'
+  error.jobRef = enqueueResult.ref
+  error.reason = enqueueResult.reason
+  error.policy = enqueueResult.policy
+  error.duplicateOf = enqueueResult.duplicateOf
+  return error
+}
+
+function createEnqueueEvent ({
+  enqueueResult,
+  name,
+  worker,
+  payload,
+  job
+}) {
+  return {
+    ref: enqueueResult.ref,
+    name,
+    worker,
+    data: payload.data,
+    meta: payload.meta,
+    state: enqueueResult.created ? 'queued' : 'deduped',
+    reason: enqueueResult.reason,
+    policy: enqueueResult.policy,
+    created: enqueueResult.created,
+    deduped: enqueueResult.deduped,
+    skipped: enqueueResult.skipped,
+    replaced: enqueueResult.replaced,
+    duplicateOf: enqueueResult.duplicateOf,
+    job
+  }
 }
 
 async function queryTrackedJobs ({ trackingKey, name, worker, states, limit }) {

--- a/core/worker/jobOptions.js
+++ b/core/worker/jobOptions.js
@@ -6,6 +6,17 @@ const DEFAULT_ACTIVE_STATES = Object.freeze([
   'waiting-children'
 ])
 
+const DEFAULT_DUPLICATE_POLICY = 'return-existing'
+const DUPLICATE_POLICIES = Object.freeze([
+  DEFAULT_DUPLICATE_POLICY,
+  'skip',
+  'throw'
+])
+const DEBOUNCE_DUPLICATE_POLICIES = Object.freeze([
+  ...DUPLICATE_POLICIES,
+  'replace'
+])
+
 export function validateJobName (name, caller) {
   if (typeof name !== 'string' || !name.trim()) {
     throw new Error(`[@startupjs/worker] ${caller}: "name" must be a non-empty string`)
@@ -68,9 +79,11 @@ export async function buildEnqueueConfig ({
       jobOptions.delay = deduplicationConfig.delay
     }
 
-    jobOptions.deduplication = {
-      ...(jobOptions.deduplication || {}),
-      ...deduplicationConfig.options
+    if (deduplicationConfig.options) {
+      jobOptions.deduplication = {
+        ...(jobOptions.deduplication || {}),
+        ...deduplicationConfig.options
+      }
     }
   }
 
@@ -78,7 +91,8 @@ export async function buildEnqueueConfig ({
     worker,
     payload,
     jobOptions,
-    trackingKey
+    trackingKey,
+    deduplication: deduplicationConfig?.meta
   }
 }
 
@@ -178,17 +192,21 @@ async function resolveDeduplication ({
   }
 
   if (options.throttle) {
-    return {
-      options: resolveThrottleDeduplication({ name, worker, throttle: options.throttle, caller })
-    }
+    return resolveThrottleDeduplication({ name, worker, throttle: options.throttle, caller })
   }
 
   const singleton = options.singleton ?? jobDefinition.singleton
   const singletonId = await getSingletonDeduplicationId({ singleton, name, worker }, data, caller)
   if (!singletonId) return
+  const policy = getSingletonDuplicatePolicy(singleton, caller)
 
   return {
-    options: { id: singletonId }
+    options: { id: singletonId },
+    meta: {
+      id: singletonId,
+      reason: 'singleton',
+      policy
+    }
   }
 }
 
@@ -223,6 +241,13 @@ export async function getSingletonDeduplicationId (jobDefinition, data, caller =
   return `singleton:${worker}:${name}:${hash}`
 }
 
+function getSingletonDuplicatePolicy (singleton, caller) {
+  if (singleton && typeof singleton === 'object') {
+    return normalizeDuplicatePolicy(singleton.onDuplicate, caller)
+  }
+  return DEFAULT_DUPLICATE_POLICY
+}
+
 function resolveDebounceDeduplication ({ name, worker, debounce, caller }) {
   if (!debounce || typeof debounce !== 'object') {
     throw new Error(`[@startupjs/worker] ${caller}: debounce must be an object`)
@@ -230,6 +255,12 @@ function resolveDebounceDeduplication ({ name, worker, debounce, caller }) {
 
   const key = normalizeRequiredKey(debounce.key, 'debounce.key', caller)
   const delay = normalizeDelay(debounce.delay ?? debounce.ttl, caller)
+  const policy = normalizeDuplicatePolicy(
+    debounce.onDuplicate ?? (debounce.replace === false ? DEFAULT_DUPLICATE_POLICY : 'replace'),
+    caller,
+    DEBOUNCE_DUPLICATE_POLICIES
+  )
+  const replace = policy === 'replace'
 
   return {
     delay,
@@ -237,7 +268,12 @@ function resolveDebounceDeduplication ({ name, worker, debounce, caller }) {
       id: `debounce:${worker}:${name}:${key}`,
       ttl: delay,
       extend: debounce.extend ?? true,
-      replace: debounce.replace ?? true
+      replace
+    },
+    meta: {
+      id: `debounce:${worker}:${name}:${key}`,
+      reason: 'debounce',
+      policy
     }
   }
 }
@@ -247,18 +283,35 @@ function resolveThrottleDeduplication ({ name, worker, throttle, caller }) {
     throw new Error(`[@startupjs/worker] ${caller}: throttle must be an object`)
   }
 
+  const key = normalizeRequiredKey(throttle.key, 'throttle.key', caller)
+  const ttl = normalizePositiveDelay(throttle.ttl, 'throttle.ttl', caller)
+  const policy = normalizeDuplicatePolicy(throttle.onDuplicate, caller)
+  const id = `throttle:${worker}:${name}:${key}`
+
   if (throttle.trailing) {
-    throw new Error(
-      `[@startupjs/worker] ${caller}: throttle.trailing is not supported yet`
-    )
+    return {
+      meta: {
+        id,
+        trailingId: `throttle-trailing:${worker}:${name}:${key}`,
+        reason: 'throttle',
+        policy: 'trailing',
+        trailing: true,
+        key,
+        ttl
+      }
+    }
   }
 
-  const key = normalizeRequiredKey(throttle.key, 'throttle.key', caller)
-  const ttl = normalizeDelay(throttle.ttl, caller)
-
   return {
-    id: `throttle:${worker}:${name}:${key}`,
-    ttl
+    options: {
+      id,
+      ttl
+    },
+    meta: {
+      id,
+      reason: 'throttle',
+      policy
+    }
   }
 }
 
@@ -268,6 +321,26 @@ function normalizeRequiredKey (value, label, caller) {
     throw new Error(`[@startupjs/worker] ${caller}: ${label} is required`)
   }
   return key
+}
+
+function normalizePositiveDelay (value, label, caller) {
+  const normalizedDelay = normalizeDelay(value, caller)
+  if (normalizedDelay > 0) return normalizedDelay
+
+  throw new Error(`[@startupjs/worker] ${caller}: ${label} must be a positive number`)
+}
+
+function normalizeDuplicatePolicy (
+  policy = DEFAULT_DUPLICATE_POLICY,
+  caller,
+  allowedPolicies = DUPLICATE_POLICIES
+) {
+  if (policy == null) return DEFAULT_DUPLICATE_POLICY
+  if (allowedPolicies.includes(policy)) return policy
+
+  throw new Error(
+    `[@startupjs/worker] ${caller}: onDuplicate must be one of: ${allowedPolicies.join(', ')}`
+  )
 }
 
 function stableStringify (value) {

--- a/core/worker/plugin.js
+++ b/core/worker/plugin.js
@@ -1,5 +1,4 @@
 import { createPlugin } from 'startupjs/registry'
-import initDashboardRoute from './initDashboardRoute.js'
 
 export default createPlugin({
   name: 'worker',
@@ -19,6 +18,7 @@ export default createPlugin({
         if (dashboardOptions === true) dashboardOptions = {}
 
         if (dashboardOptions) {
+          const { default: initDashboardRoute } = await import('./initDashboardRoute.js')
           initDashboardRoute({
             expressApp,
             ...dashboardOptions

--- a/core/worker/processJob.js
+++ b/core/worker/processJob.js
@@ -1,5 +1,11 @@
 import { isBackendInitialized } from 'startupjs/server'
-import { ensureBackendReady, getJobsMap, getRuntimeOptions } from './runtime.js'
+import {
+  createWorkerModel,
+  ensureBackendReady,
+  getJobsMap,
+  getRuntimeOptions,
+  getWorkerBackend
+} from './runtime.js'
 import { createJobRef } from './jobRef.js'
 import { enqueueJob, getJobStatus, waitJob } from './jobApi.js'
 
@@ -44,10 +50,14 @@ export default async function processJob (job) {
   }
 
   try {
-    return await runWithTimeout({
+    const result = await runWithTimeout({
       timeout,
       type,
       execute: () => Promise.resolve(jobDefinition.handler(data, {
+        get backend () {
+          return getWorkerBackend()
+        },
+        createModel: () => createWorkerModel(),
         log,
         job,
         jobRef,
@@ -57,6 +67,7 @@ export default async function processJob (job) {
         getJobStatus
       }))
     })
+    return result
   } catch (error) {
     await writeJobLog(job, `[${type}] ${formatError(error)}`, 'error')
 

--- a/core/worker/runtime.js
+++ b/core/worker/runtime.js
@@ -1,5 +1,6 @@
 import {
   createBackend,
+  getBackend,
   getRedis,
   getRedisOptions,
   isBackendInitialized,
@@ -21,7 +22,8 @@ const DEFAULT_OPTIONS = {
   useSeparateProcess: false,
   useWorkerThreads: true,
   jobTimeout: 30000,
-  queuePrefix: redisPrefix
+  queuePrefix: redisPrefix,
+  events: undefined
 }
 
 const DEFAULT_JOB_OPTIONS = {
@@ -32,8 +34,10 @@ const DEFAULT_JOB_OPTIONS = {
 const queues = new Map()
 const queueEvents = new Map()
 const redisConnections = new Set()
+const pendingWorkerEvents = new Set()
 
 let backendInitPromise
+let workerBackend
 let jobsPromise
 let runtimeOptionsOverrides = {}
 
@@ -60,7 +64,8 @@ export function getRuntimeOptions (override = {}) {
       DEFAULT_OPTIONS.useWorkerThreads
     ),
     jobTimeout: toNumber(mergedOptions.jobTimeout, DEFAULT_OPTIONS.jobTimeout),
-    queuePrefix: normalizeQueuePrefix(mergedOptions.queuePrefix, DEFAULT_OPTIONS.queuePrefix)
+    queuePrefix: normalizeQueuePrefix(mergedOptions.queuePrefix, DEFAULT_OPTIONS.queuePrefix),
+    events: normalizeEvents(mergedOptions.events)
   }
 }
 
@@ -135,6 +140,8 @@ export function getQueueJobOptions () {
 }
 
 export async function closeRuntimeResources () {
+  await flushWorkerEvents()
+
   const queuesToClose = Array.from(queues.values())
   const queueEventsToClose = Array.from(queueEvents.values())
 
@@ -160,7 +167,11 @@ export function getWorkerConnection () {
 }
 
 export async function ensureBackendReady () {
-  if (isBackendInitialized()) return
+  if (workerBackend) return
+  if (isBackendInitialized()) {
+    workerBackend = getBackend()
+    return
+  }
   if (backendInitPromise) {
     await backendInitPromise
     return
@@ -168,7 +179,7 @@ export async function ensureBackendReady () {
 
   backendInitPromise = Promise.resolve()
     .then(() => {
-      createBackend()
+      workerBackend = createBackend()
     })
     .catch(error => {
       backendInitPromise = undefined
@@ -176,6 +187,50 @@ export async function ensureBackendReady () {
     })
 
   await backendInitPromise
+}
+
+export function getWorkerBackend () {
+  if (workerBackend) return workerBackend
+
+  throw new Error(
+    '[@startupjs/worker] Worker backend is not available. ' +
+      'Enable backend initialization for the worker process before using job context backend/createModel.'
+  )
+}
+
+export function createWorkerModel () {
+  return getWorkerBackend().createModel()
+}
+
+export async function emitWorkerEvent (eventName, event = {}) {
+  const promise = runWorkerEvent(eventName, event)
+
+  pendingWorkerEvents.add(promise)
+  promise.finally(() => {
+    pendingWorkerEvents.delete(promise)
+  })
+
+  return await promise
+}
+
+async function runWorkerEvent (eventName, event = {}) {
+  const events = getRuntimeOptions().events
+  const handlerName = getWorkerEventHandlerName(eventName)
+  const handler = events?.[handlerName]
+
+  if (typeof handler !== 'function') return
+
+  try {
+    await handler(event)
+  } catch (error) {
+    console.error(`[@startupjs/worker] ${handlerName} hook failed:`, error)
+  }
+}
+
+async function flushWorkerEvents () {
+  if (!pendingWorkerEvents.size) return
+
+  await Promise.allSettled(Array.from(pendingWorkerEvents))
 }
 
 export async function getJobsMap ({ refresh = false } = {}) {
@@ -368,4 +423,13 @@ function normalizeQueuePrefix (value, defaultValue) {
 
   const normalizedValue = String(value).trim()
   return normalizedValue || defaultValue
+}
+
+function normalizeEvents (events) {
+  if (!events || typeof events !== 'object') return undefined
+  return events
+}
+
+function getWorkerEventHandlerName (eventName) {
+  return `on${eventName.charAt(0).toUpperCase()}${eventName.slice(1)}`
 }

--- a/core/worker/test/jobOptions.test.js
+++ b/core/worker/test/jobOptions.test.js
@@ -94,6 +94,60 @@ test('supports module singleton and per-call singleton', async () => {
   })
 
   assert.equal(config.jobOptions.deduplication.id, 'singleton:default:sync:manual-key')
+  assert.deepEqual(config.deduplication, {
+    id: 'singleton:default:sync:manual-key',
+    reason: 'singleton',
+    policy: 'return-existing'
+  })
+})
+
+test('supports duplicate policies for singleton and debounce', async () => {
+  const singletonConfig = await buildEnqueueConfig({
+    name: 'sync',
+    data: {},
+    options: {
+      singleton: {
+        key: 'manual-key',
+        onDuplicate: 'skip'
+      }
+    },
+    jobDefinition: {
+      name: 'sync',
+      worker: 'default'
+    },
+    defaultTimeout: 30000,
+    caller: 'test'
+  })
+
+  assert.deepEqual(singletonConfig.deduplication, {
+    id: 'singleton:default:sync:manual-key',
+    reason: 'singleton',
+    policy: 'skip'
+  })
+
+  const debounceConfig = await buildEnqueueConfig({
+    name: 'sync',
+    data: {},
+    options: {
+      debounce: {
+        key: 'manual-key',
+        delay: 100,
+        replace: false
+      }
+    },
+    jobDefinition: {
+      name: 'sync',
+      worker: 'default'
+    },
+    defaultTimeout: 30000,
+    caller: 'test'
+  })
+
+  assert.deepEqual(debounceConfig.deduplication, {
+    id: 'debounce:default:sync:manual-key',
+    reason: 'debounce',
+    policy: 'return-existing'
+  })
 })
 
 test('maps debounce and leading throttle to BullMQ deduplication', async () => {
@@ -143,6 +197,42 @@ test('maps debounce and leading throttle to BullMQ deduplication', async () => {
     id: 'throttle:default:search:user:u1',
     ttl: 300
   })
+  assert.deepEqual(throttleConfig.deduplication, {
+    id: 'throttle:default:search:user:u1',
+    reason: 'throttle',
+    policy: 'return-existing'
+  })
+})
+
+test('maps trailing throttle to worker-level deduplication metadata', async () => {
+  const config = await buildEnqueueConfig({
+    name: 'search',
+    data: {},
+    options: {
+      throttle: {
+        key: 'user:u1',
+        ttl: 300,
+        trailing: true
+      }
+    },
+    jobDefinition: {
+      name: 'search',
+      worker: 'default'
+    },
+    defaultTimeout: 30000,
+    caller: 'test'
+  })
+
+  assert.equal(config.jobOptions.deduplication, undefined)
+  assert.deepEqual(config.deduplication, {
+    id: 'throttle:default:search:user:u1',
+    trailingId: 'throttle-trailing:default:search:user:u1',
+    reason: 'throttle',
+    policy: 'trailing',
+    trailing: true,
+    key: 'user:u1',
+    ttl: 300
+  })
 })
 
 test('rejects unsupported or ambiguous options', async () => {
@@ -183,10 +273,9 @@ test('rejects unsupported or ambiguous options', async () => {
     name: 'job',
     data: {},
     options: {
-      throttle: {
+      singleton: {
         key: 'k',
-        ttl: 1,
-        trailing: true
+        onDuplicate: 'replace'
       }
     },
     jobDefinition: {
@@ -195,7 +284,24 @@ test('rejects unsupported or ambiguous options', async () => {
     },
     defaultTimeout: 30000,
     caller: 'test'
-  }), /throttle.trailing is not supported yet/)
+  }), /onDuplicate must be one of: return-existing, skip, throw/)
+
+  await assert.rejects(() => buildEnqueueConfig({
+    name: 'job',
+    data: {},
+    options: {
+      throttle: {
+        key: 'k',
+        ttl: 0
+      }
+    },
+    jobDefinition: {
+      name: 'job',
+      worker: 'default'
+    },
+    defaultTimeout: 30000,
+    caller: 'test'
+  }), /throttle\.ttl must be a positive number/)
 })
 
 test('normalizes states and tracking keys', () => {

--- a/core/worker/test/jobPlugin.test.js
+++ b/core/worker/test/jobPlugin.test.js
@@ -1,0 +1,14 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+test('plugin loads dashboard route lazily', async () => {
+  const source = await readFile(join(__dirname, '../plugin.js'), 'utf8')
+
+  assert.doesNotMatch(source, /import\s+initDashboardRoute\s+from/)
+  assert.match(source, /await import\('\.\/initDashboardRoute\.js'\)/)
+})

--- a/core/worker/test/workerApi.integration.test.js
+++ b/core/worker/test/workerApi.integration.test.js
@@ -32,6 +32,21 @@ const JOBS = {
       }
     }
   `,
+  contextInfo: `
+    export default async function contextInfo (data, { createModel }) {
+      try {
+        createModel()
+      } catch (error) {
+        return {
+          createModelError: error.message
+        }
+      }
+
+      return {
+        createModelError: null
+      }
+    }
+  `,
   parent: `
     export default async function parent (data, { enqueueJob, waitJob }) {
       const childRef = await enqueueJob('echo', { from: 'parent' }, {
@@ -220,6 +235,84 @@ test('worker public API with Redis and BullMQ', async t => {
     await api.cancelJob(firstRef)
   })
 
+  await t.test('enqueueJob returnMeta reports created and singleton duplicates', async () => {
+    const singleton = { key: api.trackingKey('singleton-meta') }
+    const first = await api.enqueueJob('echo', { value: 1 }, {
+      delay: 5000,
+      returnMeta: true,
+      singleton
+    })
+    const second = await api.enqueueJob('echo', { value: 2 }, {
+      delay: 5000,
+      returnMeta: true,
+      singleton
+    })
+
+    assert.equal(first.created, true)
+    assert.equal(first.deduped, false)
+    assert.equal(first.policy, 'return-existing')
+    assert.equal(second.created, false)
+    assert.equal(second.deduped, true)
+    assert.equal(second.skipped, false)
+    assert.equal(second.reason, 'singleton')
+    assert.equal(second.policy, 'return-existing')
+    assert.equal(second.ref.id, first.ref.id)
+    assert.equal(second.duplicateOf.id, first.ref.id)
+
+    await api.cancelJob(first.ref)
+  })
+
+  await t.test('duplicate policies can skip or throw on duplicate jobs', async () => {
+    const skipSingleton = {
+      key: api.trackingKey('singleton-skip'),
+      onDuplicate: 'skip'
+    }
+    const skippedSource = await api.enqueueJob('echo', { value: 1 }, {
+      delay: 5000,
+      returnMeta: true,
+      singleton: skipSingleton
+    })
+    const skippedDuplicate = await api.enqueueJob('echo', { value: 2 }, {
+      delay: 5000,
+      returnMeta: true,
+      singleton: skipSingleton
+    })
+
+    assert.equal(skippedDuplicate.created, false)
+    assert.equal(skippedDuplicate.deduped, true)
+    assert.equal(skippedDuplicate.skipped, true)
+    assert.equal(skippedDuplicate.reason, 'singleton')
+    assert.equal(skippedDuplicate.policy, 'skip')
+    assert.equal(skippedDuplicate.ref.id, skippedSource.ref.id)
+
+    await api.cancelJob(skippedSource.ref)
+
+    const throwSingleton = {
+      key: api.trackingKey('singleton-throw'),
+      onDuplicate: 'throw'
+    }
+    const throwSource = await api.enqueueJob('echo', { value: 1 }, {
+      delay: 5000,
+      singleton: throwSingleton
+    })
+
+    await assert.rejects(
+      () => api.enqueueJob('echo', { value: 2 }, {
+        delay: 5000,
+        singleton: throwSingleton
+      }),
+      error => {
+        assert.equal(error.name, 'DuplicateJobError')
+        assert.equal(error.reason, 'singleton')
+        assert.equal(error.policy, 'throw')
+        assert.equal(error.duplicateOf.id, throwSource.id)
+        return true
+      }
+    )
+
+    await api.cancelJob(throwSource)
+  })
+
   await t.test('debounce replaces delayed payload', async () => {
     const key = api.trackingKey('debounce')
 
@@ -246,14 +339,132 @@ test('worker public API with Redis and BullMQ', async t => {
       assert.equal((await api.getJobStatus(firstRef)).state, 'unknown')
     }
   })
+
+  await t.test('debounce returnMeta reports replaced delayed payload', async () => {
+    const key = api.trackingKey('debounce-meta')
+
+    const first = await api.enqueueJob('echo', { value: 1 }, {
+      debounce: {
+        key,
+        delay: 1000
+      },
+      returnMeta: true
+    })
+    const second = await api.enqueueJob('echo', { value: 2 }, {
+      debounce: {
+        key,
+        delay: 1000
+      },
+      returnMeta: true
+    })
+
+    assert.equal(second.created, true)
+    assert.equal(second.deduped, true)
+    assert.equal(second.replaced, true)
+    assert.equal(second.reason, 'debounce')
+    assert.equal(second.policy, 'replace')
+    assert.equal(second.duplicateOf.id, first.ref.id)
+
+    const result = await api.waitJob(second.ref, { timeout: 5000 })
+    assert.deepEqual(result, {
+      ok: true,
+      data: { value: 2 }
+    })
+  })
+
+  await t.test('trailing throttle schedules the latest duplicate after the throttle window', async () => {
+    const key = api.trackingKey('throttle-trailing')
+    const throttle = { key, ttl: 200, trailing: true }
+
+    const leading = await api.enqueueJob('echo', { value: 1 }, {
+      returnMeta: true,
+      throttle
+    })
+    const trailing = await api.enqueueJob('echo', { value: 2 }, {
+      returnMeta: true,
+      throttle
+    })
+    const latest = await api.enqueueJob('echo', { value: 3 }, {
+      returnMeta: true,
+      throttle
+    })
+
+    assert.equal(leading.created, true)
+    assert.equal(leading.deduped, false)
+    assert.equal(trailing.created, true)
+    assert.equal(trailing.deduped, true)
+    assert.equal(trailing.reason, 'throttle')
+    assert.equal(trailing.policy, 'trailing')
+    assert.equal(latest.created, true)
+    assert.equal(latest.deduped, true)
+    assert.equal(latest.replaced, true)
+    assert.equal(latest.reason, 'throttle')
+    assert.equal(latest.policy, 'trailing')
+
+    const result = await api.waitJob(latest.ref, { timeout: 5000 })
+    assert.deepEqual(result, {
+      ok: true,
+      data: { value: 3 }
+    })
+
+    if (trailing.ref.id !== latest.ref.id) {
+      assert.equal((await api.getJobStatus(trailing.ref)).state, 'unknown')
+    }
+  })
+
+  await t.test('worker events report lifecycle changes', async () => {
+    const events = []
+
+    api.setWorkerEvents({
+      onQueued: event => events.push(['queued', event.name]),
+      onStarted: event => events.push(['started', event.name]),
+      onProgress: event => events.push(['progress', event.progress]),
+      onCompleted: event => events.push(['completed', event.result.progress]),
+      onFailed: event => events.push(['failed', event.error.message])
+    })
+
+    await api.runJob('logAndProgress', { value: 4 })
+
+    await assert.rejects(
+      () => api.runJob('fail'),
+      /expected failure/
+    )
+
+    api.setWorkerEvents()
+
+    assert.ok(events.some(event => event[0] === 'queued' && event[1] === 'logAndProgress'))
+    assert.ok(events.some(event => event[0] === 'started' && event[1] === 'logAndProgress'))
+    assert.ok(events.some(event => event[0] === 'progress' && event[1].percent === 50))
+    assert.ok(events.some(event => {
+      return event[0] === 'completed' && event[1].percent === 50
+    }))
+    assert.ok(events.some(event => event[0] === 'failed' && /expected failure/.test(event[1])))
+  })
+
+  await t.test('handler context exposes createModel with backend availability errors', async () => {
+    const result = await api.runJob('contextInfo')
+
+    assert.match(
+      result.createModelError,
+      /Worker backend is not available/
+    )
+  })
 })
 
-async function setupWorkerRuntime (t) {
+async function setupWorkerRuntime (t, options = {}) {
   const previousCwd = process.cwd()
   const previousRedisUrl = process.env.REDIS_URL
   const tmpDir = await mkdtemp(join(tmpdir(), 'startupjs-worker-'))
   const jobsDir = join(tmpDir, 'workerJobs')
   const queuePrefix = `startupjs-worker-test:${process.pid}:${Date.now()}`
+  const workerOptions = {
+    concurrency: 10,
+    ensureBackend: false,
+    jobTimeout: 5000,
+    queuePrefix,
+    useSeparateProcess: false,
+    ...options
+  }
 
   await mkdir(jobsDir)
   await writeFile(join(tmpDir, 'package.json'), JSON.stringify({
@@ -273,20 +484,10 @@ async function setupWorkerRuntime (t) {
   const runtimeModule = await import('../runtime.js')
   const trackingModule = await import('../tracking.js')
 
-  runtimeModule.setRuntimeOptionsOverrides({
-    concurrency: 10,
-    ensureBackend: false,
-    jobTimeout: 5000,
-    queuePrefix,
-    useSeparateProcess: false
-  })
+  runtimeModule.setRuntimeOptionsOverrides(workerOptions)
 
   await initWorkerModule.default({
-    concurrency: 10,
-    ensureBackend: false,
-    jobTimeout: 5000,
-    queuePrefix,
-    useSeparateProcess: false,
+    ...workerOptions,
     workers: ['default', 'priority']
   })
 
@@ -308,6 +509,7 @@ async function setupWorkerRuntime (t) {
   return {
     ...workerApi,
     queuePrefix,
+    setWorkerEvents: events => runtimeModule.setRuntimeOptionsOverrides({ events }),
     trackingKey: suffix => `${queuePrefix}:${suffix}:${Date.now()}`
   }
 }

--- a/core/worker/throttle.js
+++ b/core/worker/throttle.js
@@ -1,0 +1,50 @@
+import { getRuntimeOptions } from './runtime.js'
+import { serializeJobRef } from './jobRef.js'
+
+const PENDING_THROTTLE_JOB = 'pending'
+
+export async function resolveThrottleTrailing ({ client, deduplication }) {
+  const lockKey = getThrottleLockKey(deduplication)
+  const ttl = Math.max(0, Number(deduplication.ttl || 0))
+
+  const acquired = await client.set(lockKey, PENDING_THROTTLE_JOB, 'PX', ttl, 'NX')
+  if (acquired === 'OK') {
+    return {
+      action: 'leading',
+      lockKey
+    }
+  }
+
+  let remainingTtl = await client.pttl(lockKey)
+
+  if (remainingTtl < 0) {
+    const retryAcquired = await client.set(lockKey, PENDING_THROTTLE_JOB, 'PX', ttl, 'NX')
+    if (retryAcquired === 'OK') {
+      return {
+        action: 'leading',
+        lockKey
+      }
+    }
+
+    remainingTtl = await client.pttl(lockKey)
+  }
+
+  return {
+    action: 'trailing',
+    lockKey,
+    delay: Math.max(0, remainingTtl)
+  }
+}
+
+export async function attachThrottleLeadingJob ({ client, lockKey, ref }) {
+  if (!lockKey) return
+
+  const remainingTtl = await client.pttl(lockKey)
+  if (remainingTtl <= 0) return
+
+  await client.set(lockKey, serializeJobRef(ref), 'PX', remainingTtl)
+}
+
+function getThrottleLockKey (deduplication) {
+  return `${getRuntimeOptions().queuePrefix}:worker:${deduplication.id}`
+}


### PR DESCRIPTION
## Summary
- add opt-in enqueue metadata via returnMeta and duplicate policies
- add trailing throttle support and managed best-effort lifecycle events
- expose worker backend/createModel context and lazy-load dashboard route
- document Stage 2 worker API and cover new behavior with unit/integration tests

## Tests
- cd core/worker && yarn test:unit
- cd core/worker && yarn test:integration
- cd core/worker && yarn test
- npx eslint core/server/index.js core/worker/init.js core/worker/jobApi.js core/worker/jobOptions.js core/worker/plugin.js core/worker/processJob.js core/worker/runtime.js core/worker/test/jobOptions.test.js core/worker/test/workerApi.integration.test.js core/worker/test/jobPlugin.test.js core/worker/throttle.js
- git diff --check