### PR TITLE
feat: Wire StartupjsProvider to CSSX

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -33,7 +33,7 @@ jobs:
       run: yarn install --immutable
 
     - name: Install Playwright Browsers
-      run: yarn playwright install --with-deps
+      run: yarn exec playwright install --with-deps
 
     - name: Run Playwright tests
       run: yarn test-e2e

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -29,8 +29,8 @@ jobs:
     - name: Enable corepack
       run: corepack enable
 
-    - name: Use yarn@4
-      run: corepack use yarn@4
+    - name: Install dependencies
+      run: yarn install --immutable
 
     - name: Install Playwright Browsers
       run: yarn playwright install --with-deps

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -38,7 +38,7 @@ jobs:
     - name: Run Playwright tests
       run: yarn test-e2e
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: playwright-report

--- a/core/startupjs/StartupjsProvider.d.ts
+++ b/core/startupjs/StartupjsProvider.d.ts
@@ -1,0 +1,12 @@
+import type { ReactNode } from 'react'
+import type { CssxProviderStyleInput } from 'cssxjs'
+
+export interface StartupjsProviderProps {
+  children?: ReactNode
+  style?: CssxProviderStyleInput
+  plugins?: any
+  onlyPlugins?: any
+  [key: string]: any
+}
+
+export default function StartupjsProvider (props: StartupjsProviderProps): ReactNode

--- a/core/startupjs/StartupjsProvider.d.ts
+++ b/core/startupjs/StartupjsProvider.d.ts
@@ -1,9 +1,10 @@
 import type { ReactNode } from 'react'
