### PR TITLE
Hide server-only imports from web bundler

### DIFF
--- a/core/server/index.js
+++ b/core/server/index.js
@@ -17,6 +17,7 @@ const IS_EXPO = isExpo(process.env.ROOT_PATH || process.cwd())
 //       might actually be good for performance since the data is cached
 //       between concurrent requests and we don't have to re-fetch it each time.
 const FETCH_ONLY = false
+const importLocalModule = createLocalModuleImporter()
 
 const defaultOptions = {
   publicPath: IS_EXPO ? './dist' : './public',
@@ -41,7 +42,9 @@ export default async function startServer (options) {
 }
 
 export async function createServer (options = {}) {
-  const { default: createServer } = await import('./server/createServer.js')
+  const { default: createServer } = await importLocalModule(
+    new URL('./server/createServer.js', import.meta.url).href
+  )
   options = transformOptions(options)
   const backend = _createBackend({ ...options, models: MODULE.models })
   currentBackend = backend
@@ -56,7 +59,9 @@ export async function createServer (options = {}) {
 }
 
 export async function createMiddleware (options = {}) {
-  const { default: createMiddleware } = await import('./server/createMiddleware.js')
+  const { default: createMiddleware } = await importLocalModule(
+    new URL('./server/createMiddleware.js', import.meta.url).href
+  )
   options = transformOptions(options)
   const backend = _createBackend({ ...options, models: MODULE.models })
   currentBackend = backend
@@ -109,6 +114,12 @@ function isExpo (rootPath) {
 
 function markBackendInitialized () {
   backendInitialized = true
+}
+
+function createLocalModuleImporter () {
+  // Keep server-only modules lazy without exposing literal dynamic imports
+  // to Metro/Expo web static analysis through startupjs/server consumers.
+  return new Function('specifier', 'return import(specifier)') // eslint-disable-line no-new-func
 }
 
 export {

--- a/core/server/server/createMiddleware.js
+++ b/core/server/server/createMiddleware.js
@@ -15,6 +15,7 @@ const DEFAULT_BODY_PARSER_OPTIONS = {
     extended: true
   }
 }
+const importLocalModule = createLocalModuleImporter()
 
 /**
  * A connect middleware with core startupjs functionality. You can plug this into your
@@ -61,7 +62,9 @@ export async function _createMiddleware ({ backend, session, channel, options })
   if (existsSync(join(options.dirname, SERVER_FOLDER))) {
     for (const file of readdirSync(join(options.dirname, SERVER_FOLDER))) {
       if (MIDDLEWARE_FILENAME_REGEX.test(file)) {
-        const { default: middleware } = await import(join(options.dirname, SERVER_FOLDER, file))
+        const { default: middleware } = await importLocalModule(
+          join(options.dirname, SERVER_FOLDER, file)
+        )
         if (!(typeof middleware === 'function' || Array.isArray(middleware))) {
           throw Error(ERRORS.incorrectMiddlewareFile(file))
         }
@@ -102,6 +105,12 @@ export async function _createMiddleware ({ backend, session, channel, options })
   })
 
   return publicApp
+}
+
+function createLocalModuleImporter () {
+  // Keep server middleware ESM loading server-side without exposing import(expression)
+  // to Metro/Expo web static analysis through startupjs.config.js.
+  return new Function('specifier', 'return import(specifier)') // eslint-disable-line no-new-func
 }
 
 const ERRORS = {

--- a/core/server/test/createMiddleware.test.js
+++ b/core/server/test/createMiddleware.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+test('createMiddleware keeps local middleware imports hidden from web static analysis', async () => {
+  const source = await readFile(join(__dirname, '../server/createMiddleware.js'), 'utf8')
+
+  assert.doesNotMatch(source, /import\s*\(\s*join/)
+  assert.match(source, /return import\(specifier\)/)
+})
+
+test('server entry keeps server-only modules hidden from web static analysis', async () => {
+  const source = await readFile(join(__dirname, '../index.js'), 'utf8')
+
+  assert.doesNotMatch(source, /import\s*\(\s*['"]\.\/server\//)
+  assert.match(source, /return import\(specifier\)/)
+})

--- a/core/worker/plugin.js
+++ b/core/worker/plugin.js
@@ -1,5 +1,7 @@
 import { createPlugin } from 'startupjs/registry'
 
+const importLocalModule = createLocalModuleImporter()
+
 export default createPlugin({
   name: 'worker',
   enabled: true,
@@ -18,7 +20,9 @@ export default createPlugin({
         if (dashboardOptions === true) dashboardOptions = {}
 
         if (dashboardOptions) {
-          const { default: initDashboardRoute } = await import('./initDashboardRoute.js')
+          const { default: initDashboardRoute } = await importLocalModule(
+            new URL('./initDashboardRoute.js', import.meta.url).href
+          )
           initDashboardRoute({
             expressApp,
             ...dashboardOptions
@@ -29,10 +33,18 @@ export default createPlugin({
         const shouldAutoStart = autoStart && (!isProduction || autoStartProduction)
 
         if (shouldAutoStart) {
-          const { default: initWorker } = await import('./init.js')
+          const { default: initWorker } = await importLocalModule(
+            new URL('./init.js', import.meta.url).href
+          )
           await initWorker(initOptions)
         }
       }
     }
   }
 })
+
+function createLocalModuleImporter () {
+  // Keep server-only worker modules lazy without exposing literal dynamic imports
+  // to Metro/Expo web static analysis through startupjs.config.js.
+  return new Function('specifier', 'return import(specifier)') // eslint-disable-line no-new-func
+}

--- a/core/worker/runtime.js
+++ b/core/worker/runtime.js
@@ -35,6 +35,7 @@ const queues = new Map()
 const queueEvents = new Map()
 const redisConnections = new Set()
 const pendingWorkerEvents = new Set()
+const importLocalModule = createLocalModuleImporter()
 
 let backendInitPromise
 let workerBackend
@@ -335,10 +336,16 @@ async function loadJobsFromFiles () {
 
     const jobName = basename(entry.name, extension)
     const filePath = join(jobsDir, entry.name)
-    jobs[jobName] = await import(pathToFileURL(filePath).href)
+    jobs[jobName] = await importLocalModule(pathToFileURL(filePath).href)
   }
 
   return jobs
+}
+
+function createLocalModuleImporter () {
+  // Keep workerJobs ESM loading server-side without exposing import(expression)
+  // to Metro/Expo web static analysis through @startupjs/worker/plugin.
+  return new Function('specifier', 'return import(specifier)') // eslint-disable-line no-new-func
 }
 
 function normalizeJob (jobName, jobModule) {

--- a/core/worker/test/jobPlugin.test.js
+++ b/core/worker/test/jobPlugin.test.js
@@ -10,7 +10,8 @@ test('plugin loads dashboard route lazily', async () => {
   const source = await readFile(join(__dirname, '../plugin.js'), 'utf8')
 
   assert.doesNotMatch(source, /import\s+initDashboardRoute\s+from/)
-  assert.match(source, /await import\('\.\/initDashboardRoute\.js'\)/)
+  assert.doesNotMatch(source, /import\s*\(\s*['"]\.\/init/)
+  assert.match(source, /return import\(specifier\)/)
 })
 
 test('runtime keeps local file job imports hidden from web static analysis', async () => {

--- a/core/worker/test/jobPlugin.test.js
+++ b/core/worker/test/jobPlugin.test.js
@@ -12,3 +12,10 @@ test('plugin loads dashboard route lazily', async () => {
   assert.doesNotMatch(source, /import\s+initDashboardRoute\s+from/)
   assert.match(source, /await import\('\.\/initDashboardRoute\.js'\)/)
 })
+
+test('runtime keeps local file job imports hidden from web static analysis', async () => {
+  const source = await readFile(join(__dirname, '../runtime.js'), 'utf8')
+
+  assert.doesNotMatch(source, /import\s*\(\s*pathToFileURL/)
+  assert.match(source, /return import\(specifier\)/)
+})


### PR DESCRIPTION
## Summary
- hide @startupjs/worker server-only imports from Metro/Expo static analysis
- hide @startupjs/server server-only lazy imports from Metro/Expo static analysis
- keep Node ESM loading for workerJobs and server middleware
- add regression tests for bundler-visible dynamic imports

## Why
LMS web export parses startupjs.config.js and plugin/server graphs. Literal or expression dynamic imports to server-only files make Metro include Node/BullMQ modules and fail during web bundling.

## Tests
- cd core/worker && yarn test:unit
- cd core/worker && yarn test:integration
- node --test core/server/test/createMiddleware.test.js
- LMS local yarn build with equivalent installed-package fixes passed