### PR TITLE
fix(plugins): discover plugins from non-hoisted transitive deps

### DIFF
--- a/core/babel-plugin-startupjs-plugins/loader.js
+++ b/core/babel-plugin-startupjs-plugins/loader.js
@@ -147,8 +147,15 @@ function parsePackage (root, packagePath, _pluginImports = new Set(), _handledPa
   const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
   if (!isPartOfFramework(packageJson)) return
 
-  // find all dependant framework packages and load their plugins first
-  const packagePaths = getPackagePathsFromPackageJson(root, packageJson)
+  // find all dependant framework packages and load their plugins first.
+  // Resolve each dependency from the CURRENT package's location (packagePath),
+  // not the app root — otherwise a transitive framework dep that isn't hoisted to
+  // the app's node_modules (e.g. @startupjs/auth nested under startupjs's own
+  // node_modules, which happens with portal:/file: links or a strict pnpm-style
+  // layout) is never found, and its plugins silently go undiscovered. Node's
+  // resolution walks UP from the basedir, so resolving from packagePath still
+  // finds hoisted deps too.
+  const packagePaths = getPackagePathsFromPackageJson(packagePath, packageJson)
   for (const packagePath of packagePaths) {
     parsePackage(root, packagePath, _pluginImports, _handledPackages)
   }


### PR DESCRIPTION
## Problem

Plugin auto-discovery walks the framework dependency tree (`startupjs` → its deps → their deps) collecting `*.plugin` exports, then injects them into the app entry + the generated `teamplay-env.d.ts`.

It resolved each package's dependencies with `basedir: appRoot`, so it only found deps **hoisted** to the app's top-level `node_modules`. A transitive framework dep that isn't hoisted — e.g. `@startupjs/auth` nested under `startupjs`'s own `node_modules`, which happens with `portal:`/`file:` linked deps or a strict (pnpm-style) layout — was never found, and its session/connection plugins (`cookieSession` etc.) silently went undiscovered.

The visible symptom: the client never establishes the realtime connection (no `connect()`), so every subscription throws *"Connection is not set"* and the app renders blank. It does **not** reproduce in a normal app (e.g. `expoapp`) because there `@startupjs/auth` is hoisted and resolves from the app root.

## Fix

Resolve each package's dependencies from **that package's own path** (`packagePath`) instead of the app root. Node's resolution still walks up to find hoisted deps, so this is strictly more correct — it additionally finds nested transitive deps.

One line in `core/babel-plugin-startupjs-plugins/loader.js`:

```diff
- const packagePaths = getPackagePathsFromPackageJson(root, packageJson)
+ const packagePaths = getPackagePathsFromPackageJson(packagePath, packageJson)
```

## Verification

Ran the discovery against an app tree where `@startupjs/auth` is reachable only transitively via `startupjs`: the fixed loader discovers `@startupjs/auth/plugins/{cookieSession,jwtSession,offlineSession,oauth2}.plugin` and `@startupjs-ui/file-input/files.plugin`. Hoisted discovery (the normal case) is unaffected.