-import type { CssxProviderStyleInput } from 'cssxjs'
+import type { CssxProviderProps, CssxProviderStyleInput } from 'cssxjs'
 
 export interface StartupjsProviderProps {
   children?: ReactNode
   style?: CssxProviderStyleInput
+  theme?: CssxProviderProps['theme']
   plugins?: any
   onlyPlugins?: any
   [key: string]: any

--- a/core/startupjs/StartupjsProvider.js
+++ b/core/startupjs/StartupjsProvider.js
@@ -1,6 +1,15 @@
 import { createElement as el } from 'react'
 import { ROOT_MODULE as MODULE } from '@startupjs/registry'
+import { CssxProvider } from 'cssxjs'
 
-export default MODULE.dynamicPlugins(function StartupjsProvider ({ children }) {
-  return el(MODULE.RenderNestedHook, { name: 'renderRoot' }, children)
+export default MODULE.dynamicPlugins(function StartupjsProvider ({
+  children,
+  style,
+  ...props
+}) {
+  return el(
+    CssxProvider,
+    { style },
+    el(MODULE.RenderNestedHook, { name: 'renderRoot', style, ...props }, children)
+  )
 })

--- a/core/startupjs/StartupjsProvider.js
+++ b/core/startupjs/StartupjsProvider.js
@@ -5,11 +5,12 @@ import { CssxProvider } from 'cssxjs'
 export default MODULE.dynamicPlugins(function StartupjsProvider ({
   children,
   style,
+  theme,
   ...props
 }) {
   return el(
     CssxProvider,
-    { style },
-    el(MODULE.RenderNestedHook, { name: 'renderRoot', style, ...props }, children)
+    { style, theme },
+    el(MODULE.RenderNestedHook, { name: 'renderRoot', style, theme, ...props }, children)
   )
 })

--- a/core/startupjs/package.json
+++ b/core/startupjs/package.json
@@ -23,6 +23,8 @@
     "./useRouter": "./useRouter.js",
     "./metro-config": "./metro-config.cjs",
     "./metro-babel-transformer": "./metro-babel-transformer.cjs",
+    "./themes/tailwind": "./themes/tailwind.js",
+    "./themes/shadcn": "./themes/shadcn.js",
     "./babel": "./babel.cjs",
     "./babel/plugin-react-pug": "./babel/plugin-react-pug.cjs",
     "./startupjs.config": "./startupjs.config.cjs",

--- a/core/startupjs/themes/shadcn.d.ts
+++ b/core/startupjs/themes/shadcn.d.ts
@@ -1,0 +1,2 @@
+export { default } from 'cssxjs/themes/shadcn'
+

--- a/core/startupjs/themes/shadcn.d.ts
+++ b/core/startupjs/themes/shadcn.d.ts
@@ -1,2 +1,1 @@
 export { default } from 'cssxjs/themes/shadcn'
-

--- a/core/startupjs/themes/shadcn.js
+++ b/core/startupjs/themes/shadcn.js
@@ -1,0 +1,2 @@
+export { default } from 'cssxjs/themes/shadcn'
+

--- a/core/startupjs/themes/shadcn.js
+++ b/core/startupjs/themes/shadcn.js
@@ -1,2 +1,1 @@
 export { default } from 'cssxjs/themes/shadcn'
-

--- a/core/startupjs/themes/tailwind.d.ts
+++ b/core/startupjs/themes/tailwind.d.ts
@@ -1,0 +1,2 @@
+export { default } from 'cssxjs/themes/tailwind'
+

--- a/core/startupjs/themes/tailwind.d.ts
+++ b/core/startupjs/themes/tailwind.d.ts
@@ -1,2 +1,1 @@
 export { default } from 'cssxjs/themes/tailwind'
-

--- a/core/startupjs/themes/tailwind.js
+++ b/core/startupjs/themes/tailwind.js
@@ -1,0 +1,2 @@
+export { default } from 'cssxjs/themes/tailwind'
+

--- a/core/startupjs/themes/tailwind.js
+++ b/core/startupjs/themes/tailwind.js
@@ -1,2 +1,1 @@
 export { default } from 'cssxjs/themes/tailwind'
-

--- a/docs/migration-guides/0.64.md
+++ b/docs/migration-guides/0.64.md
@@ -1,0 +1,211 @@
+# Upgrade 0.63 alpha to 0.64 alpha
+
+- Change `startupjs` and all `@startupjs/*` dependencies in your `package.json` to the matching `0.64.0-alpha` version
+- If you use `startupjs-ui`, upgrade it to `^0.4`
+- If you directly install `cssxjs` or any `@cssxjs/*` packages, upgrade them to `^0.4`
+- Run `yarn` after the version bump
+
+StartupJS 0.64 alpha is the framework release that adopts CSSX 0.4 provider styles, provider themes, runtime CSS variables, and the new CSS-first StartupJS UI integration.
+
+## Quick Migration Checklist
+
+1. Upgrade StartupJS, CSSX, and StartupJS UI together.
+2. Keep `startupjs/babel` in your Babel presets.
+3. Move app-level CSS variables and component overrides to `StartupjsProvider style`.
+4. Use `StartupjsProvider theme='auto'` for automatic light/dark selection, or `theme='default'` to force the default theme.
+5. Replace old UI theme configuration with CSS variable overrides.
+6. Replace style helper imports with the new CSSX primitives re-exported from `startupjs`.
+7. Run `npx startupjs check`, `npx eslint .`, and your app tests.
+
+## CSSX 0.4 Upgrade
+
+StartupJS now uses CSSX 0.4. Read the CSSX migration guide for the lower-level CSS engine changes:
+
+https://cssx.dev/migration-guides/0.4
+
+Important CSSX changes include:
+
+- unified CSS-to-React-Native/web style compiler and runtime
+- runtime CSS compilation with `useRuntimeCss()`
+- provider-scoped CSS variables through `CssxProvider style`
+- light/dark/custom theme selection
+- `@custom-media` and `useMedia()`
+- `useCssVariable()`, `useCssColor()`, `getCssVariable()`, and `getCssColor()`
+- Tailwind and shadcn token theme entrypoints
+- deprecation of new `u` usage in favor of `rem`, `var(--spacing)`, and `calc()`
+
+## `StartupjsProvider style`
+
+`StartupjsProvider` now forwards `style` to the underlying CSSX provider.
+
+Use it for app-wide CSS:
+
+```jsx
+import { StartupjsProvider, css } from 'startupjs'
+
+const appStyle = css`
+  :root {
+    --primary: oklch(0.55 0.2 250);
+    --primary-foreground: white;
+    --color-primary: var(--primary);
+    --color-primary-foreground: var(--primary-foreground);
+  }
+
+  Button {
+    border-radius: var(--radius-full);
+  }
+
+  Button:part(text) {
+    font-weight: 600;
+  }
+`
+
+export default function Root () {
+  return (
+    <StartupjsProvider style={appStyle}>
+      <App />
+    </StartupjsProvider>
+  )
+}
+```
+
+`style` can contain:
+
+- `:root` variable overrides
+- `:root.dark` and custom `:root.<theme>` variable overrides
+- `@custom-media`
+- app-wide classes
+- component tag overrides
+- component `:part()` / `::part()` overrides
+
+## `StartupjsProvider theme`
+
+`StartupjsProvider` now forwards `theme` to CSSX:
+
+```jsx
+<StartupjsProvider theme='auto' style={appStyle}>
+  <App />
+</StartupjsProvider>
+```
+
+`theme='auto'` is the default. It applies the provider's `:root.dark` variables when the OS color scheme is dark.
+
+Use:
+
+- `theme='default'` to force the default `:root` values
+- `theme='dark'` to force dark values
+- `theme='light'` as an alias for default unless an explicit `:root.light` exists
+- `theme='<custom-name>'` to apply `:root.<custom-name>`
+
+Bare StartupJS does not include Tailwind, shadcn, or StartupJS UI theme tokens automatically. If you do not install StartupJS UI, provide your own theme CSS or import the optional CSSX token layers.
+
+## StartupJS UI Integration
+
+When `startupjs-ui` is installed, its plugin injects the internal UI provider into `StartupjsProvider`.
+
+That means a StartupJS app still configures one provider:
+
+```jsx
+<StartupjsProvider theme='auto' style={appStyle}>
+  <App />
+</StartupjsProvider>
+```
+
+StartupJS UI supplies its default Tailwind token layer, shadcn semantic layer, and component-specific variables. Your `StartupjsProvider style` is applied after those defaults, so app overrides win.
+
+See the StartupJS UI 0.4 migration guide for component token and part migration details.
+
+## Re-Exported CSSX Primitives
+
+StartupJS re-exports the CSSX primitives that apps usually need:
+
+```js
+import {
+  css,
+  styl,
+  pug,
+  cssx,
+  useRuntimeCss,
+  CssxProvider,
+  variables,
+  useCssVariable,
+  useCssVariableRaw,
+  getCssVariable,
+  getCssVariableRaw,
+  useCssColor,
+  getCssColor,
+  useMedia,
+  u
+} from 'startupjs'
+```
+
+Theme assets are available through StartupJS entrypoints:
+
+```js
+import tailwindTheme from 'startupjs/themes/tailwind'
+import shadcnTheme from 'startupjs/themes/shadcn'
+```
+
+Use these explicitly only in bare StartupJS apps that want the token layers without StartupJS UI.
+
+## Replacing Old Style Helpers
+
+Move app code to CSSX primitives:
+
+- old media helpers -> `useMedia()` from `startupjs`
+- old CSS variable reads -> `useCssVariable()` or `useCssVariableRaw()`
+- old theme color helpers -> `useCssColor()` or CSS `var()` / `color-mix()`
+- JS `u()` -> avoid in new code; if needed during migration, import deprecated `u()` from `startupjs`
+
+Prefer CSS for styling:
+
+```css
+:root {
+  --Card-padding: 1rem;
+}
+
+Card {
+  padding: var(--Card-padding);
+}
+
+@media (--breakpoint-desktop) {
+  Card {
+    --Card-padding: 1.5rem;
+  }
+}
+```
+
+Use JS hooks only when a non-CSS prop needs a resolved value.
+
+## Global Component Overrides
+
+StartupJS UI global overrides now use component tag selectors, not old class-like component selectors:
+
+```css
+/* old */
+.Button {
+  background-color: red;
+}
+
+/* new */
+Button {
+  background-color: var(--color-primary);
+}
+
+Button:part(text) {
+  color: var(--color-primary-foreground);
+}
+```
+
+Both `:part()` and `::part()` are supported.
+
+## Validation
+
+After migrating:
+
+```sh
+npx startupjs check
+npx eslint .
+```
+
+Then run your app tests and visual smoke checks, especially around provider theme switching and component overrides.

--- a/docs/migration-guides/0.64.md
+++ b/docs/migration-guides/0.64.md
@@ -170,7 +170,7 @@ Card {
 
 @media (--breakpoint-desktop) {
   Card {
-    --Card-padding: 1.5rem;
+    padding: 1.5rem;
   }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -69,6 +69,10 @@
       "pre-commit": "lint-staged && npx startupjs check"
     }
   },
+  "resolutions": {
+    "cssxjs": "portal:../cssx/packages/cssxjs",
+    "@cssxjs/css-to-rn": "portal:../cssx/packages/css-to-rn"
+  },
   "//pre-commit-with-resolutions": "! grep -q '\"resolutions\":' ./package.json || (echo '\\033[0;31mError: \"resolutions\" found in package.json. Remove \"resolutions\" to proceed with commit.\\033[0m' && exit 1) && lint-staged",
   "license": "MIT",
   "//resolutions": {

--- a/package.json
+++ b/package.json
@@ -69,15 +69,6 @@
       "pre-commit": "lint-staged && npx startupjs check"
     }
   },
-  "resolutions": {
-    "cssxjs": "portal:../cssx/packages/cssxjs",
-    "@cssxjs/css-to-rn": "portal:../cssx/packages/css-to-rn"
-  },
-  "//pre-commit-with-resolutions": "! grep -q '\"resolutions\":' ./package.json || (echo '\\033[0;31mError: \"resolutions\" found in package.json. Remove \"resolutions\" to proceed with commit.\\033[0m' && exit 1) && lint-staged",
   "license": "MIT",
-  "//resolutions": {
-    "teamplay": "portal:../teamplay/packages/teamplay",
-    "@teamplay/channel": "portal:../teamplay/packages/channel"
-  },
   "packageManager": "yarn@4.13.0+sha512.5c20ba010c99815433e5c8453112165e673f1c7948d8d2b267f4b5e52097538658388ebc9f9580656d9b75c5cc996f990f611f99304a2197d4c56d21eea370e7"
 }

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -69,6 +69,7 @@ export default defineConfig({
           text: 'Migration Guides',
           collapsed: true,
           items: [
+            { text: '0.64', link: '/migration-guides/0.64' },
             { text: '0.62', link: '/migration-guides/0.62' },
             { text: '0.61', link: '/migration-guides/0.61' },
             { text: '0.55', link: '/migration-guides/0.55' },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1196,13 +1196,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@colordx/core@npm:5.4.3":
-  version: 5.4.3
-  resolution: "@colordx/core@npm:5.4.3"
-  checksum: 10c0/9fa1888b8794d6e80c9fb346bf18dc6de0a79834099559baab4854ed09c5684f1ec26f1d745c2702774dbb47ce936eeb0645da0f64cce43b45df68f7e8fa9ff2
-  languageName: node
-  linkType: hard
-
 "@cssxjs/babel-plugin-rn-stylename-inline@npm:^0.3.0":
   version: 0.3.0
   resolution: "@cssxjs/babel-plugin-rn-stylename-inline@npm:0.3.0"
@@ -1248,25 +1241,6 @@ __metadata:
   checksum: 10c0/54d5990946c164089be1ca2203ff360ab49528df79290b8fd9df1bcdb07780335c03c3a6668a045786ff1b5808c6e101bdfe3b9b62a9fcc3b460d3513f56287f
   languageName: node
   linkType: hard
-
-"@cssxjs/css-to-rn@portal:../cssx/packages/css-to-rn::locator=root-workspace-0b6124%40workspace%3A.":
-  version: 0.0.0-use.local
-  resolution: "@cssxjs/css-to-rn@portal:../cssx/packages/css-to-rn::locator=root-workspace-0b6124%40workspace%3A."
-  dependencies:
-    "@colordx/core": "npm:5.4.3"
-    css: "npm:^3.0.0"
-    css-mediaquery: "npm:^0.1.2"
-    postcss-value-parser: "npm:^4.2.0"
-  peerDependencies:
-    react: "*"
-    react-native: "*"
-  peerDependenciesMeta:
-    react:
-      optional: true
-    react-native:
-      optional: true
-  languageName: node
-  linkType: soft
 
 "@cssxjs/loaders@npm:^0.3.0":
   version: 0.3.0
@@ -11762,24 +11736,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cssxjs@portal:../cssx/packages/cssxjs::locator=root-workspace-0b6124%40workspace%3A.":
-  version: 0.0.0-use.local
-  resolution: "cssxjs@portal:../cssx/packages/cssxjs::locator=root-workspace-0b6124%40workspace%3A."
+"cssxjs@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "cssxjs@npm:0.3.0"
   dependencies:
     "@cssxjs/babel-plugin-rn-stylename-inline": "npm:^0.3.0"
     "@cssxjs/babel-plugin-rn-stylename-to-style": "npm:^0.3.0"
     "@cssxjs/bundler": "npm:^0.3.0"
-    "@cssxjs/css-to-rn": "npm:^0.3.0"
     "@cssxjs/loaders": "npm:^0.3.0"
+    "@cssxjs/runtime": "npm:^0.3.0"
     "@react-pug/babel-plugin-react-pug": "npm:^0.1.18"
     "@react-pug/check-types": "npm:^0.1.18"
     babel-preset-cssxjs: "npm:^0.3.0"
   peerDependencies:
     react: "*"
   bin:
-    cssxjs: ./cli.js
+    cssxjs: cli.js
+  checksum: 10c0/843c6b80ed9b3118e1c3a27dc21672f53385c8c9cb5cbda5f5bda1307e644b9d03dcedf81c6409f45610747b02d5db220b2a99255667c81a94c5660613061d81
   languageName: node
-  linkType: soft
+  linkType: hard
 
 "dargs@npm:^7.0.0":
   version: 7.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -1196,6 +1196,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@colordx/core@npm:5.4.3":
+  version: 5.4.3
+  resolution: "@colordx/core@npm:5.4.3"
+  checksum: 10c0/9fa1888b8794d6e80c9fb346bf18dc6de0a79834099559baab4854ed09c5684f1ec26f1d745c2702774dbb47ce936eeb0645da0f64cce43b45df68f7e8fa9ff2
+  languageName: node
+  linkType: hard
+
 "@cssxjs/babel-plugin-rn-stylename-inline@npm:^0.3.0":
   version: 0.3.0
   resolution: "@cssxjs/babel-plugin-rn-stylename-inline@npm:0.3.0"
@@ -1241,6 +1248,25 @@ __metadata:
   checksum: 10c0/54d5990946c164089be1ca2203ff360ab49528df79290b8fd9df1bcdb07780335c03c3a6668a045786ff1b5808c6e101bdfe3b9b62a9fcc3b460d3513f56287f
   languageName: node
   linkType: hard
+
+"@cssxjs/css-to-rn@portal:../cssx/packages/css-to-rn::locator=root-workspace-0b6124%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "@cssxjs/css-to-rn@portal:../cssx/packages/css-to-rn::locator=root-workspace-0b6124%40workspace%3A."
+  dependencies:
+    "@colordx/core": "npm:5.4.3"
+    css: "npm:^3.0.0"
+    css-mediaquery: "npm:^0.1.2"
+    postcss-value-parser: "npm:^4.2.0"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  peerDependenciesMeta:
+    react:
+      optional: true
+    react-native:
+      optional: true
+  languageName: node
+  linkType: soft
 
 "@cssxjs/loaders@npm:^0.3.0":
   version: 0.3.0
@@ -11736,25 +11762,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cssxjs@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "cssxjs@npm:0.3.0"
+"cssxjs@portal:../cssx/packages/cssxjs::locator=root-workspace-0b6124%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "cssxjs@portal:../cssx/packages/cssxjs::locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@cssxjs/babel-plugin-rn-stylename-inline": "npm:^0.3.0"
     "@cssxjs/babel-plugin-rn-stylename-to-style": "npm:^0.3.0"
     "@cssxjs/bundler": "npm:^0.3.0"
+    "@cssxjs/css-to-rn": "npm:^0.3.0"
     "@cssxjs/loaders": "npm:^0.3.0"
-    "@cssxjs/runtime": "npm:^0.3.0"
     "@react-pug/babel-plugin-react-pug": "npm:^0.1.18"
     "@react-pug/check-types": "npm:^0.1.18"
     babel-preset-cssxjs: "npm:^0.3.0"
   peerDependencies:
     react: "*"
   bin:
-    cssxjs: cli.js
-  checksum: 10c0/843c6b80ed9b3118e1c3a27dc21672f53385c8c9cb5cbda5f5bda1307e644b9d03dcedf81c6409f45610747b02d5db220b2a99255667c81a94c5660613061d81
+    cssxjs: ./cli.js
   languageName: node
-  linkType: hard
+  linkType: soft
 
 "dargs@npm:^7.0.0":
   version: 7.0.0


### PR DESCRIPTION
## Summary

- wrap `StartupjsProvider` children in CSSX `CssxProvider`
- pass `StartupjsProvider style` into CSSX and through the existing plugin `renderRoot` hook
- pass `StartupjsProvider theme` into CSSX so apps can select `auto`, `default`, `light`, `dark`, or custom CSSX themes from the framework root
- add a `.d.ts` surface for `StartupjsProvider`, including CSSX provider style and theme inputs
- re-export CSSX theme assets from `startupjs/themes/tailwind` and `startupjs/themes/shadcn`

## Why

The CSS-first UI theme migration needs framework users to configure global CSSX variables, utility classes, component tag overrides, and theme selection through the normal StartupJS root provider. Direct CSSX users can still use `CssxProvider` themselves; StartupJS users can pass the same style and theme inputs to `StartupjsProvider`.

Bare StartupJS still does not include Tailwind, shadcn, or StartupJS UI theme styles by default. Those are included by startupjs-ui when its plugin injects the UI provider.

## Related PRs

- startupjs/cssx#5 adds the unified CSSX compiler/runtime, `CssxProvider`, provider-scoped `:root`, tag selectors, CSS variable hooks, OKLCH/color-mix evaluation, custom media, theme assets, and runtime CSS support.
- startupjs/startupjs-ui#41 moves the UI theme system onto CSSX theme assets, `startupjsUiTheme.cssx.css`, direct CSS variable primitives, and component tag/part overrides.

## Validation

- `NODE_OPTIONS="-C cssx-ts" npm test` in `core/startupjs`
- normal pre-commit hook, including eslint and `npx startupjs check`
